### PR TITLE
[fused_decode] Fail the build when a model header's GLU_SLICE disagrees with the builder

### DIFF
--- a/programming_examples/fused_decode/Makefile
+++ b/programming_examples/fused_decode/Makefile
@@ -75,6 +75,14 @@ DECODE_ENV     := VOCAB_CHUNK_I2=$(VOCAB_CHUNK_I2) LM_HEAD=0 NLAYERS=1 DECODE_GO
                   W_DUAL_CHAN=$(W_DUAL_CHAN) PROJ_RC_CACHE=$(PROJ_RC_CACHE) \
                   $(if $(UNI_LM),UNI_LM=$(UNI_LM),)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 .PHONY: help compile-decode _compile_decode_build compile-decode-dynseq preflight-peano preflight-llvm-link clean
 
 help:

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -5094,6 +5094,15 @@ def build_module():
 
 
 def run():
+    # Print a module-level constant and stop, so a Makefile can hand the kernel
+    # compile the builder's own value (see glu.cc's GLU_SLICE_EXPECTED). Inert
+    # unless set, and deliberately before the import below: this must stay
+    # runnable without XRT.
+    _const = _os.environ.get("FUSED_DECODE_PRINT_CONST")
+    if _const:
+        print(globals()[_const])
+        return 0
+
     import pyxrt as xrt
 
     module = build_module()

--- a/programming_examples/fused_decode/fused_decode_qwen.py
+++ b/programming_examples/fused_decode/fused_decode_qwen.py
@@ -2292,6 +2292,14 @@ def build_module():
 
 
 def run():
+    # Const-print hook (mirrors fused_decode.py): print a module-level constant
+    # and stop, so a Makefile can hand the kernel compile the builder's own value
+    # (see glu.cc's GLU_SLICE_EXPECTED). Before build_module(): this is a query.
+    _const = _os.environ.get("FUSED_DECODE_PRINT_CONST")
+    if _const:
+        print(globals()[_const])
+        return 0
+
     module = build_module()
 
     # Emit-only hook (mirrors fused_decode.py): dump the built AIR MLIR and stop

--- a/programming_examples/fused_decode/kernels/glu.cc
+++ b/programming_examples/fused_decode/kernels/glu.cc
@@ -30,15 +30,18 @@ constexpr int y_cons_lock = 3;
 // phase 3: up/gate proj, D -> D * 8 to MT_GLU
 // phase 4: down proj, D * 4 -> D, to rms_residual
 // phase 4 is special, do not clear y to zero
