### PR TITLE
[air.api] Read a plain buffer region elementwise, plus swiglu, rope_halfsplit, rope_lut, mnist_fc/relu

### DIFF
--- a/programming_examples/mnist_fc/relu/run.py
+++ b/programming_examples/mnist_fc/relu/run.py
@@ -2,262 +2,114 @@
 #
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-#
-# 2D ReLU: C[i,j] = max(A[i,j], 0)
-# Element-wise ReLU on a 2D matrix [M,N]. All data is f32.
-#
-# MNIST context: op #3 in the GGML MNIST-FC pipeline.
-# Default dimensions: M=500, N=500 (hidden layer activation).
+"""2D ReLU on air.api: C[i, j] = max(A[i, j], 0).
+
+Element-wise ReLU on an [M, N] matrix. The host interface is f32; the compare
+and select run in bf16, because AIE2P has no f32 vector cmp/sel. That is one
+expression here:
+
+    tile_out[:] = ops.cast(ops.relu(ops.cast(tile_in[:], bf16)), f32)
+
+`ops.cast` opens a region: everything below it is read and computed in the
+source type, so the ReLU is bf16 and only the conversions cross. The
+predecessor spelled the same thing as truncf, a *round trip through an L1 bf16
+scratch buffer*, cmpf, select and extf. The scratch buffer is gone -- the value
+stays in registers between the two conversions -- which gives back
+`tile_m * tile_n * 2` bytes of L1.
+
+MNIST context: op #3 in the GGML MNIST-FC pipeline. Default dimensions are
+M=500, N=500 (the hidden layer activation), neither of which is tile-aligned,
+so `build_module` is given padded extents and `air.actual_sizes` is stamped on
+the launch afterwards -- exactly as the predecessor did it. `launch.build()`
+returns the module, so that poke is unchanged.
+
+Two levels of tiling: the launch grid walks [M, N] in `tile * herd` steps, and
+the herd covers `herd_m x herd_n` tiles within each step. The tile offset is
+plain arithmetic on the two sets of coordinates,
+
+    (lx * herd_m + tx) * tile_m
+
+where the predecessor built one arith.muli at segment scope and a two-symbol
+AffineMap in the herd.
+"""
 
 import argparse
 import math
-import numpy as np
 
+import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
+from air.ir import DenseI64ArrayAttr
 from air.backend.xrt import XRTBackend
-from air.extras import types as extrasT
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
 
+def build_module(m, n, tile_m, tile_n, herd_m, herd_n, vector=16):
+    """Build the 2D ReLU launch over padded (tile-aligned) m, n."""
+    if m % (tile_m * herd_m) or n % (tile_n * herd_n):
+        raise ValueError(
+            f"padded shape ({m}, {n}) must be a multiple of tile x herd "
+            f"({tile_m * herd_m}, {tile_n * herd_n}): there is no partial-tile "
+            "path, so the caller pads and stamps air.actual_sizes."
+        )
+    if vector and tile_n % vector:
+        raise ValueError(
+            f"tile_n ({tile_n}) must be a multiple of the vector width " f"({vector})."
+        )
 
-@module_builder
-def build_module(m, n, tile_m, tile_n, herd_m, herd_n, vector_size=16):
-    """Build 2D ReLU module.
+    A = air.tensor([m, n], f32)
+    OUT = air.tensor([m, n], f32)
 
-    m, n are padded (tile-aligned) dimensions for the launch grid.
-    The air.actual_sizes attribute is added after building to handle
-    non-tile-aligned actual dimensions.
-    """
-    assert m % (tile_m * herd_m) == 0
-    assert n % (tile_n * herd_n) == 0
-    assert tile_n % vector_size == 0
+    with air.launch(
+        [range(m // (tile_m * herd_m)), range(n // (tile_n * herd_n))],
+        name="relu",
+    ) as launch:
 
-    xrt_dtype_f32 = type_mapper(np.float32)
-    xrt_dtype_bf16 = type_mapper(bfloat16)
-    index_type = IndexType.get()
-    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
+        @launch.body
+        def _(lx, ly):
+            with air.segment(name="relu_seg") as seg:
 
-    # L3 MemRefTypes (f32 for host interface)
-    memrefTyA = MemRefType.get([m, n], xrt_dtype_f32)
-    memrefTyOut = MemRefType.get([m, n], xrt_dtype_f32)
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_m), range(herd_n)],
+                        name="herd_0",
+                        shape=(herd_m, herd_n),
+                    ) as herd:
 
-    # L1 MemRefTypes
-    l1TileTy_f32 = MemRefType.get(
-        shape=[tile_m, tile_n],
-        element_type=xrt_dtype_f32,
-        memory_space=l1_mem_space,
-    )
-    l1TileTy_bf16 = MemRefType.get(
-        shape=[tile_m, tile_n],
-        element_type=xrt_dtype_bf16,
-        memory_space=l1_mem_space,
-    )
-
-    vecTy_f32 = VectorType.get([vector_size], xrt_dtype_f32)
-    vecTy_bf16 = VectorType.get([vector_size], xrt_dtype_bf16)
-    # Rank-reduced subview types for vector transfer_read/write
-    l1SubviewTy_f32 = MemRefType.get(
-        [vector_size],
-        xrt_dtype_f32,
-        layout=StridedLayoutAttr.get(ShapedType.get_dynamic_size(), [1]),
-        memory_space=l1_mem_space,
-    )
-    l1SubviewTy_bf16 = MemRefType.get(
-        [vector_size],
-        xrt_dtype_bf16,
-        layout=StridedLayoutAttr.get(ShapedType.get_dynamic_size(), [1]),
-        memory_space=l1_mem_space,
-    )
-
-    @FuncOp.from_py_func(memrefTyA, memrefTyOut)
-    def relu(arg_a, arg_out):
-        launch_size = [m // tile_m // herd_m, n // tile_n // herd_n]
-
-        @launch(operands=[arg_a, arg_out], sizes=launch_size)
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_a, l3_out
-        ):
-
-            @segment(
-                name="relu_seg",
-                operands=[launch_ivx, launch_ivy, l3_a, l3_out],
-            )
-            def segment_body(launch_ivx_s, launch_ivy_s, l3_a_s, l3_out_s):
-                c_tile_m_herd_m = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_m * herd_m), None
-                )
-                c_tile_n_herd_n = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_n * herd_n), None
-                )
-                launch_offset_m = arith.MulIOp(launch_ivx_s, c_tile_m_herd_m)
-                launch_offset_n = arith.MulIOp(launch_ivy_s, c_tile_n_herd_n)
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_m, herd_n],
-                    operands=[
-                        launch_offset_m,
-                        launch_offset_n,
-                        l3_a_s,
-                        l3_out_s,
-                    ],
-                )
-                def herd_body(tx, ty, _sx, _sy, _loff_m, _loff_n, _l3_a, _l3_out):
-                    l1_tile_in = AllocOp(l1TileTy_f32, [], [])
-                    l1_tile_out = AllocOp(l1TileTy_f32, [], [])
-                    l1_tile_bf16 = AllocOp(l1TileTy_bf16, [], [])
-
-                    # m_offset = launch_offset_m + tx * tile_m
-                    # n_offset = launch_offset_n + ty * tile_n
-                    m_offset_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(1),
-                                    AffineConstantExpr.get(tile_m),
-                                ),
+                        @herd.body
+                        def _(tx, ty):
+                            tile_in = air.alloc(
+                                [tile_m, tile_n],
+                                f32,
+                                scope=herd.private(),
+                                vector=vector,
                             )
