### PR TITLE
[air-runner] Let an op name the kernel entry that prices it

### DIFF
--- a/docs/AIRRunner.md
+++ b/docs/AIRRunner.md
@@ -92,6 +92,27 @@ operand 0:
 An expression that cannot be evaluated is an error naming the op and quoting
 the expression; the run then reports no latency.
 
+### Naming the entry
+
+`kernels` is keyed by op name, which is enough only while an op name identifies
+the work. It often does not: the projections of a transformer layer are all a
+`linalg.matvec` over the same activation and cost differently. An `air.kernel`
+attribute names the entry instead, so an op can both say what it computes and
+carry its own cost.
+
+```mlir
+linalg.matvec {air.kernel = "o_proj"} ins(%w, %act : ...) outs(%act : ...)
+```
+
+An op that names an entry the model does not define, or defines only for
+another datatype, is an error rather than a silent fall back to the default
+rate -- it asked for something specific.
+
+Note that `linalg.softmax` is **not** costed. It implements
+`AggregatedOpInterface` rather than `LinalgStructuredInterface`, so the cost
+model does not see it and it runs in a single cycle. Write a softmax as
+`linalg.generic` if its time matters.
+
 ## Machine parameters
 
 How a `linalg` body is priced was once fixed in the runner and chosen for AIE.

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -910,9 +910,29 @@ private:
     return (uint64_t)std::llround(*result);
   }
 