-// GLU_SLICE is DERIVED, not a model fact: fused_decode.py computes it from this
-// model's own egress-round parity, so a header that copies a neighbour's value
-// can disagree with the IR. Nothing catches that at runtime -- the DMA delivers
-// one width, the kernel below reads another, and the FFN output is silently
-// wrong. When the builder feeds its value in, hold the two to it.
+// GLU_SLICE is DERIVED, not a model fact: whichever fused-decode builder emits
+// this model's IR fixes it (fused_decode.py from the model's own egress-round
+// parity, fused_decode_qwen.py at two demux rounds per slice), so a header that
+// copies a neighbour's value can disagree with the IR. Nothing catches that at
+// runtime -- the DMA delivers one width, the kernel below reads another, and
+// the FFN output is silently wrong. When the builder feeds its value in, hold
+// the two to it.
 #ifdef GLU_SLICE_EXPECTED
 static_assert(GLU_SLICE == GLU_SLICE_EXPECTED,
-              "models/<model>.h GLU_SLICE disagrees with the GLU_SLICE "
-              "fused_decode.py derives for this DECODE_MODEL");
+              "models/<model>.h GLU_SLICE disagrees with the GLU_SLICE this "
+              "model's fused-decode builder derives; see the builder named by "
+              "DECODE_DRIVER in the Makefile that set GLU_SLICE_EXPECTED");
 #endif
 
 extern "C" {

--- a/programming_examples/fused_decode/kernels/glu.cc
+++ b/programming_examples/fused_decode/kernels/glu.cc
@@ -30,6 +30,17 @@ constexpr int y_cons_lock = 3;
 // phase 3: up/gate proj, D -> D * 8 to MT_GLU
 // phase 4: down proj, D * 4 -> D, to rms_residual
 // phase 4 is special, do not clear y to zero
+// GLU_SLICE is DERIVED, not a model fact: fused_decode.py computes it from this
+// model's own egress-round parity, so a header that copies a neighbour's value
+// can disagree with the IR. Nothing catches that at runtime -- the DMA delivers
+// one width, the kernel below reads another, and the FFN output is silently
+// wrong. When the builder feeds its value in, hold the two to it.
+#ifdef GLU_SLICE_EXPECTED
+static_assert(GLU_SLICE == GLU_SLICE_EXPECTED,
+              "models/<model>.h GLU_SLICE disagrees with the GLU_SLICE "
+              "fused_decode.py derives for this DECODE_MODEL");
+#endif
+
 extern "C" {
 
 // AIR-friendly pure-compute GLU (no in-kernel locks; AIR owns sync),

--- a/programming_examples/llms/gemma3_4b_q4nx/Makefile
+++ b/programming_examples/llms/gemma3_4b_q4nx/Makefile
@@ -54,6 +54,14 @@ PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
 # Gemma decode env (module-level constants read these): 34 layers, vocab-262208 chunking.
 DECODE_ENV := DECODE_MODEL=gemma3-4b VOCAB_CHUNK_I2=5 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 16 = the Paris gate (P + a few tokens <= 16); 2048 = production.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/lfm2_1_2b_q4nx/Makefile
+++ b/programming_examples/llms/lfm2_1_2b_q4nx/Makefile
@@ -101,6 +101,14 @@ ATTN_EXTRA    ?=
 # against UNI_LM=4 in the lfm2-1.2b _MODELS entry; fused_decode.py asserts it.
 DECODE_ENV := DECODE_MODEL=lfm2-1.2b VOCAB_CHUNK_I2=16 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # Build only the first N model layers. The weight, rms and state slabs are all
 # per-layer prefixes, so a short build is a prefix of the full one and needs no
 # separate weight pack -- which makes this the bisect when the decode gate says

--- a/programming_examples/llms/llama31_8b_q4nx/Makefile
+++ b/programming_examples/llms/llama31_8b_q4nx/Makefile
@@ -85,6 +85,14 @@ DECODE_ENV := DECODE_MODEL=llama-3.1-8b VOCAB_CHUNK_I2=16 UNIFIED=1 LM_HEAD=0 \
               NLAYERS=1 DECODE_GOLDEN=1 \
               DECODE_STACK=$(DECODE_STACK) DECODE_WGROUP=$(DECODE_WGROUP)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 2048 = production; a small value builds fast for a gate.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/llama32_3b_q4nx/Makefile
+++ b/programming_examples/llms/llama32_3b_q4nx/Makefile
@@ -76,6 +76,14 @@ PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
 DECODE_ENV := DECODE_MODEL=llama-3.2-3b VOCAB_CHUNK_I2=9 UNIFIED=1 LM_HEAD=0 \
               NLAYERS=1 DECODE_GOLDEN=1
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 2048 = production; a small value builds fast for a gate.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/phi4_mini_q4nx/Makefile
+++ b/programming_examples/llms/phi4_mini_q4nx/Makefile
@@ -76,6 +76,14 @@ PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
 DECODE_ENV := DECODE_MODEL=phi4-mini VOCAB_CHUNK_I2=18 UNIFIED=1 LM_HEAD=0 \
               NLAYERS=1 DECODE_GOLDEN=1
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 2048 = production; a small value builds fast for a gate.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -80,6 +80,14 @@ PEANO_KBASE     := -std=c++20 --target=aie2p-none-unknown-elf \
   -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
 DECODE_ENV      := QWEN_NLAYERS=$(N_LAYERS) ATTN_L=$(ATTN_L) W_DUAL_CHAN=$(W_DUAL_CHAN)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # Build-flag stamp for the idempotent skip. Every variable below changes either the
 # xclbin's dataflow, its DDR weight layout or its core ELFs, so a warm build made
 # with different settings must NOT be silently reused. (Distinct from the builder's

--- a/programming_examples/llms/qwen25_7b_q4nx/Makefile
+++ b/programming_examples/llms/qwen25_7b_q4nx/Makefile
@@ -63,6 +63,14 @@ DECODE_WGROUP ?= 7
 DECODE_ENV := DECODE_MODEL=qwen2.5-7b VOCAB_CHUNK_I2=7 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1 \
               DECODE_STACK=$(DECODE_STACK) DECODE_WGROUP=$(DECODE_WGROUP)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 16 = the Paris gate (P + a few tokens <= 16); 2048 = production.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/qwen3_4b_q4nx/Makefile
+++ b/programming_examples/llms/qwen3_4b_q4nx/Makefile
@@ -70,6 +70,14 @@ DECODE_WGROUP ?= 0
 DECODE_ENV := DECODE_MODEL=qwen3-4b VOCAB_CHUNK_I2=30 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1 \
               $(if $(filter-out 0,$(DECODE_WGROUP)),DECODE_WGROUP=$(DECODE_WGROUP),)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 16 = the Paris gate (P + a few tokens <= 16); 2048 = production.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))