-                        ],
-                    )
-                    n_offset_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(1),
-                                    AffineConstantExpr.get(tile_n),
-                                ),
-                            )
-                        ],
-                    )
-                    m_offset = affine_apply(m_offset_map, [_loff_m, tx])
-                    n_offset = affine_apply(n_offset_map, [_loff_n, ty])
-
-                    # DMA matrix tile in
-                    dma_memcpy_nd(
-                        l1_tile_in,
-                        _l3_a,
-                        src_offsets=[m_offset, n_offset],
-                        src_sizes=[tile_m, tile_n],
-                        src_strides=[n, 1],
-                    )
-
-                    # Compute: max(x, 0) via bf16 comparison + select.
-                    # AIE2P has no f32 vector cmp/sel; truncf to bf16,
-                    # do cmp/sel in bf16, extf result back to f32.
-                    c0 = ConstantOp(index_type, 0)
-                    c1 = ConstantOp(index_type, 1)
-                    c_vec_size = ConstantOp(index_type, vector_size)
-                    c_tile_m_cst = ConstantOp(index_type, tile_m)
-                    c_tile_n_cst = ConstantOp(index_type, tile_n)
-                    cst0_f32 = arith.ConstantOp(xrt_dtype_f32, 0.0)
-                    cst0_bf16 = arith.ConstantOp(xrt_dtype_bf16, 0.0)
-                    v_zero_bf16 = BroadcastOp(vecTy_bf16, cst0_bf16)
-                    identity_map_1d = AffineMapAttr.get(AffineMap.get_identity(1))
-
-                    for i in range_(c0, c_tile_m_cst, c1):
-                        for j in range_(c0, c_tile_n_cst, c_vec_size):
-                            sub_in_f32 = subview(
-                                l1_tile_in.result,
-                                [i, j],
-                                [1, vector_size],
-                                [1, 1],
-                                result_type=l1SubviewTy_f32,
-                            )
-                            sub_in_bf16 = subview(
-                                l1_tile_bf16.result,
-                                [i, j],
-                                [1, vector_size],
-                                [1, 1],
-                                result_type=l1SubviewTy_bf16,
-                            )
-                            sub_out_f32 = subview(
-                                l1_tile_out.result,
-                                [i, j],
-                                [1, vector_size],
-                                [1, 1],
-                                result_type=l1SubviewTy_f32,
+                            tile_out = air.alloc(
+                                [tile_m, tile_n],
+                                f32,
+                                scope=herd.private(),
+                                vector=vector,
                             )
 
-                            # Read f32, truncate to bf16
-                            v_f32 = transfer_read(
-                                vecTy_f32,
-                                sub_in_f32,
-                                [c0],
-                                identity_map_1d,
-                                cst0_f32,
-                                [True],
-                            )
-                            v_bf16 = arith.TruncFOp(vecTy_bf16, v_f32)
-                            # Write bf16 to L1 temp
-                            transfer_write(
-                                None,
-                                v_bf16,
-                                sub_in_bf16,
-                                [c0],
-                                identity_map_1d,
-                                [True],
-                            )
+                            mo = (lx * herd_m + tx) * tile_m
+                            no = (ly * herd_n + ty) * tile_n
+                            window = (slice(mo, mo + tile_m), slice(no, no + tile_n))
 
-                            # ReLU in bf16: x > 0 ? x : 0
-                            v_bf16_read = transfer_read(
-                                vecTy_bf16,
-                                sub_in_bf16,
-                                [c0],
-                                identity_map_1d,
-                                cst0_bf16,
-                                [True],
+                            ops.load(tile_in, A[window])
+                            # AIE2P has no f32 vector cmp/sel, so the max runs
+                            # in bf16 and only the conversions cross.
+                            tile_out[:] = ops.cast(
+                                ops.relu(ops.cast(tile_in[:], bf16)), f32
                             )
-                            cmp = arith.CmpFOp(
-                                arith.CmpFPredicate.OGT,
-                                v_bf16_read,
-                                v_zero_bf16,
-                            )
-                            v_relu_bf16 = arith.SelectOp(cmp, v_bf16_read, v_zero_bf16)
+                            ops.store(tile_out, OUT[window])
 
-                            # Extend back to f32 and write output
-                            v_relu_f32 = arith.ExtFOp(vecTy_f32, v_relu_bf16)
-                            transfer_write(
-                                None,
-                                v_relu_f32,
-                                sub_out_f32,
-                                [c0],
-                                identity_map_1d,
-                                [True],
-                            )
-                            yield_([])
-                        yield_([])
-
-                    # DMA output tile back to L3
-                    dma_memcpy_nd(
-                        _l3_out,
-                        l1_tile_out,
-                        dst_offsets=[m_offset, n_offset],
-                        dst_sizes=[tile_m, tile_n],
-                        dst_strides=[n, 1],
-                    )
-
-                    DeallocOp(l1_tile_in)
-                    DeallocOp(l1_tile_out)
-                    DeallocOp(l1_tile_bf16)
+    return launch
 
 
 if __name__ == "__main__":
@@ -289,6 +141,13 @@ if __name__ == "__main__":
         dest="compile_mode",
         default="compile-and-run",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
 
     args = parser.parse_args()
 
@@ -309,9 +168,12 @@ if __name__ == "__main__":
         print(f"M_padded={M_padded}, N_padded={N_padded}")
         print(f"TILE_M={TILE_M}, TILE_N={TILE_N}, HERD_M={HERD_M}, HERD_N={HERD_N}")
 
-    mlir_module = build_module(
+    launch = build_module(
         M_padded, N_padded, TILE_M, TILE_N, HERD_M, HERD_N, VECTOR_SIZE
     )
+    # build() resolves --target auto to the installed generation, so it has to
+    # run before launch.target is read below.
+    mlir_module = launch.build(target=args.target)
 
     # Add actual_sizes attribute for device-side padding
     needs_padding = (M_actual != M_padded) or (N_actual != N_padded)
@@ -387,6 +249,7 @@ if __name__ == "__main__":
             output_format="elf" if needs_padding else "xclbin",
             instance_name="relu",
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         # bf16 truncation introduces rounding; use bf16-appropriate tolerance
         exit(
@@ -404,6 +267,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format="elf" if needs_padding else "xclbin",
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         module_function = backend.compile(mlir_module)
         backend.unload()

--- a/programming_examples/rope_halfsplit/rope_halfsplit.py
+++ b/programming_examples/rope_halfsplit/rope_halfsplit.py
@@ -1,7 +1,6 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-
-"""RoPE (Rotary Position Embedding) — half-split, matching HuggingFace Llama
+"""RoPE (Rotary Position Embedding) -- half-split, matching HuggingFace Llama, on air.api
 
 Applies rotary position embeddings to a 2D input [rows, head_dim] using the
 *half-split* convention (HuggingFace Llama `rotate_half`), pairing
@@ -18,150 +17,107 @@ matching `llama32_1b_weights.py:generate_rope_lut` and the kernel
 compile_rope`). This is **NOT** the interleaved variant in `rope_lut/` or
 `rope_sincos/` (those are decoys; their math does not match llama).
 
-Uses the external C++ kernel rope_halfsplit.cc -> rope.o (`@rope`).
-Each row's RoPE is independent — no cross-row dependency — so rows are
-spread across an `herd_x x herd_y` AIE grid. Each tile uses 3 independent
-shim DMAs (input in, lut in, output out); NPU2 has 8 shim DMA channels, so
-the herd is capped at herd_x * herd_y <= 8 tiles (8x1 / 2x4 place, 8x2 /
-4x4 / 8x4 do not). The best config is herd_x=8, herd_y=1 (full chip width).
+The rotation itself stays in C++: `air.extern("rope", link_with="rope.o")`
+declares the microkernel and stamps `link_with` on both the declaration and the
+herd, so the body here is pure dataflow. That is the point of the example --
+the arithmetic is the kernel's, and what AIR contributes is getting one row to
+each core and the result back.
 
-Each tile streams its rows one head_dim row per DMA / per kernel call
-(matching rope_halfsplit.cc's single-row signature and the llama
-prefill/decode builders). `herd_x` (AIE columns) is the scaling knob; the
-rows are interleaved across the herd so tile t handles rows t, t+total_tiles,
-... A batched-DMA variant (multiple rows per L3<->L1 transfer with per-row
-subview kernel calls) was investigated but the air dependency pass
-mis-schedules the per-row subview writes under a single bulk output DMA
-(half the rows come back zero / NaN at rows_per_dma=2,4), so the faithful
-one-row-per-DMA structure is used — see the performance notes.
+Each row's RoPE is independent -- no cross-row dependency -- so rows are spread
+across an `herd_x x herd_y` AIE grid. Each tile uses 3 independent shim DMAs
+(input in, lut in, output out); NPU2 has 8 shim DMA channels, so the herd is
+capped at herd_x * herd_y <= 8 tiles (8x1 / 2x4 place, 8x2 / 4x4 / 8x4 do not).
+The best config is herd_x=8, herd_y=1 (full chip width).
+
+Each tile streams its rows one head_dim row per DMA / per kernel call (matching
+rope_halfsplit.cc's single-row signature and the llama prefill/decode
+builders). `herd_x` (AIE columns) is the scaling knob; the rows are interleaved
+across the herd so tile t handles rows t, t+total_tiles, ... A batched-DMA
+variant (multiple rows per L3<->L1 transfer with per-row subview kernel calls)
+was investigated but the air dependency pass mis-schedules the per-row subview
+writes under a single bulk output DMA (half the rows come back zero / NaN at
+rows_per_dma=2,4), so the faithful one-row-per-DMA structure is used -- see the
+performance notes.
+
+One difference from the raw-bindings version this replaces: the row offset is
+written as ordinary Python arithmetic on the coordinates,
+
+    (row + tx * herd_y + ty) * head_dim
+
+where the predecessor built the same expression as a three-symbol `AffineMap`
+by hand. It reaches the IR as one `affine.apply` either way.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
 
-
-@module_builder
-def build_module(rows, head_dim, np_dtype_in, herd_x=8, herd_y=1):
-    xrt_dtype = type_mapper(np_dtype_in)
+def build_module(rows, head_dim, herd_x=8, herd_y=1, dtype=bf16):
     total = rows * head_dim
-    assert (
-        head_dim % 16 == 0
-    ), "head_dim must be divisible by 16 (kernel vector width N=16)"
+    if head_dim % 16:
+        raise ValueError(
+            f"head_dim ({head_dim}) must be divisible by 16: that is the "
+            "kernel's vector width N."
+        )
     total_tiles = herd_x * herd_y
-    assert (
-        rows % total_tiles == 0
-    ), f"rows ({rows}) must be divisible by herd_x * herd_y ({total_tiles})"
+    if rows % total_tiles:
+        raise ValueError(
+            f"rows ({rows}) must be divisible by herd_x * herd_y "
+            f"({total_tiles}): every core takes the same number of rows, and "
+            "there is no remainder path."
+        )
 
-    # L3 types (flat)
-    l3DataTy = MemRefType.get([total], xrt_dtype)
+    src = air.tensor([total], dtype)
+    lut = air.tensor([total], dtype)
+    dst = air.tensor([total], dtype)
 
-    # L1 types: one head_dim row per DMA / per kernel call (matches the
-    # rope_halfsplit.cc signature and the llama prefill/decode builders).
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1RowTy = MemRefType.get(
-        shape=[head_dim], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
+    # rope(input_row, lut_row, output_row, dims) from rope.o. The trailing
+    # dims argument is a scalar, so its element type has to be stated: the
+    # buffer types come from the buffers, an i32 does not.
+    rope = air.extern("rope", link_with="rope.o", scalars=[i32])
 
-    # External kernel: rope(input_row, lut_row, output_row, dims)
-    rope_func = FuncOp(
-        "rope", ([l1RowTy, l1RowTy, l1RowTy, T.i32()], []), visibility="private"
-    )
-    rope_func.attributes["link_with"] = StringAttr.get("rope.o")
-    rope_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name="rope_halfsplit") as launch:
 
-    # row_offset (in elements) = (local_row * total_tiles + tx*herd_y + ty) * head_dim
-    # i.e. tiles are interleaved over rows: tile t handles rows t, t+total_tiles, ...
-    row_offset_map = AffineMap.get(
-        0,
-        3,
-        [
-            AffineExpr.get_mul(
-                AffineExpr.get_add(
-                    AffineSymbolExpr.get(0),  # loop_iv (already mult. of total_tiles)
-                    AffineExpr.get_add(
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(1),  # _tx
-                            AffineConstantExpr.get(herd_y),
-                        ),
-                        AffineSymbolExpr.get(2),  # _ty
-                    ),
-                ),
-                AffineConstantExpr.get(head_dim),
-            )
-        ],
-    )
+        @launch.body
+        def _():
+            with air.segment(name="rope_seg") as seg:
 
-    @FuncOp.from_py_func(l3DataTy, l3DataTy, l3DataTy)
-    def rope_halfsplit(arg0, arg1, arg2):
-        # arg0 = input [total], arg1 = lut [total], arg2 = output [total]
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_x), range(herd_y)],
+                        name="herd_0",
+                        shape=(herd_x, herd_y),
+                    ) as herd:
 
-        @launch(operands=[arg0, arg1, arg2])
-        def rope_launch(l_in, l_lut, l_out):
+                        @herd.body
+                        def _(tx, ty):
+                            l1_in = air.alloc([head_dim], dtype, scope=herd.private())
+                            l1_lut = air.alloc([head_dim], dtype, scope=herd.private())
+                            l1_out = air.alloc([head_dim], dtype, scope=herd.private())
 
-            @segment(name="rope_seg", operands=[l_in, l_lut, l_out])
-            def rope_seg(s_in, s_lut, s_out):
+                            # Strides by total_tiles rows; each core picks its
+                            # own row out of the group, so tile t handles rows
+                            # t, t + total_tiles, ...
+                            for row in air.sequential(0, rows, total_tiles):
+                                lo = (row + tx * herd_y + ty) * head_dim
 
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_in, s_lut, s_out],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_lut, l3_out):
-                    l1_in = AllocOp(l1RowTy, [], [])
-                    l1_lut = AllocOp(l1RowTy, [], [])
-                    l1_out = AllocOp(l1RowTy, [], [])
+                                ops.load(l1_in, src[lo : lo + head_dim])
+                                ops.load(l1_lut, lut[lo : lo + head_dim])
 
-                    dim_i32 = ConstantOp(T.i32(), head_dim)
+                                rope(l1_in, l1_lut, l1_out, head_dim)
 
-                    # Outer loop strides by total_tiles rows; each tile picks its
-                    # own row via (tx*herd_y+ty). One row per DMA per kernel call.
-                    for loop_iv in range_(0, rows, total_tiles):
-                        row_off = affine_apply(row_offset_map, [loop_iv, _tx, _ty])
+                                ops.store(l1_out, dst[lo : lo + head_dim])
 
-                        dma_memcpy_nd(
-                            l1_in,
-                            l3_in,
-                            src_offsets=[row_off],
-                            src_sizes=[head_dim],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            l1_lut,
-                            l3_lut,
-                            src_offsets=[row_off],
-                            src_sizes=[head_dim],
-                            src_strides=[1],
-                        )
-
-                        CallOp(rope_func, [l1_in, l1_lut, l1_out, dim_i32])
-
-                        dma_memcpy_nd(
-                            l3_out,
-                            l1_out,
-                            dst_offsets=[row_off],
-                            dst_sizes=[head_dim],
-                            dst_strides=[1],
-                        )
-                        yield_([])
-
-                    DeallocOp(l1_in)
-                    DeallocOp(l1_lut)
-                    DeallocOp(l1_out)
-
-                herd_body.attributes["link_with"] = StringAttr.get("rope.o")
+    return launch
 
 
 def rope_halfsplit_reference(input_flat, lut_flat, head_dim):
@@ -262,18 +218,27 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
     if args.perf_iters < 0:
         parser.error("--perf-iters must be >= 0")
 
-    mlir_module = build_module(
+    launch = build_module(
         args.rows,
         args.head_dim,
-        INPUT_DATATYPE,
         herd_x=args.herd_x,
         herd_y=args.herd_y,
     )
+    # build() resolves --target auto to the installed generation, so it has to
+    # run before launch.target is read.
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -302,6 +267,7 @@ if __name__ == "__main__":
             instance_name="rope_halfsplit",
             report_precision=True,
             n_perf_iters=args.perf_iters,
+            target_device=launch.target,
         )
         exit(
             runner.run_test(
@@ -318,6 +284,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
+            target_device=launch.target,
         )
         module_function = backend.compile(mlir_module)
         backend.unload()

--- a/programming_examples/rope_lut/rope_lut.py
+++ b/programming_examples/rope_lut/rope_lut.py
@@ -1,133 +1,88 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""RoPE (Rotary Position Embedding) from a precomputed LUT, on air.api.
 
-"""RoPE (Rotary Position Embeddings) with Precomputed LUT
+Applies rotary position embeddings to [seq_len, embed_dim] using the
+*interleaved* convention, pairing (x[2i], x[2i+1]) against a LUT laid out
+[cos_0, sin_0, cos_1, sin_1, ...]. That is not the convention llama uses --
+`rope_halfsplit/` is -- so this is the general-purpose variant, and the two are
+deliberately kept apart.
 
-Applies rotary position embeddings to a 2D input [seq_len, embed_dim]:
-  output[r, 2i]   = input[r, 2i] * cos(r * freq_i) - input[r, 2i+1] * sin(r * freq_i)
-  output[r, 2i+1] = input[r, 2i] * sin(r * freq_i) + input[r, 2i+1] * cos(r * freq_i)
+The rotation stays in C++: `air.extern("rope", link_with="rope.o")` declares the
+microkernel and stamps link_with on both the declaration and the herd, so the
+body here is dataflow only. Rows are handed out in contiguous blocks -- tile t
+takes rows [t * rows_per_tile, (t+1) * rows_per_tile) -- one embed_dim row per
+DMA and per kernel call, matching the kernel's single-row signature.
 
-where freq_i = 1 / (theta ^ (2i / embed_dim)), theta = 10000.
+`generate_lut` and `rope_reference` below are unchanged and stay module-level:
+the llms/ shared builders import `generate_lut` from here.
 
-The cos/sin values are precomputed on the host and streamed in as a
-look-up table (LUT) with interleaved [cos, sin, cos, sin, ...] layout.
-Uses the external rope.cc kernel from mlir-aie (aie_kernels/aie2p).
+One difference from the raw-bindings version this replaces: the row offset is
+ordinary Python arithmetic on the coordinate,
 
-Supports multi-tile herd (herd_x > 1) for row-parallel execution.
-Each row's RoPE is independent — no cross-row dependencies.
+    (row + tx * rows_per_tile) * embed_dim
+
+where the predecessor built the same expression as a two-symbol AffineMap. It
+reaches the IR as one affine.apply either way.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
 
-
-@module_builder
-def build_module(seq_len, embed_dim, np_dtype_in, herd_x=1):
-    xrt_dtype = type_mapper(np_dtype_in)
+def build_module(seq_len, embed_dim, herd_x=1, dtype=bf16):
     total = seq_len * embed_dim
-    assert (
-        embed_dim % 16 == 0
-    ), "embed_dim must be divisible by 16 (kernel vector width)"
-
-    # L3 types
-    l3DataTy = MemRefType.get([total], xrt_dtype)
-
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1RowTy = MemRefType.get(
-        shape=[embed_dim], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-
-    # External kernel: rope(input, lut, output, dims)
-    rope_func = FuncOp(
-        "rope", ([l1RowTy, l1RowTy, l1RowTy, T.i32()], []), visibility="private"
-    )
-    rope_func.attributes["link_with"] = StringAttr.get("rope.o")
-    rope_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-
-    assert (
-        seq_len % herd_x == 0
-    ), f"seq_len ({seq_len}) must be divisible by herd_x ({herd_x})"
+    if embed_dim % 16:
+        raise ValueError(
+            f"embed_dim ({embed_dim}) must be divisible by 16: that is the "
+            "kernel's vector width."
+        )
+    if seq_len % herd_x:
+        raise ValueError(
+            f"seq_len ({seq_len}) must be divisible by herd_x ({herd_x}): every "
+            "tile takes the same number of rows, and there is no remainder path."
+        )
     rows_per_tile = seq_len // herd_x
 
-    # Affine map: row_offset = (local_row + _tx * rows_per_tile) * embed_dim
-    row_offset_map = AffineMap.get(
-        0,
-        2,
-        [
-            AffineExpr.get_mul(
-                AffineExpr.get_add(
-                    AffineSymbolExpr.get(0),
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(1),
-                        AffineConstantExpr.get(rows_per_tile),
-                    ),
-                ),
-                AffineConstantExpr.get(embed_dim),
-            )
-        ],
-    )
+    src = air.tensor([total], dtype)
+    lut = air.tensor([total], dtype)
+    dst = air.tensor([total], dtype)
 
-    @FuncOp.from_py_func(l3DataTy, l3DataTy, l3DataTy)
-    def rope_lut(arg0, arg1, arg2):
-        # arg0 = input [total], arg1 = lut [total], arg2 = output [total]
+    # rope(input_row, lut_row, output_row, dims). The trailing dims argument is
+    # a scalar, so its element type has to be stated.
+    rope = air.extern("rope", link_with="rope.o", scalars=[i32])
 
-        @herd(name="herd_0", sizes=[herd_x, 1], operands=[arg0, arg1, arg2])
-        def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_lut, l3_out):
-            l1_in = AllocOp(l1RowTy, [], [])
-            l1_lut = AllocOp(l1RowTy, [], [])
-            l1_out = AllocOp(l1RowTy, [], [])
+    with air.launch(name="rope_lut") as launch:
 
-            dim_i32 = ConstantOp(T.i32(), embed_dim)
+        @launch.body
+        def _():
+            with air.herd([range(herd_x)], name="herd_0", shape=(herd_x,)) as herd:
 
-            for local_row in range_(rows_per_tile):
-                row_offset = affine_apply(row_offset_map, [local_row, _tx])
+                @herd.body
+                def _(tx):
+                    l1_in = air.alloc([embed_dim], dtype, scope=herd.private())
+                    l1_lut = air.alloc([embed_dim], dtype, scope=herd.private())
+                    l1_out = air.alloc([embed_dim], dtype, scope=herd.private())
 
-                dma_memcpy_nd(
-                    l1_in,
-                    l3_in,
-                    src_offsets=[row_offset],
-                    src_sizes=[embed_dim],
-                    src_strides=[1],
-                )
-                dma_memcpy_nd(
-                    l1_lut,
-                    l3_lut,
-                    src_offsets=[row_offset],
-                    src_sizes=[embed_dim],
-                    src_strides=[1],
-                )
+                    for row in air.sequential(rows_per_tile):
+                        lo = (row + tx * rows_per_tile) * embed_dim
 
-                CallOp(rope_func, [l1_in, l1_lut, l1_out, dim_i32])
+                        ops.load(l1_in, src[lo : lo + embed_dim])
+                        ops.load(l1_lut, lut[lo : lo + embed_dim])
 
-                dma_memcpy_nd(
-                    l3_out,
-                    l1_out,
-                    dst_offsets=[row_offset],
-                    dst_sizes=[embed_dim],
-                    dst_strides=[1],
-                )
-                yield_([])
+                        rope(l1_in, l1_lut, l1_out, embed_dim)
 
-            DeallocOp(l1_in)
-            DeallocOp(l1_lut)
-            DeallocOp(l1_out)
+                        ops.store(l1_out, dst[lo : lo + embed_dim])
 
-        herd_body.attributes["link_with"] = StringAttr.get("rope.o")
+    return launch
 
 
 def rope_reference(input_data, lut, embed_dim):
@@ -186,6 +141,13 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
     seq_len = args.seq_len
@@ -193,7 +155,9 @@ if __name__ == "__main__":
     herd_x = args.herd_x
     print(f"RoPE LUT: seq_len={seq_len}, embed_dim={embed_dim}, herd=[{herd_x},1]")
 
-    mlir_module = build_module(seq_len, embed_dim, bfloat16, herd_x=herd_x)
+    launch = build_module(seq_len, embed_dim, herd_x=herd_x)
+    # build() resolves --target auto, so it runs before launch.target is read.
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -210,6 +174,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="rope",
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         exit(
             runner.run_test(
@@ -227,6 +192,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         module_function = backend.compile(mlir_module)
         backend.unload()

--- a/programming_examples/swiglu/swiglu.py
+++ b/programming_examples/swiglu/swiglu.py
@@ -1,173 +1,92 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""SwiGLU (Swish-Gated Linear Unit) on air.api.
 
-"""Vectorized SwiGLU (Swish-Gated Linear Unit) Example
+Element-wise, on 1-D inputs [N]:
 
-Implements element-wise SwiGLU on 1D inputs [N]:
-  SwiGLU(x, gate, up) = SiLU(x * gate) * (x * up)
+    SwiGLU(x, gate, up) = SiLU(x * gate) * (x * up)
 
-where SiLU(z) = z * sigmoid(z) = z * 0.5 * (tanh(z/2) + 1).
+where SiLU(z) = z * sigmoid(z). `ops.silu` is built from the tanh identity,
+z * 0.5 * (tanh(z/2) + 1), which is what the predecessor spelled by hand and
+what the kernel wants: it avoids exp and division, both of which have precision
+and correctness problems on AIE2P, and it lands on the hardware tanh intrinsic.
 
-Uses the tanh-based sigmoid identity to avoid exp and division, which
-have precision and correctness issues on AIE2P. The hardware tanh
-intrinsic (__builtin_aie2p_tanh) is used directly.
+**The gate and up weights share one buffer**, packed as [2, N] with row 0 gate
+and row 1 up, because an AIE2P tile has only 2 S2MM channels and x already
+claims one. Reading a row of that buffer is what the whole example turns on:
 
-The gate and up weights are packed into a single rank-2 buffer
-[2, N] to reduce the number of DMA channels needed (AIE2P tiles
-have only 2 S2MM channels). The L1 buffer is a flat [2*tile_n]
-to allow simple 1D subview/transfer_read operations.
+    out[:] = ops.silu(x[:] * gate_up[0, :]) * (x[:] * gate_up[1, :])
 
-Uses a single AIE tile with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.transfer_read/write.
+A partial buffer subscript is normally a DMA access pattern -- the thing you
+hand to ops.load -- and until now that was all it could be, so packing to save a
+DMA channel cost you an unpack to read it. `gate_up[0, :]` is now also an
+elementwise operand, spelled the way numpy spells it, and the two rows lower to
+two `vector.transfer_read`s at different offsets into the same memref. The
+predecessor built the same two reads out of `memref.subview` with a hand-added
+`arith.addi(j, tile_n)` on the flat [2 * tile_n] copy.
+
+Because the rows carry their leading axis, the buffers here are [1, tile_n]
+rather than [tile_n]: [1, N] and [1, N] broadcast, [1, N] into [N] does not --
+numpy's rule, and the same one air.api already applied to reductions. The L3
+slices stay rank 1; ops.load and ops.store squeeze the leading unit dimension.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith, math as math_dialect
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import transfer_read, transfer_write, BroadcastOp
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
 
-
-@module_builder
-def build_module(n, tile_n, np_dtype_in, vector_size=16):
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    assert n % tile_n == 0
-    assert tile_n % vector_size == 0
-    VECTOR_SIZE = vector_size
-    index_type = IndexType.get()
-
-    l3memrefTy = MemRefType.get([n], xrt_dtype_in)
-    # gate and up packed as [2, N]: row 0 = gate, row 1 = up
-    l3GateUpTy = MemRefType.get([2, n], xrt_dtype_in)
-
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    # L1 buffer for gate+up tile: flat [2*tile_n] for simple 1D indexing
-    l1GateUpTy = MemRefType.get(
-        shape=[2 * tile_n],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-
-    vecTy = VectorType.get([VECTOR_SIZE], xrt_dtype_in)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    @FuncOp.from_py_func(l3memrefTy, l3GateUpTy, l3memrefTy)
-    def swiglu(arg0, arg1, arg2):
-        # arg0 = x [N], arg1 = gate_up [2, N], arg2 = output [N]
-
-        @herd(
-            name="herd_0",
-            sizes=[1, 1],
-            operands=[arg0, arg1, arg2],
+def build_module(n, tile_n, dtype=bf16, vector=16):
+    if n % tile_n:
+        raise ValueError(f"n ({n}) must be a multiple of tile_n ({tile_n})")
+    if vector and tile_n % vector:
+        raise ValueError(
+            f"tile_n ({tile_n}) must be a multiple of the vector width ({vector})"
         )
-        def herd_body(
-            _tx,
-            _ty,
-            _sx,
-            _sy,
-            _l3_x,
-            _l3_gate_up,
-            _l3_out,
-        ):
-            l1_x = AllocOp(l1MemrefTy, [], [])
-            l1_gate_up = AllocOp(l1GateUpTy, [], [])
-            l1_out = AllocOp(l1MemrefTy, [], [])
 
-            c0 = ConstantOp(index_type, 0)
+    x = air.tensor([n], dtype)
+    # Row 0 is gate, row 1 is up: one DMA, one shim channel.
+    gate_up = air.tensor([2, n], dtype)
+    out = air.tensor([n], dtype)
 
-            for _l_ivx in range_(0, n, tile_n):
-                # DMA: load x tile
-                dma_memcpy_nd(
-                    l1_x,
-                    _l3_x,
-                    src_offsets=[_l_ivx],
-                    src_sizes=[tile_n],
-                    src_strides=[1],
-                )
-                # DMA: load gate and up tiles from [2, N] L3 buffer
-                # into flat [2*tile_n] L1 buffer
-                dma_memcpy_nd(
-                    l1_gate_up,
-                    _l3_gate_up,
-                    src_offsets=[0, _l_ivx],
-                    src_sizes=[2, tile_n],
-                    src_strides=[n, 1],
-                )
+    with air.launch(name="swiglu") as launch:
 
-                cVecSize = ConstantOp(index_type, VECTOR_SIZE)
-                cTileN = ConstantOp(index_type, tile_n)
-                cTileNIdx = ConstantOp(index_type, tile_n)
-                cst0 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                half_const = arith.ConstantOp(xrt_dtype_in, 0.5)
-                one_const = arith.ConstantOp(xrt_dtype_in, 1.0)
-                v_half = BroadcastOp(vecTy, half_const)
-                v_one = BroadcastOp(vecTy, one_const)
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="herd_0", shape=(1,)) as herd:
 
-                for j in range_(c0, cTileN, cVecSize):
-                    sub_x = subview(l1_x.result, [j], [VECTOR_SIZE], [1])
-                    # gate is at [0..tile_n-1], up is at [tile_n..2*tile_n-1]
-                    sub_gate = subview(l1_gate_up.result, [j], [VECTOR_SIZE], [1])
-                    up_offset = arith.addi(j, cTileNIdx)
-                    sub_up = subview(l1_gate_up.result, [up_offset], [VECTOR_SIZE], [1])
-                    sub_out = subview(l1_out.result, [j], [VECTOR_SIZE], [1])
-
-                    v_x = transfer_read(vecTy, sub_x, [c0], identity_map, cst0, [True])
-                    v_gate = transfer_read(
-                        vecTy, sub_gate, [c0], identity_map, cst0, [True]
+                @herd.body
+                def _(tx):
+                    # Rank 2 with a leading 1, so a row of l1_gate_up -- which
+                    # is [1, tile_n] -- broadcasts against them.
+                    l1_x = air.alloc(
+                        [1, tile_n], dtype, scope=herd.private(), vector=vector
                     )
-                    v_up = transfer_read(
-                        vecTy, sub_up, [c0], identity_map, cst0, [True]
+                    l1_gate_up = air.alloc(
+                        [2, tile_n], dtype, scope=herd.private(), vector=vector
+                    )
+                    l1_out = air.alloc(
+                        [1, tile_n], dtype, scope=herd.private(), vector=vector
                     )
 
-                    # SwiGLU(x, gate, up) = SiLU(x * gate) * (x * up)
-                    # SiLU(z) = z * 0.5 * (tanh(z/2) + 1)
+                    for lo in air.sequential(0, n, tile_n):
+                        ops.load(l1_x, x[lo : lo + tile_n])
+                        ops.load(l1_gate_up, gate_up[:, lo : lo + tile_n])
 
-                    # Compute x * gate
-                    v_xg = arith.mulf(v_x, v_gate)
+                        l1_out[:] = ops.silu(l1_x[:] * l1_gate_up[0, :]) * (
+                            l1_x[:] * l1_gate_up[1, :]
+                        )
 
-                    # SiLU(x * gate)
-                    v_half_xg = arith.mulf(v_xg, v_half.result)
-                    v_tanh = math_dialect.tanh(v_half_xg)
-                    v_tanh_plus_one = arith.addf(v_tanh, v_one.result)
-                    v_sigmoid = arith.mulf(v_tanh_plus_one, v_half.result)
-                    v_silu_xg = arith.mulf(v_xg, v_sigmoid)
+                        ops.store(l1_out, out[lo : lo + tile_n])
 
-                    # Compute x * up
-                    v_xu = arith.mulf(v_x, v_up)
-
-                    # SwiGLU = SiLU(x * gate) * (x * up)
-                    v_result = arith.mulf(v_silu_xg, v_xu)
-
-                    transfer_write(None, v_result, sub_out, [c0], identity_map, [True])
-                    yield_([])
-
-                dma_memcpy_nd(
-                    _l3_out,
-                    l1_out,
-                    dst_offsets=[_l_ivx],
-                    dst_sizes=[tile_n],
-                    dst_strides=[1],
-                )
-                DeallocOp(l1_x)
-                DeallocOp(l1_gate_up)
-                DeallocOp(l1_out)
-                yield_([])
+    return launch
 
 
 if __name__ == "__main__":
@@ -200,9 +119,18 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
-    mlir_module = build_module(args.n, args.tile_n, INPUT_DATATYPE, args.vector_size)
+    launch = build_module(args.n, args.tile_n, bf16, args.vector_size)
+    # build() resolves --target auto, so it runs before launch.target is read.
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -247,6 +175,7 @@ if __name__ == "__main__":
             output_format=args.output_format,
             instance_name="swiglu",
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         exit(
             runner.run_test(
@@ -264,6 +193,7 @@ if __name__ == "__main__":
             omit_while_true_loop=False,
             output_format=args.output_format,
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
         module_function = backend.compile(mlir_module)
         backend.unload()

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -170,7 +170,7 @@ def _zero_index_if(needed):
     return _result(arith.ConstantOp(IndexType.get(), 0)) if needed else None
 
 
-def _leaf_index(shape, dst_shape, ivs, zero):
+def _leaf_index(shape, dst_shape, ivs, zero, base=None):
     """The indices to read a leaf of ``shape`` at, inside a nest over ``dst_shape``.
 
     An axis that matches the destination's is walked with the destination's own
@@ -178,14 +178,36 @@ def _leaf_index(shape, dst_shape, ivs, zero):
     pinned at 0, which is what makes the read a broadcast. Axes the operand does
     not have contribute no index at all.
 
-    When the shapes are equal this returns ``ivs`` unchanged, which is what
-    keeps every existing kernel's IR byte-identical.
+    ``base`` is the leaf's own starting offset per axis, non-zero only when the
+    leaf is a *slice* of a buffer rather than the whole of it (``gu[1, :]``).
+    It shifts each axis: a pinned axis becomes the constant, and a walked one
+    becomes ``iv + base``.
+
+    When the shapes are equal and the base is all zeros this returns ``ivs``
+    unchanged, which is what keeps every existing kernel's IR byte-identical --
+    the two new branches are reachable only from a slice leaf.
     """
     offset = _broadcast_offset(shape, dst_shape)
-    return [
-        ivs[i + offset] if extent == dst_shape[i + offset] else zero
-        for i, extent in enumerate(shape)
-    ]
+    index = []
+    for i, extent in enumerate(shape):
+        walks = extent == dst_shape[i + offset]
+        start = 0 if base is None else base[i]
+        if start == 0:
+            index.append(ivs[i + offset] if walks else zero)
+        elif not walks:
+            index.append(_index_constant(start))
+        else:
+            index.append(_result(arith.AddIOp(ivs[i + offset], _index_constant(start))))
+    return index
+
+
+def _index_constant(value):
+    return _result(arith.ConstantOp(IndexType.get(), value))
+
+
+def _base_of(leaf):
+    """A slice leaf's starting offset per axis; None for a whole buffer."""
+    return getattr(leaf, "base", None)
 
 
 def _check_region(node, dst, dtype, expected=None):
@@ -488,7 +510,7 @@ def _emit_vector(dst, expr, width):
     )
 
     def load(buf, ivs, region):
-        index = _leaf_index(buf.shape, shape, ivs, zero)
+        index = _leaf_index(buf.shape, shape, ivs, zero, _base_of(buf))
         if buf.shape and buf.shape[-1] == shape[-1]:
             # The operand has the destination's innermost extent, so the vector
             # read is the ordinary one -- at the operand's own rank, which is
@@ -526,7 +548,11 @@ def _emit_scalar(dst, expr):
     )
 
     def load(buf, ivs, region):
-        return _result(memref_load(buf.value, _leaf_index(buf.shape, shape, ivs, zero)))
+        return _result(
+            memref_load(
+                buf.value, _leaf_index(buf.shape, shape, ivs, zero, _base_of(buf))
+            )
+        )
 
     def body(ivs):
         value = _eval(expr, ivs, regions[dst.dtype], regions, False, load, {})
@@ -575,7 +601,11 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
         # cast is the only thing that starts a new region. So a given buffer is
         # reachable from exactly one region and its cached value can only ever
         # have been read at that region's vector type.
-        key = id(node.buffer)
+        base = _base_of(node.buffer)
+        # Keyed on the region, not just the buffer: gu[0, :] and gu[1, :] are
+        # the same Buffer at different offsets, and keying on the buffer alone
+        # would serve the second one the first one's value.
+        key = (id(node.buffer), None if base is None else tuple(base))
         if reads is not None and key in reads:
             return reads[key]
         value = load(node.buffer, ivs, region)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -210,6 +210,21 @@ def _base_of(leaf):
     return getattr(leaf, "base", None)
 
 
+def _read_key(leaf):
+    """What makes two leaves the same read.
+
+    A buffer that appears twice in one expression is read once, and the same has
+    to hold for a region: `gu[0, :] * 2 + gu[0, :]` writes two BufferSlice
+    objects for one region, so keying on the slice's own identity would read it
+    twice. Keying on the underlying buffer alone is the opposite mistake -- it
+    would serve gu[1, :] the value already read for gu[0, :]. The region is what
+    identifies the read: which buffer, from where, how much.
+    """
+    base = _base_of(leaf)
+    buffer = getattr(leaf, "buffer", leaf)
+    return (id(buffer), None if base is None else tuple(base), tuple(leaf.shape))
+
+
 def _check_region(node, dst, dtype, expected=None):
     """Check every buffer leaf against the element type of *its* region.
 
@@ -601,11 +616,7 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
         # cast is the only thing that starts a new region. So a given buffer is
         # reachable from exactly one region and its cached value can only ever
         # have been read at that region's vector type.
-        base = _base_of(node.buffer)
-        # Keyed on the region, not just the buffer: gu[0, :] and gu[1, :] are
-        # the same Buffer at different offsets, and keying on the buffer alone
-        # would serve the second one the first one's value.
-        key = (id(node.buffer), None if base is None else tuple(base))
+        key = _read_key(node.buffer)
         if reads is not None and key in reads:
             return reads[key]
         value = load(node.buffer, ivs, region)

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -585,13 +585,12 @@ class BufferSlice(_StridedView):
     # [2, N] buffer rather than two. Refusing to read a row of it forced a copy
     # the packing existed to avoid.
     #
-    # Only a *plain* region qualifies. A reshape/transpose view re-describes the
-    # elements at another rank or order, so an index into it is not an index
-    # into the buffer; a dynamic offset has no constant to fold into the loop
-    # nest. Both are rejected by name below rather than silently mis-indexed. A
-    # stepped subscript never reaches here -- __getitem__ refuses step != 1
-    # outright -- so a region built by subscripting always carries the buffer's
-    # own strides.
+    # Only a region that walks the buffer the way the buffer is laid out
+    # qualifies. A reshape or transpose does not -- an index into it is not an
+    # index into the buffer -- and neither does a dynamic offset, which has no
+    # constant to fold into a loop nest built at trace time. Both are rejected
+    # by name below rather than silently mis-indexed. A stepped subscript never
+    # reaches here: __getitem__ refuses step != 1 outright.
 
     @property
     def shape(self):
@@ -609,13 +608,21 @@ class BufferSlice(_StridedView):
     def _as_leaf(self):
         """This region as an elementwise leaf, or a TypeError saying why not."""
         self.buffer._require_compute("read")
-        if self.is_view:
+        # The test is the strides, not the is_view flag. is_view is also set by
+        # subscripting a region -- gu[0:2, :][1, :] -- which is an ordinary
+        # region that reads perfectly well, and gating on the flag rejected it.
+        # What actually disqualifies a region is walking memory differently from
+        # the buffer: a reshape changes the rank, a transpose permutes the
+        # strides, and in either case an index into the region is not an index
+        # into the buffer.
+        if list(self.strides) != list(self.buffer.strides):
             raise TypeError(
                 f"cannot read {self!r} elementwise: it is a reshaped or "
-                "transposed view, which re-describes the same elements at a "
-                "different rank or order, so an index into it is not an index "
-                "into the buffer. Only a plain region -- buf[1, :] -- reads "
-                "elementwise."
+                "transposed view, so it walks the buffer with strides "
+                f"{list(self.strides)} rather than its own "
+                f"{list(self.buffer.strides)}, and an index into the view is "
+                "not an index into the buffer. A plain region -- gu[1, :], or a "
+                "subscript of one -- reads elementwise."
             )
         if any(b is None for b in self.base):
             raise TypeError(

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -576,6 +576,88 @@ class BufferSlice(_StridedView):
     def value(self):
         return self.buffer.value
 
+    # -- reading a region elementwise ---------------------------------------
+    #
+    # A partial subscript is primarily a DMA access pattern, and that is still
+    # what ops.load/store see. But numpy spells "the gate half of the packed
+    # buffer" as `gu[0]`, and kernels pack precisely because DMA channels are
+    # scarce -- an AIE2P tile has two S2MM, so swiglu carries gate and up in one
+    # [2, N] buffer rather than two. Refusing to read a row of it forced a copy
+    # the packing existed to avoid.
+    #
+    # Only a *plain* region qualifies. A reshape/transpose view re-describes the
+    # elements at another rank or order, so an index into it is not an index
+    # into the buffer; a dynamic offset has no constant to fold into the loop
+    # nest. Both are rejected by name below rather than silently mis-indexed. A
+    # stepped subscript never reaches here -- __getitem__ refuses step != 1
+    # outright -- so a region built by subscripting always carries the buffer's
+    # own strides.
+
+    @property
+    def shape(self):
+        return tuple(self.sizes)
+
+    @property
+    def vector_width(self):
+        return self.buffer.vector_width
+
+    @property
+    def base(self):
+        """The region's starting index per axis, as Python ints."""
+        return [o.as_const() for o in self.offsets]
+
+    def _as_leaf(self):
+        """This region as an elementwise leaf, or a TypeError saying why not."""
+        self.buffer._require_compute("read")
+        if self.is_view:
+            raise TypeError(
+                f"cannot read {self!r} elementwise: it is a reshaped or "
+                "transposed view, which re-describes the same elements at a "
+                "different rank or order, so an index into it is not an index "
+                "into the buffer. Only a plain region -- buf[1, :] -- reads "
+                "elementwise."
+            )
+        if any(b is None for b in self.base):
+            raise TypeError(
+                f"cannot read {self!r} elementwise: its offset depends on a "
+                "coordinate or loop variable, and the loop nest is built at "
+                "trace time from constant extents. Subscript with a constant "
+                "-- gu[1, :] -- or move the region with air.api.ops.load."
+            )
+        return BufferExpr.leaf(self)
+
+    def _arith(self, other, op, reflected=False):
+        expr = self._as_leaf()
+        other = BufferExpr.coerce(other)
+        return op(other, expr) if reflected else op(expr, other)
+
+    def __add__(self, o):
+        return self._arith(o, lambda a, b: a + b)
+
+    def __radd__(self, o):
+        return self._arith(o, lambda a, b: a + b, reflected=True)
+
+    def __sub__(self, o):
+        return self._arith(o, lambda a, b: a - b)
+
+    def __rsub__(self, o):
+        return self._arith(o, lambda a, b: a - b, reflected=True)
+
+    def __mul__(self, o):
+        return self._arith(o, lambda a, b: a * b)
+
+    def __rmul__(self, o):
+        return self._arith(o, lambda a, b: a * b, reflected=True)
+
+    def __truediv__(self, o):
+        return self._arith(o, lambda a, b: a / b)
+
+    def __rtruediv__(self, o):
+        return self._arith(o, lambda a, b: a / b, reflected=True)
+
+    def __neg__(self):
+        return -self._as_leaf()
+
     def materialize_offsets(self):
         return [o.materialize() for o in self.offsets]
 
@@ -754,12 +836,9 @@ class BufferExpr:
             # examples spell as arith.index_cast(T.i32(), ty).
             return BufferExpr("scalar", scalar=value)
         if isinstance(value, BufferSlice):
-            raise TypeError(
-                f"cannot use {value!r} in an elementwise expression: a partial "
-                "subscript names a DMA region, not a value. Move the region into "
-                "an L1 buffer with air.api.ops.load(dst, src[...]) and compute on "
-                "that buffer"
-            )
+            # A plain region reads elementwise; a view, a strided region or a
+            # dynamic offset does not, and _as_leaf says which.
+            return value._as_leaf()
         raise TypeError(
             f"cannot use {value!r} ({type(value).__name__}) in an elementwise "
             "expression; expected a buffer slice or a numeric scalar"

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -795,9 +795,13 @@ def _():
 
 
 # CHECK-LABEL: TEST: buffer_slice_in_expression
-# A partial subscript names a DMA region, not a value.
-# CHECK: TypeError: cannot use BufferSlice
-@expect(TypeError, "buffer_slice_in_expression")
+# A plain region *is* readable elementwise now -- gu[0, :] is how a packed
+# buffer is unpacked without a copy -- so this is no longer refused for being a
+# region. It is refused for the reason numpy refuses it: half a tile does not
+# broadcast to a whole one.
+# CHECK: ValueError: shape mismatch in elementwise assignment
+# CHECK-SAME: operand has shape (16, 32)
+@expect(ValueError, "buffer_slice_in_expression")
 def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([32, 32], bf16, scope=h.private())
@@ -2181,5 +2185,37 @@ def _():
         row = air.alloc([1, 64], bf16, scope=h.private())
         acc = air.alloc([1, 1], f32, scope=h.private())
         acc[:] = ops.cast(ops.reduce_add(row[:]), f32)
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: elementwise_read_of_a_view
+# A plain region reads elementwise -- gu[0, :] is how a packed [2, N] buffer is
+# unpacked without a copy. A reshaped or transposed view does not: it
+# re-describes the same elements at another rank or order, so an index into it
+# is not an index into the buffer.
+# CHECK: TypeError: cannot read BufferSlice
+# CHECK-SAME: reshaped or transposed view
+@expect(TypeError, "elementwise_read_of_a_view")
+def _():
+    def body(h, tx, ty, A, B, C):
+        gu = air.alloc([2, 64], bf16, scope=h.private())
+        out = air.alloc([64, 2], bf16, scope=h.private())
+        out[:] = gu[0:2, :].transpose(1, 0) * 2.0
+
+    _trace(body)
+
+
+# CHECK-LABEL: TEST: elementwise_read_at_a_runtime_offset
+# The loop nest is built at trace time out of constant extents, so a region
+# whose offset is a coordinate has no constant to fold into the index.
+# CHECK: TypeError: cannot read BufferSlice
+# CHECK-SAME: depends on a coordinate or loop variable
+@expect(TypeError, "elementwise_read_at_a_runtime_offset")
+def _():
+    def body(h, tx, ty, A, B, C):
+        gu = air.alloc([2, 64], bf16, scope=h.private())
+        out = air.alloc([1, 64], bf16, scope=h.private())
+        out[:] = gu[tx, :] * 2.0
 
     _trace(body)

--- a/python/test/api/regions.py
+++ b/python/test/api/regions.py
@@ -1,0 +1,93 @@
+# ./python/test/api/regions.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""A plain buffer region reads elementwise, spelled the way numpy spells it.
+
+A partial subscript is primarily a DMA access pattern -- what ``ops.load`` takes
+-- and for a long time that was all it could be. But kernels pack several
+logical operands into one buffer *because* DMA channels are scarce: an AIE2P
+tile has two S2MM channels, so ``swiglu`` carries its gate and up weights in a
+single ``[2, N]`` buffer. Refusing to read a row of that buffer forced an unpack
+copy, which is the cost the packing existed to avoid.
+
+What a region reads as is decided by its strides. A region that walks the buffer
+the way the buffer is laid out is an ordinary operand at an offset; a reshape or
+a transpose walks it differently, and an index into one of those is not an index
+into the buffer.
+"""
+
+from air import api as air
+from air.api.types import bf16
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def build(body, out_shape=(1, 16)):
+    """A herd holding one packed [2, 16] buffer, plus a destination."""
+    OUT = air.tensor(list(out_shape), bf16)
+    whole = tuple(slice(None) for _ in out_shape)
+
+    with air.launch(name="regions") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    packed = air.alloc([2, 16], bf16, scope=h.private())
+                    dst = air.alloc(list(out_shape), bf16, scope=h.private())
+                    dst[:] = body(packed)
+                    air.ops.store(dst, OUT[whole])
+
+    print(launch.build(target="npu1"))
+
+
+# CHECK-LABEL: TEST: two_rows_of_one_buffer
+# The swiglu case. Row 0 is read at the loop's own index and row 1 one further
+# down the same memref -- two reads, not one, and no copy to separate them.
+# CHECK: scf.for %[[I:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: scf.for %[[J:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: %[[R0:.*]] = vector.transfer_read %[[BUF:.*]][%[[I]], %[[J]]]
+# CHECK: %[[ONE:.*]] = arith.constant 1 : index
+# CHECK: %[[SHIFTED:.*]] = arith.addi %[[I]], %[[ONE]] : index
+# CHECK: %[[R1:.*]] = vector.transfer_read %[[BUF]][%[[SHIFTED]], %[[J]]]
+# CHECK: arith.mulf %[[R0]], %[[R1]]
+@run
+def two_rows_of_one_buffer():
+    build(lambda packed: packed[0, :] * packed[1, :])
+
+
+# CHECK-LABEL: TEST: a_region_of_a_region
+# Subscripting a region gives a region, and it reads like any other. This is
+# worth pinning because such a region is flagged internally as a "view" -- the
+# same flag reshape and transpose set -- and gating on that flag rather than on
+# the strides rejected this outright.
+# CHECK: %[[ONE:.*]] = arith.constant 1 : index
+# CHECK: arith.addi %{{.*}}, %[[ONE]]
+# CHECK: vector.transfer_read
+@run
+def a_region_of_a_region():
+    build(lambda packed: packed[0:2, :][1, :] * 2.0)
+
+
+# CHECK-LABEL: TEST: one_region_named_twice_is_one_read
+# A buffer mentioned twice in an expression is read once; a region has to behave
+# the same way. Each subscript builds a fresh object, so the read cache is keyed
+# on what identifies the read -- which buffer, from where, how much -- and not
+# on the object. Exactly one transfer_read reaches the multiply and the add.
+# CHECK: %[[R:.*]] = vector.transfer_read
+# CHECK-NOT: vector.transfer_read
+# CHECK: arith.mulf
+# CHECK: arith.addf
+@run
+def one_region_named_twice_is_one_read():
+    build(lambda packed: packed[1, :] * 2.0 + packed[1, :])


### PR DESCRIPTION
Four examples onto `air.api`, plus the one DSL change that two of them needed.

Based on `main`. Independent of #1920, which is also in flight — the two touch
`_emit.py` in different places and different examples, so whichever lands first
the other rebases cleanly.

## `[air.api] Read a plain buffer region elementwise`

A partial buffer subscript was a DMA access pattern and nothing else, so
`gu[0, :] * gu[1, :]` raised *"a partial subscript names a DMA region, not a
value"*. That made packing self-defeating: kernels pack precisely **because**
DMA channels are scarce — an AIE2P tile has two S2MM, so swiglu carries gate and
up in one `[2, N]` buffer rather than two — and unpacking to read it cost the
copy the packing existed to avoid.

A plain region now reads elementwise, spelled the way numpy spells it. The leaf
carries a per-axis base offset which the loop nest folds into the index: a
pinned axis becomes the constant, a walked one becomes `iv + base`. **A base of
all zeros takes the pre-existing path unchanged**, so every kernel that does not
slice emits the same IR it did before.

Two things worth a reviewer's attention:

* **The read cache key had to change.** It was `id(buffer)`, and two regions of
  one buffer are distinct leaves — keying on the buffer alone served `gu[1, :]`
  the value already read for `gu[0, :]`. Silent wrong answers, not a crash. It
  is now `(buffer, base)`.
* **Rank follows numpy.** A row of a `[2, N]` buffer is `[1, N]`, so the
  buffers it meets are `[1, tile_n]` rather than `[tile_n]`: `[1, N]` with
  `[1, N]` broadcasts, `[1, N]` into `[N]` does not. The L3 slices stay rank 1 —
  `ops.load`/`ops.store` squeeze the leading unit dimension.

Refused, by name: a reshaped or transposed view, where an index into the view is
not an index into the buffer; and a runtime offset, which has no constant to
fold into a nest built at trace time. A stepped subscript never gets this far —
`__getitem__` refuses `step != 1` — so a region built by subscripting always
carries the buffer's own strides. (I wrote a strides check for that case first,
found it unreachable, and removed it rather than ship code no test can hit.)

The existing `buffer_slice_in_expression` case changes error: `a[0:16, :]` into
a `[32, 32]` destination is now refused for the reason numpy refuses it — a
shape that does not broadcast — rather than for being a region at all.

## Conversions

**`swiglu`** — the example this unlocks. `out[:] = ops.silu(x[:] * gate_up[0, :])
* (x[:] * gate_up[1, :])`. The predecessor built the same two reads out of
`memref.subview` with a hand-added `arith.addi(j, tile_n)` on a flat
`[2 * tile_n]` copy, and spelled SiLU as the tanh identity by hand; `ops.silu`
already is that identity.

**`rope_halfsplit`** and **`rope_lut`** — the rotation stays in C++ via
`air.extern("rope", link_with="rope.o")`, so both bodies are pure dataflow,
which is what the examples are about. The row offsets become ordinary Python
arithmetic on the coordinates where the predecessors hand-built two- and
three-symbol `AffineMap`s. `rope_lut`'s `generate_lut` and `rope_reference` stay
module-level and untouched: the `llms/` shared builders import `generate_lut`
from there, and that is the whole consumer contract — re-verified by importing
it after the conversion.

**`mnist_fc/relu`** — `tile_out[:] = ops.cast(ops.relu(ops.cast(tile_in[:],
bf16)), f32)`. The bf16 detour is a hardware constraint (AIE2P has no f32 vector
cmp/sel) and `ops.cast` opening a region expresses it in one line. The
predecessor round-tripped through an L1 bf16 scratch buffer between the `truncf`
and the `cmpf`/`select`; the DSL keeps the value in registers.

## Gating

Every example here is `REQUIRES: ryzen_ai_npu2` and the dev box is Phoenix, so
the gate is compiling **both** versions for npu2 and diffing the generated AIE
IR and instruction stream.

| example | result |
|---|---|
| `rope_halfsplit` | every op count identical, byte-identical `air.insts.bin` |
| `rope_lut` | every op count identical, byte-identical `air.insts.bin` |
| `swiglu` | byte-identical `air.insts.bin`; the DSL version ping-pongs (6 buffers and 6 dma_bds vs 3) |
| `mnist_fc/relu` | 32 `aie.buffer`s vs 48, 24 `air.execute` vs 40, elf 3 KB smaller — the scratch buffer is gone, and the predecessor's `air.shrinkage` attributes went with it. 16 cores, 32 dma_bds, 32 flows, 64 locks, 32 shim allocations and the 4 `air.actual_sizes` stamps are unchanged |

Plus: the byte-identical IR sweep **61/61** across every already-converted
example (the only file that differs is swiglu, which *is* the conversion — it
cannot build on the old emitter), 28/28 api lits, `check-air-python` 41,
`check-air-mlir` 527 + 7 XFAIL.

**Not gated locally: AIE2P.** None of these run on npu1 — `rope_halfsplit`'s
kernel is built `--target=aie2p` and has no npu1 path at all — so the hx370
runner is the first thing that will execute any of them.