+  // Which entry of the model's `kernels` map prices this op.
+  //
+  // The op's name by default, which is enough when an op name identifies the
+  // work. It often does not: the projections of a transformer layer are all a
+  // matvec and cost differently, so keying on "linalg.matvec" gives all of them
+  // one cost and no way to tell them apart. An `air.kernel` attribute names the
+  // entry instead -- the same thing air.custom's symbol does, without giving up
+  // an op that says what it computes.
+  static std::string kernelKeyForOp(Operation *op) {
+    if (auto named = op->getAttrOfType<StringAttr>("air.kernel"))
+      return named.getValue().str();
+    return air::to_string(op);
+  }
+
+  // True when the op asked for a specific entry rather than defaulting to its
+  // name, so a missing entry is a mistake in the model and not silence.
+  static bool namesItsKernel(Operation *op) {
+    return (bool)op->getAttrOfType<StringAttr>("air.kernel");
+  }
+
   // A model-supplied cycle expression for this op and datatype, if any.
   std::optional<std::string> kernelCycleExpr(device &d, Operation *op) {
-    auto name = air::to_string(op);
+    auto name = kernelKeyForOp(op);
     if (!d.kernels.count(name))
       return std::nullopt;
     auto dt = getElementTypeAsString(op->getOperandTypes()[0]);
@@ -968,16 +988,24 @@ private:
 
     if (compute_op_count) {
       auto op_datatype = getElementTypeAsString(op->getOperandTypes()[0]);
+      auto key = kernelKeyForOp(op);
       double ops_per_core_per_cycle = d.default_ops_per_core_per_cycle;
       double efficiency = 1.0f;
-      if (d.kernels.count(air::to_string(op))) {
-        if (d.kernels[air::to_string(op)]->datatypes.count(op_datatype)) {
+      if (d.kernels.count(key)) {
+        if (d.kernels[key]->datatypes.count(op_datatype)) {
           ops_per_core_per_cycle =
-              d.kernels[air::to_string(op)]->datatypes[op_datatype].second;
-          efficiency =
-              d.kernels[air::to_string(op)]->datatypes[op_datatype].first;
-        }
-      }
+              d.kernels[key]->datatypes[op_datatype].second;
+          efficiency = d.kernels[key]->datatypes[op_datatype].first;
+        } else if (namesItsKernel(op))
+          op->emitOpError("names kernel '")
+              << key << "', which the model has, but not for datatype '"
+              << op_datatype << "'";
+      } else if (namesItsKernel(op))
+        // Falling back to the default rate here would price the op at a number
+        // the model never stated, which is the failure this attribute exists to
+        // avoid. An op that named an entry meant it.
+        op->emitOpError("names kernel '")
+            << key << "', which the model does not define";
 
       double ops_per_cycle =
           d.cores_per_kernel_instance * ops_per_core_per_cycle * efficiency;

--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -965,6 +965,25 @@ private:
       return 0;
     }
 
+    // Check a named entry exists before looking at the body at all. An op that
+    // names one has asked for something specific whether or not its body holds
+    // any priced arithmetic -- a copy or a fill has none, and gating this on
+    // the op count would let those fall back to the default rate in silence,
+    // which is the case the attribute exists to rule out.
+    auto op_datatype = getElementTypeAsString(op->getOperandTypes()[0]);
+    auto key = kernelKeyForOp(op);
+    if (namesItsKernel(op)) {
+      // A cycles expression for this datatype has already been taken above, so
+      // reaching here means the entry must price it some other way.
+      if (!d.kernels.count(key))
+        op->emitOpError("names kernel '")
+            << key << "', which the model does not define";
+      else if (!d.kernels[key]->datatypes.count(op_datatype))
+        op->emitOpError("names kernel '")
+            << key << "', which the model has, but not for datatype '"
+            << op_datatype << "'";
+    }
+
     uint64_t compute_op_count = 0;
     for (auto &p : opCounts.map) {
       auto name = std::get<0>(p);
@@ -987,25 +1006,13 @@ private:
     }
 
     if (compute_op_count) {
-      auto op_datatype = getElementTypeAsString(op->getOperandTypes()[0]);
-      auto key = kernelKeyForOp(op);
       double ops_per_core_per_cycle = d.default_ops_per_core_per_cycle;
       double efficiency = 1.0f;
-      if (d.kernels.count(key)) {
-        if (d.kernels[key]->datatypes.count(op_datatype)) {
-          ops_per_core_per_cycle =
-              d.kernels[key]->datatypes[op_datatype].second;
-          efficiency = d.kernels[key]->datatypes[op_datatype].first;
-        } else if (namesItsKernel(op))
-          op->emitOpError("names kernel '")
-              << key << "', which the model has, but not for datatype '"
-              << op_datatype << "'";
-      } else if (namesItsKernel(op))
-        // Falling back to the default rate here would price the op at a number
-        // the model never stated, which is the failure this attribute exists to
-        // avoid. An op that named an entry meant it.
-        op->emitOpError("names kernel '")
-            << key << "', which the model does not define";
+      if (d.kernels.count(key) &&
+          d.kernels[key]->datatypes.count(op_datatype)) {
+        ops_per_core_per_cycle = d.kernels[key]->datatypes[op_datatype].second;
+        efficiency = d.kernels[key]->datatypes[op_datatype].first;
+      }
 
       double ops_per_cycle =
           d.cores_per_kernel_instance * ops_per_core_per_cycle * efficiency;

--- a/mlir/test/Util/Runner/kernel_key/arch.json
+++ b/mlir/test/Util/Runner/kernel_key/arch.json
@@ -1,0 +1,93 @@
+{
+  "clock": 1000000000,
+  "devicename": "bitserial",
+  "datatypes": [
+    {
+      "name": "i8",
+      "bytes": 1
+    },
+    {
+      "name": "i4",
+      "bytes": 1
+    }
+  ],
+  "compute_model": {
+    "kernel_invocation_overhead": 0
+  },
+  "kernels": {
+    "proj_a": {
+      "name": "proj_a",
+      "datatypes": {
+        "i8": {
+          "cycles": "ceildiv(volume0, 4096) * 40 +  20"
+        }
+      }
+    },
+    "proj_b": {
+      "name": "proj_b",
+      "datatypes": {
+        "i8": {
+          "cycles": "ceildiv(volume0, 4096) * 40 +  60"
+        }
+      }
+    },
+    "proj_c": {
+      "name": "proj_c",
+      "datatypes": {
+        "i8": {
+          "cycles": "ceildiv(volume0, 4096) * 40 + 140"
+        }
+      }
+    }
+  },
+  "dus": {
+    "count": [
+      1,
+      1
+    ],
+    "memory": {
+      "memory_space": "L2",
+      "bytes": 1048576
+    },
+    "ports": {
+      "outbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      },
+      "inbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      }
+    },
+    "tiles": {
+      "count": [
+        1,
+        1
+      ],
+      "memory": {
+        "memory_space": "L1",
+        "bytes": 65536
+      },
+      "ports": {
+        "outbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        },
+        "inbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        }
+      }
+    }
+  },
+  "noc": {
+    "outbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    },
+    "inbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    }
+  }
+}

--- a/mlir/test/Util/Runner/kernel_key/missing_kernel.mlir
+++ b/mlir/test/Util/Runner/kernel_key/missing_kernel.mlir
@@ -1,0 +1,46 @@
+//===- missing_kernel.mlir ---------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json -g core 2>&1 | FileCheck %s
+
+// Naming an entry the model does not define is an error, and it has to be one
+// whatever the op's body holds.
+//
+// linalg.copy has no priced scalar arithmetic in it, so the op count is zero
+// and the throughput model has nothing to do. That must not be a reason to
+// stop checking: gating the check on the op count lets a copy or a fill name a
+// kernel that does not exist and fall back to the default rate in silence,
+// which is the one thing this attribute exists to prevent.
+
+// CHECK: error: 'linalg.copy' op names kernel 'does_not_exist', which the model does not define
+// CHECK: No latency reported
+// CHECK-NOT: Latency (
+
+module {
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %2 = air.herd @herd_0 async tile (%hx, %hy) in (%hsx=%c1_0, %hsy=%c1_0) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          %ta, %a = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %tb, %b = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %e = air.execute [%ta, %tb] {
+            linalg.copy {air.kernel = "does_not_exist"} ins(%a : memref<64xi8, 2>) outs(%b : memref<64xi8, 2>)
+          }
+        }
+      }
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/kernel_key/named_kernels.mlir
+++ b/mlir/test/Util/Runner/kernel_key/named_kernels.mlir
@@ -1,0 +1,83 @@
+//===- named_kernels.mlir ----------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-runner %s -f test -m %S/arch.json -g core | FileCheck %s
+
+// Three ops of the same kind and the same shape, costing three different
+// things.
+//
+// The model's kernels are keyed by op name, which is enough only while an op
+// name identifies the work. It often does not: the projections of a
+// transformer layer are all a matvec over the same activation, and they cost
+// differently. Keyed by name they would share one entry and there would be no
+// way to tell them apart -- the reason to reach for air.custom, which gives up
+// an op that says what it computes in exchange for a symbol to hang a number
+// on.
+//
+// `air.kernel` names the entry instead, so an op can be both.
+//
+//     proj_a  ceildiv(volume0, 4096) * 40 +  20 =  60
+//     proj_b  ceildiv(volume0, 4096) * 40 +  60 = 100
+//     proj_c  ceildiv(volume0, 4096) * 40 + 140 = 180
+
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,T0:]],
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.0[[#T0 + 60]],
+
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.0[[#%d,T1:]],
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#T1 + 100]],
+
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.[[#%d,T2:]],
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#T2 + 180]],
+
+// CHECK: "name": "LaunchTerminator",
+// CHECK: "ph": "E",
+
+module {
+  func.func @test() {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) attributes {id = 1 : i32} {
+      %1 = air.segment @seg async attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_0 = arith.constant 1 : index
+        %2 = air.herd @herd_0 async tile (%hx, %hy) in (%hsx=%c1_0, %hsy=%c1_0) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 0 : i64} {
+          // Weights are allocated and never written: on a weight-stationary
+          // machine they are already resident, so the alloc is the residency
+          // and there is no fill to model.
+          %tw, %w = air.execute -> (memref<64x64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64x64xi8, 2>
+            air.execute_terminator %alloc : memref<64x64xi8, 2>
+          }
+          %ta, %act = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %e0 = air.execute [%tw, %ta] {
+            linalg.matvec {air.kernel = "proj_a"} ins(%w, %act : memref<64x64xi8, 2>, memref<64xi8, 2>) outs(%act : memref<64xi8, 2>)
+          }
+          %e1 = air.execute [%e0] {
+            linalg.matvec {air.kernel = "proj_b"} ins(%w, %act : memref<64x64xi8, 2>, memref<64xi8, 2>) outs(%act : memref<64xi8, 2>)
+          }
+          %e2 = air.execute [%e1] {
+            linalg.matvec {air.kernel = "proj_c"} ins(%w, %act : memref<64x64xi8, 2>, memref<64xi8, 2>) outs(%act : memref<64xi8, 2>)
+          }
+        }
+      }
+    }
+    return
+  }
+}


### PR DESCRIPTION
Follow-up to #1918, which let a machine model describe how an op is priced. This lets an op say *which* description applies to it.

## The gap

`kernels` is keyed by op name. That is enough only while an op name identifies the work, and often it does not. The projections of a transformer layer are all a `linalg.matvec` over the same activation, in the same shape, and they cost different things. Keyed by name they share one entry and there is no way to tell them apart.

That is a reason to reach for `air.custom` — trading an op that says what it computes for a symbol to hang a number on. The point of #1918 was to stop having to make that trade, and without this it is only half made.

## The change

An `air.kernel` string attribute names the entry:

```mlir
linalg.matvec {air.kernel = "o_proj"} ins(%w, %act : ...) outs(%act : ...)
```

falling back to the op name when absent, so nothing existing changes. It is the same keying `air.custom` already has through its symbol, without giving up the semantics.

An op that names an entry the model does not define, or defines only for another datatype, is an **error**:

```
error: 'linalg.matvec' op names kernel 'proj_b', which the model does not define
error: 'linalg.matvec' op names kernel 'proj_c', which the model has, but not for datatype 'i8'
```

Falling back to the default rate would price it at a number the model never stated, which is the failure the attribute exists to avoid. The run then reports no latency, as #1918 established for errors.

## Also documented: `linalg.softmax` is not costed

While testing which named linalg ops the cost model actually sees, `linalg.softmax` turned out not to be one. It implements `AggregatedOpInterface` rather than `LinalgStructuredInterface`, so `modelOp`'s `dyn_cast<linalg::LinalgOp>` misses it and it runs in a single cycle — its `kernels` entry is ignored entirely. I gave it `"cycles": "12345"` and got 11 cycles, silently.

Not fixed here, because the naive fix is wrong: the same fall-through is reached ~5,700 times across the runner suite by `memref.alloc`, `memref.dealloc` and `affine.apply`, which are legitimately free (allocs are accounted as resource events elsewhere). A blanket warning would be noise. The correct rule is narrower — a `linalg`-dialect op that is not a `LinalgOp` — and belongs in its own change. Documented in `docs/AIRRunner.md` so it is at least not a surprise.

## Test

`kernel_key/named_kernels.mlir` — three `linalg.matvec` ops, identical shape and identical MAC count, costing 60 / 100 / 180 because each names its own entry. Weights are allocated and never written, which is how a weight-stationary target's resident weights appear in the IR.

Negative-controlled: drop the attribute lookup and the test fails.

## Checks

- `check-air-mlir` 545 tests / 527 passed / 7 expectedly failed / 0 failed
- `check-air-python` 38/38, `check-air-cpp` 1/1
- `git clang-format origin/main` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