--- a/programming_examples/llms/qwen3_8b_q4nx/Makefile
+++ b/programming_examples/llms/qwen3_8b_q4nx/Makefile
@@ -62,6 +62,14 @@ DECODE_WGROUP ?= 9
 DECODE_ENV := DECODE_MODEL=qwen3-8b VOCAB_CHUNK_I2=8 UNIFIED=1 LM_HEAD=0 NLAYERS=1 DECODE_GOLDEN=1 \
               DECODE_STACK=$(DECODE_STACK) DECODE_WGROUP=$(DECODE_WGROUP)
 
+# GLU_SLICE is derived from this model's own egress-round parity, not looked up,
+# so a header copied from another model can disagree with the IR -- silently, at
+# runtime. Hand the builder's value to the kernel compile; glu.cc asserts on it.
+# Empty (and the assert inert) if the query fails, so this cannot break a build
+# that works today.
+GLU_SLICE_EXPECTED := $(shell $(DECODE_ENV) FUSED_DECODE_PRINT_CONST=GLU_SLICE python3 $(DECODE_DRIVER) 2>/dev/null)
+PEANO_KBASE += $(if $(GLU_SLICE_EXPECTED),-DGLU_SLICE_EXPECTED=$(GLU_SLICE_EXPECTED))
+
 # ATTN_MAXL to build for. 16 = the Paris gate (P + a few tokens <= 16); 2048 = production.
 LBUILD ?= 2048
 LREF   := $(shell echo $$(($(LBUILD) - 1)))


### PR DESCRIPTION
## The problem

`GLU_SLICE` has to be known by two things that are built separately and never compare notes:

- **The IR.** `fused_decode.py` computes it, then sizes the L1 buffer and the DMA transfer with it — this decides *how many bf16 elements the hardware actually moves per round*.
- **The kernel.** Each `models/<model>.h` hardcodes it, and `glu.cc` instantiates `pseduo_glu<GLU_SLICE>` — this decides *how many elements the compute kernel reads and writes*.

The header reaches the kernel via `-DMODEL_TYPE=X -I .../models`; the Python value reaches the device via the MLIR. Nothing checks that they match.

When they disagree, **nothing complains**: the buffer allocates, the DMA completes, the kernel runs. It just reads past what was delivered. You get a wrong number, not an error.

## Why it recurs

`GLU_SLICE` is not a model fact anyone can look up. It is *derived* from the model's own egress-round parity:

```
GLU_PKTS = 2 if (ROUNDS_PER_DEST[GLU_DEST] // 2) % 2 == 0 else 1
```

The header is re-stating a computation the builder already did, and the parity flips unpredictably between models — 8 of 10 want 1024, 2 want 512. Copying a neighbour's header gets it wrong about a fifth of the time. That is exactly how qwen3-4b shipped `1024` instead of `512` during bring-up (#1916); the symptom was the FFN contributing zero to the residual on all 36 layers, and it took a bisect to localise.

## The fix

1. Both builders gain a `FUSED_DECODE_PRINT_CONST` query that prints a module-level constant and exits (~0.15 s, no XRT needed).
2. Each of the 10 Makefiles passes the derived value as `-DGLU_SLICE_EXPECTED`.
3. `glu.cc` gains a `static_assert` against it.

Deliberately conservative: the flag is omitted if the query fails, and the assert is `#ifdef`-guarded, so **a build that works today cannot start failing because of this.**

## Audit

All 10 configs currently agree, so this is preventive rather than a bug fix:

| model | PAIR_ROWS | glu rounds | PKTS | derived | header |
|---|--:|--:|--:|--:|--:|
| llama-3.2-1b / 3b, phi4-mini, lfm2-1.2b | 2 | 32 | 2 | 1024 | 1024 |
| gemma3-4b | 1 | 40 | 2 | 1024 | 1024 |
| qwen3-8b | 2 | 48 | 2 | 1024 | 1024 |
| llama-3.1-8b | 2 | 56 | 2 | 1024 | 1024 |
| qwen2.5-7b | 1 | 74 | 1 | 512 | 512 |
| qwen3-4b | 1 | 38 | 1 | 512 | 512 |
| qwen2.5-3b (`fused_decode_qwen.py`) | — | — | — | 1024 | 1024 |

## Verification

- **Perturbation test.** Set qwen3-4b's header back to the bring-up value of 1024: the build now stops in under a second with `static assertion failed due to requirement 'GLU_SLICE == 512'`, naming the file. Previously this produced a clean build and wrong text.
- **No false positives.** `glu.cc` compiles clean for all 10 `MODEL_TYPE` configs, each with its own derived value.
- **No behaviour change.** Restored the header, rebuilt `qwen3_4b_q4nx` clean, Paris gate unchanged: `' Paris. The capital of Germany is Berlin. The'`.
- `black` and `clang-format-17` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)