### PR TITLE
[air.api] Reduce a long axis in vector-width steps, plus layer_norm and weighted_rms_norm

### DIFF
--- a/programming_examples/layer_norm/layer_norm.py
+++ b/programming_examples/layer_norm/layer_norm.py
@@ -1,273 +1,132 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Affine LayerNorm over [M, N], on air.api.
 
-"""Vectorized Layer Normalization Example (with affine weight + bias)
+Row by row, following the GPU/PyTorch standard:
 
-Implements affine layer normalization on a 2D input [M, N]:
-  1. mean = sum(x, axis=-1) / N                    (F32 reduction)
-  2. var  = sum((x - mean)^2, axis=-1) / N          (F32 reduction)
-  3. rstd = 1 / sqrt(var + eps)                      (F32)
-  4. y    = (x - mean) * rstd * weight + bias        (bf16 epilogue)
+    mean = sum(x) / N                       accumulated in f32
+    var  = sum((x - mean)^2) / N            accumulated in f32
+    rstd = rsqrt(var + eps)                 scalar, f32
+    y    = (x - mean) * rstd * weight + bias
 
-The affine parameters `weight` (gamma) and `bias` (beta) both have shape [N]
-and are shared across all M rows. This matches HuggingFace / PyTorch
-`nn.LayerNorm` — the accuracy-critical reductions (mean and variance) run in
-FP32; only the per-element epilogue runs in the bf16 vector unit.
+The two reductions and the rsqrt run in f32 because that is where LayerNorm's
+accuracy lives; the per-element epilogue runs in bf16 vectors, because the AIE
+vector unit does not legalize f32 vector elementwise ops. `ops.cast` marks that
+boundary, and everything below a cast is read and computed in the source type,
+so the region each step runs in is visible in the expression rather than left to
+a convention.
 
-Two herd modes share the same math:
-  * single-tile (herd_x=1): one AIE tile loops over all M rows.
-  * multi-tile  (herd_x=8): the M rows are split across `herd_x` AIE columns
-    (full NPU2 chip width) — LayerNorm is row-independent, so this is a pure
-    memory-bandwidth win. weight/bias [N] are broadcast to every column.
+**weight and bias share one flat [2N] buffer**, `[0:N]` weight and `[N:2N]`
+bias, because AIE per-tile routing caps at about three L3 streams and
+in + weight + bias + out is four. The halves are read straight out of it:
 
-Computation is vectorized using vector.transfer_read/write with a
-configurable VECTOR_SIZE (default 16 for AIE2/AIE2P).
+    out[:] = (row[:] - mean[:]) * rstd[:] * param[0:N] + param[N : 2 * N]
+
+Each half is a plain region of the packed buffer, which is an ordinary
+elementwise operand, so the packing costs nothing to read. The predecessor
+carved the same two halves out with `memref.subview` plus a hand-added
+`arith.addi(j, N)`.
+
+`mean` and `rstd` are [1, 1] buffers multiplied against a [1, N] row -- numpy
+broadcasting along the innermost axis, which the DSL lowers to `memref.load`
+plus `vector.broadcast` where the predecessor built the broadcast by hand and
+threaded it through three loop nests.
+
+N is 768 by default, far longer than one vector, so both reductions are read in
+vector-width steps with the partials accumulated through an L1 scratch buffer --
+the same structure the predecessor wrote by hand, and the reason it is not one
+768-lane `vector.reduction` (that does not legalize).
+
+`build_module` returns the **module**, not the launch, unlike the other
+converted examples: smolvla's vision builders do
+`str(build_layer_norm(seq_len, emb_dim, bfloat16, 16, herd_x=8))`, so the
+signature and the return type are a contract.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith, math as math_dialect
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    reduction as vector_reduction,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
-
-# SigLIP LayerNorm uses eps=1e-6; the example default is 1e-5. The difference
-# is negligible versus the bf16 datapath error, so we keep 1e-5 here (record
-# the value used in the registry page).
 EPS = 1e-5
 
 
-@module_builder
-def build_module(M, N, np_dtype, vector_size=16, herd_x=1):
-    xrt_dtype = type_mapper(np_dtype)
-    assert (
-        N % vector_size == 0
-    ), f"N ({N}) must be divisible by vector_size ({vector_size})"
-
-    vecTy = VectorType.get([vector_size], xrt_dtype)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    # FP32 compute types. Following the GPU/PyTorch standard (torch LayerNorm /
-    # HF *LayerNorm), the accuracy-critical reductions (mean, then variance) are
-    # done in f32: bf16 inputs are upcast and both sums are accumulated in an f32
-    # buffer, with the scalar rsqrt also in f32. The per-element epilogue
-    # ((x-mean) * rstd * weight + bias) then runs in bf16 vectors — the aie
-    # vector unit does not legalize f32 vector elementwise ops — so the only
-    # remaining quantization is the single bf16 output rounding, as in a
-    # standard GPU LayerNorm.
-    f32 = F32Type.get()
-    vecTyF32 = VectorType.get([vector_size], f32)
-
-    # L3 types
-    l3MemrefTy = MemRefType.get([M, N], xrt_dtype)
-    # weight (gamma) and bias (beta) are packed into a single flat [2N] buffer
-    # ([0:N] = weight, [N:2N] = bias) so they cost ONE L3<->L1 DMA channel per
-    # tile instead of two — the AIE per-tile routing caps at ~3 L3 streams, and
-    # in + weight + bias + out = 4 exceeds that (aie.connect routing failure).
-    l3ParamTy = MemRefType.get([2 * N], xrt_dtype)
-
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1RowTy = MemRefType.get([N], xrt_dtype, memory_space=l1_mem_space)
-    l1ParamTy = MemRefType.get([2 * N], xrt_dtype, memory_space=l1_mem_space)
-    l1VecTyF32 = MemRefType.get([vector_size], f32, memory_space=l1_mem_space)
-    # Small bf16 scratch to break mulf->addf def-use chains (see Steps 2 & 4):
-    # aievec rejects an addf whose operand comes directly from a mulf, so we
-    # round-trip the product through a dedicated L1 scratch buffer.
-    l1SqTy = MemRefType.get([vector_size], xrt_dtype, memory_space=l1_mem_space)
-
-    def emit_body(l3_in, l3_param, l3_out, row_iter, tx=None, row_map=None):
-        """Emit the per-tile LayerNorm body. `row_iter` yields the loop trip
-        count; the global row index is computed from row_map when multi-tile.
-        `l3_param` is the packed [2N] weight||bias buffer."""
-        l1_row = AllocOp(l1RowTy, [], [])
-        l1_out = AllocOp(l1RowTy, [], [])
-        l1_param = AllocOp(l1ParamTy, [], [])  # [0:N]=weight, [N:2N]=bias
-        l1_acc = AllocOp(l1VecTyF32, [], [])
-        l1_sq = AllocOp(l1SqTy, [], [])
-
-        c0 = arith.ConstantOp.create_index(0)
-        cst0 = arith.ConstantOp(xrt_dtype, 0.0)
-        cst0_f32 = arith.ConstantOp(f32, 0.0)
-        n_f = arith.ConstantOp(f32, float(N))
-        eps_f = arith.ConstantOp(f32, EPS)
-
-        v_zero_f32 = BroadcastOp(vecTyF32, cst0_f32)
-
-        # DMA the packed weight||bias [2N] buffer to L1 in one transfer (shared
-        # across all rows / broadcast to tiles). One DMA channel, not two — the
-        # AIE per-tile routing caps at ~3 L3 streams; in + weight + bias + out
-        # = 4 overflows it (aie.connect routing failure).
-        dma_memcpy_nd(
-            l1_param, l3_param, src_offsets=[0], src_sizes=[2 * N], src_strides=[1]
+def build_launch(M, N, dtype=bf16, vector=16, herd_x=1):
+    """The launch; `build_module` wraps this and returns the module."""
+    if vector and N % vector:
+        raise ValueError(f"N ({N}) must be divisible by the vector width ({vector})")
+    if M % herd_x:
+        raise ValueError(
+            f"M ({M}) must be divisible by herd_x ({herd_x}): every tile takes "
+            "the same number of rows, and there is no remainder path."
         )
+    rows_per_tile = M // herd_x
 
-        for it in range_(row_iter):
-            if row_map is not None:
-                row = affine_apply(row_map, [it, tx])
-            else:
-                row = it
-            # DMA: load one row from L3 to L1
-            dma_memcpy_nd(
-                l1_row,
-                l3_in,
-                src_offsets=[row, 0],
-                src_sizes=[1, N],
-                src_strides=[N, 1],
-            )
+    X = air.tensor([M, N], dtype)
+    # weight || bias, one DMA rather than two.
+    PARAM = air.tensor([2 * N], dtype)
+    Y = air.tensor([M, N], dtype)
 
-            # Step 1: sum(x) accumulated in F32 (for the mean).
-            transfer_write(None, v_zero_f32, l1_acc, [c0], identity_map, [True])
-            for j in range_(0, N, vector_size):
-                sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                v_x = transfer_read(vecTy, sub_row, [c0], identity_map, cst0, [True])
-                v_x_f32 = arith.extf(vecTyF32, v_x)
-                v_acc = transfer_read(
-                    vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                )
-                v_sum = arith.addf(v_acc, v_x_f32)
-                transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
-                yield_([])
+    with air.launch(name="layer_norm") as launch:
 
-            v_final = transfer_read(
-                vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-            )
-            sum_x = vector_reduction(f32, "add", v_final)
-            mean_f32 = arith.divf(sum_x, n_f)
-            # bf16 mean for the vector subtraction (f32 vector elementwise not
-            # legalized); mean itself was computed in f32.
-            mean = arith.truncf(xrt_dtype, mean_f32)
-            v_mean = BroadcastOp(vecTy, mean)
+        @launch.body
+        def _():
+            with air.herd([range(herd_x)], name="herd_0", shape=(herd_x,)) as herd:
 
-            # Step 2: var = sum((x - mean)^2) / N, accumulated in F32.
-            transfer_write(None, v_zero_f32, l1_acc, [c0], identity_map, [True])
-            for j in range_(0, N, vector_size):
-                sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                v_x = transfer_read(vecTy, sub_row, [c0], identity_map, cst0, [True])
-                v_diff = arith.subf(v_x, v_mean)
-                v_sq = arith.mulf(v_diff, v_diff)
-                # break the mulf->addf chain via an L1 scratch round-trip.
-                transfer_write(None, v_sq, l1_sq, [c0], identity_map, [True])
-                v_sq_rd = transfer_read(vecTy, l1_sq, [c0], identity_map, cst0, [True])
-                v_sq_f32 = arith.extf(vecTyF32, v_sq_rd)
-                v_acc = transfer_read(
-                    vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                )
-                v_sum = arith.addf(v_acc, v_sq_f32)
-                transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
-                yield_([])
+                @herd.body
+                def _(tx):
+                    row = air.alloc([1, N], dtype, scope=herd.private(), vector=vector)
+                    out = air.alloc([1, N], dtype, scope=herd.private(), vector=vector)
+                    # Shared by every row of this tile, so it is fetched once,
+                    # above the loop.
+                    param = air.alloc(
+                        [2 * N], dtype, scope=herd.private(), vector=vector
+                    )
+                    acc = air.alloc([1, 1], f32, scope=herd.private(), vector=vector)
+                    mean = air.alloc([1, 1], dtype, scope=herd.private(), vector=vector)
+                    rstd = air.alloc([1, 1], dtype, scope=herd.private(), vector=vector)
 
-            v_var = transfer_read(
-                vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-            )
-            var_sum = vector_reduction(f32, "add", v_var)
-            variance = arith.divf(var_sum, n_f)
+                    ops.load(param, PARAM[:])
 
-            # Step 3: rstd = rsqrt(var + eps) in f32, truncate scalar to bf16.
-            var_eps = arith.addf(variance, eps_f)
-            rstd_f32 = math_dialect.rsqrt(var_eps)
-            rstd = arith.truncf(xrt_dtype, rstd_f32)
-            v_rstd = BroadcastOp(vecTy, rstd)
+                    for it in air.sequential(rows_per_tile):
+                        r = it + tx * rows_per_tile
+                        ops.load(row, X[r : r + 1, :])
 
-            # Step 4: y = (x - mean) * rstd * weight + bias (bf16 vector).
-            # weight lives at l1_param[j], bias at l1_param[N + j].
-            for j in range_(0, N, vector_size):
-                jb = arith.addi(j, arith.ConstantOp.create_index(N))
-                sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                sub_w = subview(l1_param.result, [j], [vector_size], [1])
-                sub_b = subview(l1_param.result, [jb], [vector_size], [1])
-                sub_out = subview(l1_out.result, [j], [vector_size], [1])
-                v_x = transfer_read(vecTy, sub_row, [c0], identity_map, cst0, [True])
-                v_w = transfer_read(vecTy, sub_w, [c0], identity_map, cst0, [True])
-                v_b = transfer_read(vecTy, sub_b, [c0], identity_map, cst0, [True])
-                v_diff = arith.subf(v_x, v_mean)
-                v_normed = arith.mulf(v_diff, v_rstd)
-                v_weighted = arith.mulf(v_normed, v_w)
-                # break the mulf->addf chain before adding bias.
-                transfer_write(None, v_weighted, l1_sq, [c0], identity_map, [True])
-                v_weighted_rd = transfer_read(
-                    vecTy, l1_sq, [c0], identity_map, cst0, [True]
-                )
-                v_out = arith.addf(v_weighted_rd, v_b)
-                transfer_write(None, v_out, sub_out, [c0], identity_map, [True])
-                yield_([])
+                        # mean, accumulated in f32
+                        acc[:] = ops.reduce_add(ops.cast(row[:], f32))
+                        mean[:] = ops.cast(acc[:] * (1.0 / N), dtype)
 
-            # DMA: write result row from L1 to L3
-            dma_memcpy_nd(
-                l3_out,
-                l1_out,
-                dst_offsets=[row, 0],
-                dst_sizes=[1, N],
-                dst_strides=[N, 1],
-            )
+                        # variance: the difference and its square are bf16 and
+                        # the accumulation f32 -- the predecessor's split.
+                        acc[:] = ops.reduce_add(
+                            ops.cast((row[:] - mean[:]) * (row[:] - mean[:]), f32)
+                        )
+                        rstd[:] = ops.cast(ops.rsqrt(acc[:] * (1.0 / N) + EPS), dtype)
 
-            yield_([])
+                        out[:] = (row[:] - mean[:]) * rstd[:] * param[0:N] + param[
+                            N : 2 * N
+                        ]
 
-        DeallocOp(l1_row)
-        DeallocOp(l1_out)
-        DeallocOp(l1_param)
-        DeallocOp(l1_acc)
-        DeallocOp(l1_sq)
+                        ops.store(out, Y[r : r + 1, :])
 
-    if herd_x > 1:
-        assert M % herd_x == 0
-        rows_per_tile = M // herd_x
-        # Map: global_row = local_row + tx * rows_per_tile
-        row_map = AffineMap.get(
-            0,
-            2,
-            [
-                AffineExpr.get_add(
-                    AffineSymbolExpr.get(0),
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(1), AffineConstantExpr.get(rows_per_tile)
-                    ),
-                )
-            ],
+    return launch
+
+
+def build_module(M, N, np_dtype=bfloat16, vector_size=16, herd_x=1, target="npu2"):
+    """The MLIR module. Signature and return type are smolvla's contract."""
+    if np_dtype is not bfloat16:
+        raise NotImplementedError(
+            f"layer_norm is bf16 only, got {np_dtype!r}: the epilogue runs in "
+            "bf16 vectors because the AIE vector unit does not legalize f32 "
+            "vector elementwise ops."
         )
-
-        @FuncOp.from_py_func(l3MemrefTy, l3ParamTy, l3MemrefTy)
-        def layer_norm(arg0, arg1, arg2):
-
-            @herd(
-                name="herd_0",
-                sizes=[herd_x, 1],
-                operands=[arg0, arg1, arg2],
-            )
-            def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_param, l3_out):
-                emit_body(
-                    l3_in,
-                    l3_param,
-                    l3_out,
-                    rows_per_tile,
-                    tx=_tx,
-                    row_map=row_map,
-                )
-
-        return  # end of herd_x > 1 path
-
-    # Single-tile path (herd_x == 1)
-    @FuncOp.from_py_func(l3MemrefTy, l3ParamTy, l3MemrefTy)
-    def layer_norm(arg0, arg1, arg2):
-
-        @herd(name="herd_0", sizes=[1, 1], operands=[arg0, arg1, arg2])
-        def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_param, l3_out):
-            emit_body(l3_in, l3_param, l3_out, M)
+    return build_launch(M, N, bf16, vector_size, herd_x).build(target=target)
 
 
 def layer_norm_reference(x, weight, bias, eps=EPS):

--- a/programming_examples/layer_norm/layer_norm.py
+++ b/programming_examples/layer_norm/layer_norm.py
@@ -154,6 +154,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("--vector-size", type=int, default=16)
     parser.add_argument(
+        "--target",
+        type=str,
+        default="npu2",
+        help="NPU generation to build for (npu2; the epilogue is AIE2P bf16)",
+    )
+    parser.add_argument(
         "--herd-x",
         type=int,
         default=1,
@@ -187,7 +193,9 @@ if __name__ == "__main__":
     herd_x = args.herd_x
     print(f"LayerNorm (affine): M={M}, N={N}, herd=[{herd_x},1]")
 
-    mlir_module = build_module(M, N, bfloat16, args.vector_size, herd_x=herd_x)
+    mlir_module = build_module(
+        M, N, bfloat16, args.vector_size, herd_x=herd_x, target=args.target
+    )
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/programming_examples/weighted_rms_norm/weighted_rms_norm.py
+++ b/programming_examples/weighted_rms_norm/weighted_rms_norm.py
@@ -1,325 +1,109 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Weighted RMS normalisation over [M, N], on air.api.
 
-"""Vectorized Weighted RMS Normalization Example
+Row by row, following the GPU/PyTorch standard (torch rms_norm_composite /
+HF LlamaRMSNorm):
 
-Implements weighted RMS normalization on a 2D input [M, N]:
-  1. rms  = sum(x^2, axis=-1) / N
-  2. rstd = 1 / sqrt(rms + eps)
-  3. y    = x * rstd * weight
+    ms   = sum(x * x) / N                   accumulated in f32
+    rstd = rsqrt(ms + eps)                  scalar, f32
+    y    = x * rstd * weight
 
-The weight vector has shape [N] and is shared across all M rows.
+The reduction and the rsqrt run in f32 because that is where the accuracy
+lives; the per-element epilogue runs in bf16 vectors, because the AIE vector
+unit does not legalize f32 vector elementwise mul. `ops.cast` marks the
+boundary, so the region each step runs in is visible in the expression.
 
-Uses a single AIE tile with DMA transfers between L3 and L1 memory.
-Computation is vectorized using vector.transfer_read/write with
-configurable VECTOR_SIZE (default 16 for AIE2).
+N is 2048 by default -- LLAMA's embedding dim -- so the reduction is read in
+vector-width steps with the partials accumulated through an L1 scratch buffer.
+That is the same structure the predecessor wrote by hand, and the reason it is
+not one 2048-lane `vector.reduction`.
+
+Two things the predecessor needed and this does not: the L1 scratch it used to
+break the `mulf`->`addf` def-use chain that aievec rejects (the multiply here
+feeds a `vector.reduction`, not an add), and the hand-built `vector.broadcast`
+of the scalar `rstd` (a [1, 1] buffer against a [1, N] row is numpy
+broadcasting, which the DSL lowers to `memref.load` + `vector.broadcast`).
+
+`build_module` returns the **module**, not the launch, unlike most converted
+examples: `llms/llama32_1b_int4/multi_launch_builder/rms_gemms_rope_bfp16_multi`
+imports it and stitches the result, so the signature and the return type are a
+contract.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith, math as math_dialect
-from air.dialects.memref import AllocOp, DeallocOp, subview
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    reduction as vector_reduction,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
-
-range_ = for_
+from air.backend.xrt_runner import XRTRunner
 
 EPS = 1e-5
 
 
-@module_builder
-def build_module(M, N, np_dtype, vector_size=16, herd_x=1):
-    xrt_dtype = type_mapper(np_dtype)
-    assert (
-        N % vector_size == 0
-    ), f"N ({N}) must be divisible by vector_size ({vector_size})"
-
-    vecTy = VectorType.get([vector_size], xrt_dtype)
-    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    # FP32 compute types. Following the GPU/PyTorch standard (torch
-    # rms_norm_composite / HF LlamaRMSNorm), the accuracy-critical reduction is
-    # done in f32: bf16 inputs are squared, upcast, and the sum-of-squares is
-    # accumulated in f32, with the scalar rsqrt also in f32. The per-element
-    # epilogue (x * rstd * weight) then runs in bf16 vectors — the aie vector
-    # unit does not legalize f32 vector elementwise mul — so the only remaining
-    # quantization is the single bf16 output rounding, as in a standard GPU
-    # RMSNorm.
-    f32 = F32Type.get()
-    vecTyF32 = VectorType.get([vector_size], f32)
-
-    # L3 types
-    l3MemrefTy = MemRefType.get([M, N], xrt_dtype)
-    l3WeightTy = MemRefType.get([N], xrt_dtype)
-
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1RowTy = MemRefType.get([N], xrt_dtype, memory_space=l1_mem_space)
-    l1VecTyF32 = MemRefType.get([vector_size], f32, memory_space=l1_mem_space)
-    # Small bf16 scratch for the square round-trip that breaks the mulf->addf
-    # def-use chain (see Step 1). Dedicated buffer so the reduction phase does
-    # not alias the output buffer.
-    l1SqTy = MemRefType.get([vector_size], xrt_dtype, memory_space=l1_mem_space)
-
-    if herd_x > 1:
-        assert M % herd_x == 0
-        rows_per_tile = M // herd_x
-        # Map: global_row = local_row + tx * rows_per_tile
-        row_map = AffineMap.get(
-            0,
-            2,
-            [
-                AffineExpr.get_add(
-                    AffineSymbolExpr.get(0),
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(1), AffineConstantExpr.get(rows_per_tile)
-                    ),
-                )
-            ],
+def build_launch(M, N, dtype=bf16, vector=16, herd_x=1):
+    """The launch; `build_module` wraps this and returns the module."""
+    if vector and N % vector:
+        raise ValueError(f"N ({N}) must be divisible by the vector width ({vector})")
+    if M % herd_x:
+        raise ValueError(
+            f"M ({M}) must be divisible by herd_x ({herd_x}): every tile takes "
+            "the same number of rows, and there is no remainder path."
         )
+    rows_per_tile = M // herd_x
 
-        # Multi-tile mode: each tile DMAs the full weight vector from L3
-        # (the compiler may merge these identical loads into a broadcast).
-        @FuncOp.from_py_func(l3MemrefTy, l3WeightTy, l3MemrefTy)
-        def weighted_rms_norm(arg0, arg1, arg2):
+    X = air.tensor([M, N], dtype)
+    W = air.tensor([N], dtype)
+    Y = air.tensor([M, N], dtype)
 
-            @herd(name="herd_0", sizes=[herd_x, 1], operands=[arg0, arg1, arg2])
-            def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_weight, l3_out):
-                l1_row = AllocOp(l1RowTy, [], [])
-                l1_out = AllocOp(l1RowTy, [], [])
-                l1_weight = AllocOp(l1RowTy, [], [])
-                l1_acc = AllocOp(l1VecTyF32, [], [])
-                l1_sq = AllocOp(l1SqTy, [], [])
+    with air.launch(name="weighted_rms_norm") as launch:
 
-                c0 = arith.ConstantOp.create_index(0)
-                cst0 = arith.ConstantOp(xrt_dtype, 0.0)
-                cst0_f32 = arith.ConstantOp(f32, 0.0)
-                n_f = arith.ConstantOp(f32, float(N))
-                eps_f = arith.ConstantOp(f32, EPS)
+        @launch.body
+        def _():
+            with air.herd([range(herd_x)], name="herd_0", shape=(herd_x,)) as herd:
 
-                v_zero_f32 = BroadcastOp(vecTyF32, cst0_f32)
-
-                # Weight DMA: same data to all tiles (broadcast)
-                dma_memcpy_nd(
-                    l1_weight,
-                    l3_weight,
-                    src_offsets=[0],
-                    src_sizes=[N],
-                    src_strides=[1],
-                )
-
-                for local_row in range_(rows_per_tile):
-                    row = affine_apply(row_map, [local_row, _tx])
-                    # DMA: load one row (tile-dependent offset)
-                    dma_memcpy_nd(
-                        l1_row,
-                        l3_in,
-                        src_offsets=[row, 0],
-                        src_sizes=[1, N],
-                        src_strides=[N, 1],
+                @herd.body
+                def _(tx):
+                    row = air.alloc([1, N], dtype, scope=herd.private(), vector=vector)
+                    out = air.alloc([1, N], dtype, scope=herd.private(), vector=vector)
+                    # Shared by every row of this tile, so it is fetched once.
+                    weight = air.alloc(
+                        [1, N], dtype, scope=herd.private(), vector=vector
                     )
+                    acc = air.alloc([1, 1], f32, scope=herd.private(), vector=vector)
+                    rstd = air.alloc([1, 1], dtype, scope=herd.private(), vector=vector)
 
-                    # Step 1: sum of x^2, accumulated in F32 (GPU standard).
-                    # Square in bf16 vector (aievec-legal), upcast to f32, and
-                    # accumulate into an f32 buffer — the running sum stays f32 so
-                    # the reduction over N does not lose low-order bits.
-                    transfer_write(None, v_zero_f32, l1_acc, [c0], identity_map, [True])
-                    for j in range_(0, N, vector_size):
-                        sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                        v_x = transfer_read(
-                            vecTy, sub_row, [c0], identity_map, cst0, [True]
-                        )
-                        v_sq = arith.mulf(v_x, v_x)
-                        # break the mulf->addf chain (aievec rejects addf fed
-                        # directly by mulf); round-trip through a dedicated L1
-                        # scratch buffer.
-                        transfer_write(None, v_sq, l1_sq, [c0], identity_map, [True])
-                        v_sq_rd = transfer_read(
-                            vecTy, l1_sq, [c0], identity_map, cst0, [True]
-                        )
-                        v_sq_f32 = arith.extf(vecTyF32, v_sq_rd)
-                        v_acc = transfer_read(
-                            vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                        )
-                        v_sum = arith.addf(v_acc, v_sq_f32)
-                        transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
-                        yield_([])
+                    ops.load(weight, W[:])
 
-                    # Horizontal reduce in f32
-                    v_final = transfer_read(
-                        vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                    )
-                    total_sum = vector_reduction(f32, "add", v_final)
-                    rms = arith.divf(total_sum, n_f)
+                    for it in air.sequential(rows_per_tile):
+                        r = it + tx * rows_per_tile
+                        ops.load(row, X[r : r + 1, :])
 
-                    # Step 2: rstd = rsqrt(mean + eps) in f32, truncate the
-                    # scalar to bf16 (f32 scalar ops are legal; f32 *vector*
-                    # elementwise is not, so the per-element scaling below stays
-                    # in bf16).
-                    rms_eps = arith.addf(rms, eps_f)
-                    rstd_f32 = math_dialect.rsqrt(rms_eps)
-                    rstd = arith.truncf(xrt_dtype, rstd_f32)
+                        # The square is bf16 and the accumulation f32, which is
+                        # the predecessor's split.
+                        acc[:] = ops.reduce_add(ops.cast(row[:] * row[:], f32))
+                        rstd[:] = ops.cast(ops.rsqrt(acc[:] * (1.0 / N) + EPS), dtype)
 
-                    # Step 3: y = x * rstd * weight (bf16 vector elementwise)
-                    v_rstd = BroadcastOp(vecTy, rstd)
-                    for j in range_(0, N, vector_size):
-                        sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                        sub_w = subview(l1_weight.result, [j], [vector_size], [1])
-                        sub_out = subview(l1_out.result, [j], [vector_size], [1])
-                        v_x = transfer_read(
-                            vecTy, sub_row, [c0], identity_map, cst0, [True]
-                        )
-                        v_w = transfer_read(
-                            vecTy, sub_w, [c0], identity_map, cst0, [True]
-                        )
-                        v_normed = arith.mulf(v_x, v_rstd)
-                        v_weighted = arith.mulf(v_normed, v_w)
-                        transfer_write(
-                            None,
-                            v_weighted,
-                            sub_out,
-                            [c0],
-                            identity_map,
-                            [True],
-                        )
-                        yield_([])
+                        out[:] = row[:] * rstd[:] * weight[:]
 
-                    # DMA: write result row (tile-dependent offset)
-                    dma_memcpy_nd(
-                        l3_out,
-                        l1_out,
-                        dst_offsets=[row, 0],
-                        dst_sizes=[1, N],
-                        dst_strides=[N, 1],
-                    )
+                        ops.store(out, Y[r : r + 1, :])
 
-                    yield_([])
+    return launch
 
-                DeallocOp(l1_row)
-                DeallocOp(l1_out)
-                DeallocOp(l1_weight)
-                DeallocOp(l1_acc)
-                DeallocOp(l1_sq)
 
-        return  # end of herd_x > 1 path
-
-    # Original single-tile path (herd_x == 1)
-    @FuncOp.from_py_func(l3MemrefTy, l3WeightTy, l3MemrefTy)
-    def weighted_rms_norm(arg0, arg1, arg2):
-
-        @herd(name="herd_0", sizes=[1, 1], operands=[arg0, arg1, arg2])
-        def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_weight, l3_out):
-            l1_row = AllocOp(l1RowTy, [], [])
-            l1_out = AllocOp(l1RowTy, [], [])
-            l1_weight = AllocOp(l1RowTy, [], [])
-            l1_acc = AllocOp(l1VecTyF32, [], [])
-            l1_sq = AllocOp(l1SqTy, [], [])
-
-            c0 = arith.ConstantOp.create_index(0)
-            cst0 = arith.ConstantOp(xrt_dtype, 0.0)
-            cst0_f32 = arith.ConstantOp(f32, 0.0)
-            n_f = arith.ConstantOp(f32, float(N))
-            eps_f = arith.ConstantOp(f32, EPS)
-
-            v_zero_f32 = BroadcastOp(vecTyF32, cst0_f32)
-
-            # DMA weight to L1 (shared across all rows)
-            dma_memcpy_nd(l1_weight, l3_weight)
-
-            for row in range_(M):
-                # DMA: load one row from L3 to L1
-                dma_memcpy_nd(
-                    l1_row,
-                    l3_in,
-                    src_offsets=[row, 0],
-                    src_sizes=[1, N],
-                    src_strides=[N, 1],
-                )
-
-                # Step 1: sum of x^2, accumulated in F32 (GPU standard).
-                # Square in bf16 vector (aievec-legal), upcast to f32, and
-                # accumulate into an f32 buffer — the running sum stays f32 so
-                # the reduction over N does not lose low-order bits.
-                transfer_write(None, v_zero_f32, l1_acc, [c0], identity_map, [True])
-                for j in range_(0, N, vector_size):
-                    sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                    v_x = transfer_read(
-                        vecTy, sub_row, [c0], identity_map, cst0, [True]
-                    )
-                    v_sq = arith.mulf(v_x, v_x)
-                    # break the mulf->addf chain (aievec rejects addf fed
-                    # directly by mulf); round-trip through a dedicated L1
-                    # scratch buffer.
-                    transfer_write(None, v_sq, l1_sq, [c0], identity_map, [True])
-                    v_sq_rd = transfer_read(
-                        vecTy, l1_sq, [c0], identity_map, cst0, [True]
-                    )
-                    v_sq_f32 = arith.extf(vecTyF32, v_sq_rd)
-                    v_acc = transfer_read(
-                        vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                    )
-                    v_sum = arith.addf(v_acc, v_sq_f32)
-                    transfer_write(None, v_sum, l1_acc, [c0], identity_map, [True])
-                    yield_([])
-
-                # Horizontal reduce in f32
-                v_final = transfer_read(
-                    vecTyF32, l1_acc, [c0], identity_map, cst0_f32, [True]
-                )
-                total_sum = vector_reduction(f32, "add", v_final)
-                rms = arith.divf(total_sum, n_f)
-
-                # Step 2: rstd = rsqrt(mean + eps) in f32, truncate scalar to bf16.
-                rms_eps = arith.addf(rms, eps_f)
-                rstd_f32 = math_dialect.rsqrt(rms_eps)
-                rstd = arith.truncf(xrt_dtype, rstd_f32)
-
-                # Step 3: y = x * rstd * weight (bf16 vector elementwise)
-                v_rstd = BroadcastOp(vecTy, rstd)
-                for j in range_(0, N, vector_size):
-                    sub_row = subview(l1_row.result, [j], [vector_size], [1])
-                    sub_w = subview(l1_weight.result, [j], [vector_size], [1])
-                    sub_out = subview(l1_out.result, [j], [vector_size], [1])
-                    v_x = transfer_read(
-                        vecTy, sub_row, [c0], identity_map, cst0, [True]
-                    )
-                    v_w = transfer_read(vecTy, sub_w, [c0], identity_map, cst0, [True])
-                    v_normed = arith.mulf(v_x, v_rstd)
-                    v_weighted = arith.mulf(v_normed, v_w)
-                    transfer_write(
-                        None, v_weighted, sub_out, [c0], identity_map, [True]
-                    )
-                    yield_([])
-
-                # DMA: write result row from L1 to L3
-                dma_memcpy_nd(
-                    l3_out,
-                    l1_out,
-                    dst_offsets=[row, 0],
-                    dst_sizes=[1, N],
-                    dst_strides=[N, 1],
-                )
-
-                yield_([])
-
-            DeallocOp(l1_row)
-            DeallocOp(l1_out)
-            DeallocOp(l1_weight)
-            DeallocOp(l1_acc)
-            DeallocOp(l1_sq)
+def build_module(M, N, np_dtype=bfloat16, vector_size=16, herd_x=1, target="npu2"):
+    """The MLIR module. Signature and return type are the llms/ builders' contract."""
+    if np_dtype is not bfloat16:
+        raise NotImplementedError(
+            f"weighted_rms_norm is bf16 only, got {np_dtype!r}: the epilogue "
+            "runs in bf16 vectors because the AIE vector unit does not legalize "
+            "f32 vector elementwise mul."
+        )
+    return build_launch(M, N, bf16, vector_size, herd_x).build(target=target)
 
 
 def rms_norm_reference(x, weight, eps=1e-5):
@@ -345,6 +129,12 @@ if __name__ == "__main__":
         "--N", type=int, default=2048, help="Cols (default: LLAMA emb_dim)"
     )
     parser.add_argument("--vector-size", type=int, default=16)
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="npu2",
+        help="NPU generation to build for (npu2; the epilogue is AIE2P bf16)",
+    )
     parser.add_argument(
         "--herd-x",
         type=int,
@@ -380,7 +170,9 @@ if __name__ == "__main__":
     herd_x = args.herd_x if hasattr(args, "herd_x") else 1
     print(f"Weighted RMSNorm: M={M}, N={N}, herd=[{herd_x},1]")
 
-    mlir_module = build_module(M, N, bfloat16, args.vector_size, herd_x=herd_x)
+    mlir_module = build_module(
+        M, N, bfloat16, args.vector_size, herd_x=herd_x, target=args.target
+    )
     if args.print_module_only:
         print(mlir_module)
         exit(0)

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -433,27 +433,32 @@ def _emit_reduce(dst, expr):
     # from the operand's own leaves: that dimension is what gets collapsed, so
     # it is the one thing the destination cannot tell us.
     leaves = operand.leaves()
-    src_shape = leaves[0].shape
+    # The shape being reduced is the widest leaf's. The others broadcast to it,
+    # exactly as they would in an elementwise assignment: a variance is
+    # `reduce_add((x - mean) * (x - mean))` with mean a per-row scalar, and
+    # numpy stretches it the same way. What the collapsed axis means is fixed by
+    # the widest operand, so a leaf of extent 1 there is a scalar being
+    # stretched and not a different reduction.
+    src_shape = max((leaf.shape for leaf in leaves), key=len)
     for leaf in leaves:
-        if leaf.shape != src_shape:
+        if _broadcast_offset(leaf.shape, src_shape) is None:
             raise ValueError(
                 f"shape mismatch inside a reduction: operands have shapes "
-                f"{src_shape} and {leaf.shape}. Unlike a plain elementwise "
-                f"assignment, a reduction does not broadcast its operands: the "
-                f"innermost extent is the thing being collapsed, so an operand "
-                f"of extent 1 there would change what the reduction means "
-                f"rather than being stretched to fit"
-            )
-        if leaf.dtype is not dtype:
-            raise ValueError(
-                f"dtype mismatch in elementwise assignment: destination is "
-                f"{dtype} but operand is {leaf.dtype}"
+                f"{src_shape} and {leaf.shape}, and the second does not "
+                f"broadcast to the first. Right-aligned, every operand axis "
+                f"must either match or be 1"
             )
         if leaf.value is None:
             raise RuntimeError(
                 "buffer used before allocation; air.alloc() must be called "
                 "inside the herd body that uses it"
             )
+    # Each leaf is checked against the element type of *its own* region, not
+    # against the destination's. A reduction that accumulates in a wider type
+    # than it reads -- `reduce_add(ops.cast(row[:], f32))`, which is how a mean
+    # is computed -- has bf16 leaves under an f32 destination, and comparing
+    # every leaf to the destination refused exactly that.
+    _check_reduce_regions(operand, dtype)
 
     # Two destination spellings are accepted, matching numpy's keepdims:
     #   [.., n] -> [.., 1]  keeps the reduced axis (keepdims=True)
@@ -472,7 +477,14 @@ def _emit_reduce(dst, expr):
             f"(dropping it), but the destination is {tuple(dst.shape)}"
         )
 
-    lanes = src_shape[-1]
+    axis = src_shape[-1]
+    # How many lanes one step reads. The operand's own vector width, exactly as
+    # an elementwise read of the same buffer would use -- so a [.., 768] row
+    # allocated at width 16 is reduced in 48 steps of 16 rather than as one
+    # 768-lane vector, which is what the backend refuses
+    # (`G_EXTRACT_VECTOR_ELT <768 x s16>`). When the axis is one step, this is
+    # the whole-axis read the emitter has always done, unchanged.
+    lanes = _reduce_lanes(max(leaves, key=lambda l: len(l.shape)), axis)
     minor = _minor(len(src_shape))
     regions = {d: _Region(d, lanes, True) for d in _regions_in(operand, dtype, [])}
     kind = (_REDUCE_F if dtype.is_float else _REDUCE_I)[expr.op]
@@ -482,21 +494,120 @@ def _emit_reduce(dst, expr):
     zero = _result(arith.ConstantOp(IndexType.get(), 0))
     bounds = [(0, extent, 1) for extent in src_shape[:-1]]
 
-    # Every leaf here has the operand's shape -- the check above insists on it,
-    # since a reduction's extent is what is being collapsed -- so the read is
-    # always the plain one and broadcasting does not arise.
+    # The same broadcast-aware read the elementwise path uses: a leaf with the
+    # reduced axis's full extent is a vector read, and one of extent 1 there is
+    # a single element splatted across the vector.
     def load(buf, at, region):
+        index = _leaf_index(buf.shape, src_shape, at, zero, _base_of(buf))
+        if buf.shape and buf.shape[-1] == src_shape[-1]:
+            return _result(
+                transfer_read(
+                    region.vec_ty,
+                    buf.value,
+                    index,
+                    _minor(len(buf.shape)),
+                    region.pad,
+                    [True],
+                )
+            )
+        return _result(broadcast(region.vec_ty, _result(memref_load(buf.value, index))))
+
+    if lanes == axis:
+
+        def body(ivs):
+            reads = {}
+            value = _eval(
+                operand, ivs + [zero], regions[dtype], regions, True, load, reads
+            )
+            scalar = _result(reduction(dtype.mlir(), kind, value))
+            memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
+
+        _nest(bounds, body)
+        return
+
+    # Stepped. The partial sums are carried through an L1 scratch vector rather
+    # than an scf.for iter_arg: a loop-carried vector is what LLVM splits into
+    # sub-512-bit pieces the AIE2 backend will not legalize. Every hand-written
+    # kernel this models does the same round-trip.
+    from ._trace import current_herd
+
+    scratch = current_herd().scratch(dtype, lanes)
+    acc_region = regions[dtype]
+    flat = _minor(1)
+
+    def read_acc():
         return _result(
-            transfer_read(region.vec_ty, buf.value, at, minor, region.pad, [True])
+            transfer_read(
+                acc_region.vec_ty, scratch.value, [zero], flat, acc_region.pad, [True]
+            )
         )
 
+    def write_acc(value):
+        transfer_write(None, value, scratch.value, [zero], flat, [True])
+
+    combine = (_FLOAT_OPS if dtype.is_float else _INT_OPS)[expr.op]
+
+    def step_value(ivs, at):
+        return _eval(operand, ivs + [at], regions[dtype], regions, True, load, {})
+
     def body(ivs):
-        reads = {}
-        value = _eval(operand, ivs + [zero], regions[dtype], regions, True, load, reads)
-        scalar = _result(reduction(dtype.mlir(), kind, value))
+        # The first step seeds the accumulator, rather than an identity vector
+        # seeding it and the first step combining into that. An identity is the
+        # obvious thing to write and is wrong for reduce_max: the identity there
+        # is the type's minimum, not the zero _Region carries as its padding
+        # value, so seeding with padding would floor every maximum at 0. Peeling
+        # the first step needs no identity at all and is the same shape for both
+        # reductions.
+        write_acc(step_value(ivs, zero))
+
+        for at in range_(lanes, axis, lanes):
+            write_acc(_result(combine(read_acc(), step_value(ivs, at))))
+            yield_([])
+
+        scalar = _result(reduction(dtype.mlir(), kind, read_acc()))
         memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
 
     _nest(bounds, body)
+
+
+def _reduce_lanes(leaf, axis):
+    """How many lanes one step of a reduction reads.
+
+    The operand's own vector width, which is what an elementwise read of the
+    same buffer uses -- unless the axis is not a whole number of steps, in which
+    case it is read in one go and the backend decides whether that width is
+    legal. A width of 0 selects the scalar path elsewhere; here it means the
+    same thing, so the whole axis is read at once and no stepping applies.
+    """
+    width = getattr(leaf, "vector_width", 0)
+    if not width or width >= axis or axis % width:
+        return axis
+    return width
+
+
+def _check_reduce_regions(node, dtype):
+    """Every leaf's element type against the region it sits in.
+
+    The elementwise path spells this as ``_check_region``, which also checks
+    shapes against the destination. A reduction's operand has a different shape
+    from its destination by construction -- that is what a reduction is -- so
+    only the type half applies here.
+    """
+    if node.kind == "cast":
+        _check_reduce_regions(node.args[0], node.args[0].element_dtype())
+        return
+    if node.kind == "buffer":
+        if dtype is not None and node.buffer.dtype is not dtype:
+            raise ValueError(
+                f"dtype mismatch inside a reduction: this part of the "
+                f"expression is computed in {dtype} but the operand is "
+                f"{node.buffer.dtype}. Reading in one type and accumulating in "
+                f"another is spelled with ops.cast: "
+                f"ops.reduce_add(ops.cast(row[:], {dtype}))"
+            )
+        return
+    for arg in node.args:
+        _check_reduce_regions(arg, dtype)
 
 
 def _minor(rank):

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -144,6 +144,33 @@ def _broadcast_offset(shape, dst_shape):
     return offset
 
 
+def _broadcast_shape(shapes):
+    """numpy's broadcast of several shapes, or None if they do not agree.
+
+    Right-aligned, each axis is the one non-1 extent among the operands, or 1
+    when they are all 1. Unlike ``_broadcast_offset`` this is two-sided -- there
+    is no destination to broadcast *to* yet, which is the situation inside a
+    reduction, where the collapsed shape is whatever the operands together say
+    it is.
+    """
+    rank = max(len(s) for s in shapes)
+    out = []
+    for axis in range(rank):
+        extent = 1
+        for shape in shapes:
+            i = axis - (rank - len(shape))
+            if i < 0:
+                continue
+            e = shape[i]
+            if e == 1:
+                continue
+            if extent not in (1, e):
+                return None
+            extent = e
+        out.append(extent)
+    return tuple(out)
+
+
 def _pins_an_axis(shape, dst_shape):
     """Does reading ``shape`` as ``dst_shape`` pin one of its axes to 0?
 
@@ -433,13 +460,19 @@ def _emit_reduce(dst, expr):
     # from the operand's own leaves: that dimension is what gets collapsed, so
     # it is the one thing the destination cannot tell us.
     leaves = operand.leaves()
-    # The shape being reduced is the widest leaf's. The others broadcast to it,
-    # exactly as they would in an elementwise assignment: a variance is
+    # The shape being reduced is every leaf broadcast together, exactly as an
+    # elementwise assignment broadcasts them: a variance is
     # `reduce_add((x - mean) * (x - mean))` with mean a per-row scalar, and
-    # numpy stretches it the same way. What the collapsed axis means is fixed by
-    # the widest operand, so a leaf of extent 1 there is a scalar being
-    # stretched and not a different reduction.
-    src_shape = max((leaf.shape for leaf in leaves), key=len)
+    # numpy stretches it the same way. Taking the widest leaf instead would be
+    # right only when one leaf already covers every axis -- [tm, 1] with [1, N]
+    # broadcast to [tm, N] and neither operand is that shape.
+    src_shape = _broadcast_shape([leaf.shape for leaf in leaves])
+    if src_shape is None:
+        raise ValueError(
+            f"shape mismatch inside a reduction: operands have shapes "
+            f"{[tuple(leaf.shape) for leaf in leaves]} and do not broadcast "
+            f"together. Right-aligned, every axis must either agree or be 1"
+        )
     for leaf in leaves:
         if _broadcast_offset(leaf.shape, src_shape) is None:
             raise ValueError(
@@ -484,7 +517,11 @@ def _emit_reduce(dst, expr):
     # 768-lane vector, which is what the backend refuses
     # (`G_EXTRACT_VECTOR_ELT <768 x s16>`). When the axis is one step, this is
     # the whole-axis read the emitter has always done, unchanged.
-    lanes = _reduce_lanes(max(leaves, key=lambda l: len(l.shape)), axis)
+    # The step width comes from a leaf that actually spans the reduced axis. A
+    # leaf pinned at extent 1 there is splatted, not stepped, so its own width
+    # says nothing about how far each step should advance.
+    spanning = [leaf for leaf in leaves if leaf.shape and leaf.shape[-1] == axis]
+    lanes = _reduce_lanes(spanning[0], axis) if spanning else axis
     minor = _minor(len(src_shape))
     regions = {d: _Region(d, lanes, True) for d in _regions_in(operand, dtype, [])}
     kind = (_REDUCE_F if dtype.is_float else _REDUCE_I)[expr.op]

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -954,6 +954,10 @@ class HerdContext:
         self._objects = {}
         # The core's position in the herd, bound while the body is traced.
         self._coords = []
+        # Reduction scratch buffers, one per (dtype, lanes), allocated at the
+        # top of the body and reused by every reduction under it. See scratch().
+        self._scratch = {}
+        self._entry_block = None
         if link_with is not None:
             if not isinstance(link_with, str) or not link_with:
                 raise TypeError(
@@ -1073,6 +1077,36 @@ class HerdContext:
     def register_buffer(self, buf):
         self._buffers.append(buf)
 
+    def scratch(self, dtype, lanes):
+        """An L1 vector the emitter accumulates a long reduction through.
+
+        A reduction longer than one vector has to accumulate across steps, and
+        the accumulator cannot be a loop-carried SSA vector: LLVM splits one
+        into sub-512-bit pieces the AIE2 backend will not legalize, which is the
+        failure ``ops.dot`` documents. Every hand-written kernel this models --
+        rms_norm, layer_norm, weighted_rms_norm -- round-trips its partial sums
+        through a small L1 buffer instead, so that is what this provides.
+
+        Allocated **at the top of the herd body**, not where the reduction is
+        written. A reduction normally sits inside a row loop, and allocating
+        there would emit one alloc per trip and leave the dealloc outside the
+        region that dominates it. One buffer per (dtype, lanes) serves every
+        reduction in the body, which is what the predecessors do by hand.
+        """
+        from air.ir import InsertionPoint
+
+        key = (dtype, int(lanes))
+        if key in self._scratch:
+            return self._scratch[key]
+        if self._entry_block is None:
+            raise RuntimeError(
+                "a reduction scratch buffer was requested outside a herd body"
+            )
+        with InsertionPoint.at_block_begin(self._entry_block):
+            buf = alloc([int(lanes)], dtype, scope=self.private(), _hoisted=True)
+        self._scratch[key] = buf
+        return buf
+
     # -- emission -----------------------------------------------------------
 
     def _emit(self, fn):
@@ -1165,6 +1199,10 @@ class HerdContext:
             herd_self._coords = [
                 IndexExpr.leaf(c, f"c{axis}") for axis, c in enumerate(phys_coords)
             ]
+            # Where a reduction's scratch accumulator is allocated, whatever
+            # loop or branch the reduction itself sits in. See scratch().
+            herd_self._entry_block = args[0].owner
+            herd_self._scratch.clear()
 
             def run(strip_ivs):
                 tile_ids = []
@@ -1270,7 +1308,7 @@ def tensor(shape, dtype, name=None):
     return t
 
 
-def alloc(shape, dtype, scope=None, vector=None):
+def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     """Allocate a tile: L1 in a herd body, or L2 in a segment body."""
     from air.ir import IntegerAttr, MemRefType
     from air.dialects.air import MemorySpace
@@ -1322,7 +1360,11 @@ def alloc(shape, dtype, scope=None, vector=None):
             "being traced; allocate inside the body of the scope you are asking "
             "for"
         )
-    if space == "L1" and loop_depth():
+    # _hoisted: the caller has already moved the insertion point to the top of
+    # the herd body, so the alloc does not land in the loop the caller is
+    # standing in and the dominance argument below does not apply. Only
+    # HerdContext.scratch sets it, and it is not part of the public signature.
+    if space == "L1" and loop_depth() and not _hoisted:
         raise NotImplementedError(
             "air.alloc inside an air.sequential or ops.branch body is not "
             "supported: the herd frees its buffers once the body is finished, "

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1104,8 +1104,19 @@ class HerdContext:
             )
         with InsertionPoint.at_block_begin(self._entry_block):
             buf = alloc([int(lanes)], dtype, scope=self.private(), _hoisted=True)
+        # Kept out of _buffers, which is freed at the end of every strip-mined
+        # run. A scratch buffer outlives those: it is allocated once above the
+        # strip loop and reused by every trip, so a dealloc inside the loop
+        # would free it after the first trip and leave the rest reading a dead
+        # buffer. It is freed once, after the strip nest, by _free_scratch.
+        self._buffers.remove(buf)
         self._scratch[key] = buf
         return buf
+
+    def _free_scratch(self):
+        """Dealloc the reduction scratch, once, after the strip-mined runs."""
+        free_buffers(list(self._scratch.values()))
+        self._scratch.clear()
 
     # -- emission -----------------------------------------------------------
 
@@ -1222,9 +1233,13 @@ class HerdContext:
             outer_depth = enter_body()
             try:
                 run_strip_mined(run, herd_self.repeats, range_, yield_)
+                # After the strip nest, not inside it: one alloc above the loop
+                # needs one dealloc below it.
+                herd_self._free_scratch()
             finally:
                 exit_body(outer_depth)
                 herd_self._buffers.clear()
+                herd_self._scratch.clear()
                 for t, v in zip(tensors, saved):
                     t.value = v
                 for b, v in zip(staged, saved_staged):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -1995,17 +1995,17 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: a_reduction_does_not_broadcast_its_operands
-# Everywhere else an extent of 1 is stretched, but the innermost extent of a
-# reduction is the thing being collapsed: stretching it would decide how many
-# terms the sum has, which is the reduction's meaning rather than a fit.
+# CHECK-LABEL: TEST: a_reduction_operand_that_does_not_broadcast
+# A reduction's operands broadcast like any others -- a variance is
+# `reduce_add((x - mean) * (x - mean))` with a per-row scalar mean -- but the
+# rule is still numpy's, so a mismatched extent is refused rather than stretched.
 # CHECK: ValueError: shape mismatch inside a reduction
-# CHECK-SAME: does not broadcast its operands
-@expect(ValueError, "a_reduction_does_not_broadcast_its_operands")
+# CHECK-SAME: does not broadcast to the first
+@expect(ValueError, "a_reduction_operand_that_does_not_broadcast")
 def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([64, 16], bf16, scope=h.private())
-        s = air.alloc([64, 1], bf16, scope=h.private())
+        s = air.alloc([64, 8], bf16, scope=h.private())
         out = air.alloc([64], bf16, scope=h.private())
         out[:] = ops.reduce_add(a[:] * s[:])
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2000,7 +2000,7 @@ def _():
 # `reduce_add((x - mean) * (x - mean))` with a per-row scalar mean -- but the
 # rule is still numpy's, so a mismatched extent is refused rather than stretched.
 # CHECK: ValueError: shape mismatch inside a reduction
-# CHECK-SAME: does not broadcast to the first
+# CHECK-SAME: do not broadcast together
 @expect(ValueError, "a_reduction_operand_that_does_not_broadcast")
 def _():
     def body(h, tx, ty, A, B, C):

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -226,3 +226,48 @@ def a_reduction_operand_may_broadcast():
             scalar=True,
         ).mlir()
     )
+
+
+# CHECK-LABEL: TEST: operands_broadcast_against_each_other
+# [tm, 1] and [1, N] reduce over [tm, N], and neither operand has that shape.
+# Taking the widest leaf instead of broadcasting them together would pick one of
+# the two and then reject the other, so this pins the two-sided rule.
+# CHECK: scf.for
+# CHECK: vector.reduction <add>
+@run
+def operands_broadcast_against_each_other():
+    A = air.tensor([256, 16], bf16)
+    OUT = air.tensor([256], bf16)
+
+    with air.launch(name="bc") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(0, 256, 256), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    col = air.alloc([256, 1], bf16, scope=h.private())
+                    row = air.alloc([1, 16], bf16, scope=h.private())
+                    o = air.alloc([256], bf16, scope=h.private())
+                    air.ops.load(col, A[0:256, 0:1])
+                    o[:] = air.ops.reduce_add(col[:] * row[:])
+                    air.ops.store(o, OUT[0:256])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: the_scratch_outlives_a_strip_mined_run
+# Four tiles onto a two-wide herd, so the body is strip-mined and runs twice.
+# The scratch is allocated once above the strip loop, and its dealloc has to sit
+# once *below* it: freeing it inside the loop would leave the second trip
+# reading a dead buffer. The alloc, the whole strip loop, and only then the
+# dealloc.
+# CHECK: %[[S:.*]] = memref.alloc() : memref<16xbf16, 2 : i32>
+# CHECK: scf.for
+# CHECK: vector.reduction <add>
+# CHECK: memref.dealloc %[[S]] : memref<16xbf16, 2 : i32>
+# CHECK-NOT: memref.dealloc %[[S]]
+@run
+def the_scratch_outlives_a_strip_mined_run():
+    print(build(lambda a: air.ops.reduce_add(a[:]), M=1024, N=32, tile=256).mlir())

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -19,7 +19,16 @@ from air import api as air
 from air.api.types import bf16, i32
 
 
-def build(body, dtype=bf16, M=65536, N=16, tile=256, out_shape=None):
+def build(
+    body,
+    dtype=bf16,
+    M=65536,
+    N=16,
+    tile=256,
+    out_shape=None,
+    vector=None,
+    scalar=False,
+):
     A = air.tensor([M, N], dtype)
     OUT = air.tensor([M], dtype)
 
@@ -33,10 +42,17 @@ def build(body, dtype=bf16, M=65536, N=16, tile=256, out_shape=None):
                 def _(tx):
                     (tm,) = h.tile_sizes
                     row = tx * tm
-                    a = air.alloc([tm, N], dtype, scope=h.private())
+                    kw = {} if vector is None else {"vector": vector}
+                    a = air.alloc([tm, N], dtype, scope=h.private(), **kw)
                     o = air.alloc(out_shape or [tm], dtype, scope=h.private())
                     air.ops.load(a, A[row : row + tm, :])
-                    o[:] = body(a)
+                    if scalar:
+                        # A per-row scalar to broadcast across the reduced
+                        # axis, as a variance's mean is.
+                        m = air.alloc([tm, 1], dtype, scope=h.private())
+                        o[:] = air.ops.reduce_add((a[:] - m[:]) * (a[:] - m[:]))
+                    else:
+                        o[:] = body(a)
                     air.ops.store(o, OUT[row : row + tm])
 
     return launch
@@ -160,13 +176,53 @@ def reduce_over_an_expression_is_a_row_dot_product():
     print(build(lambda a: air.ops.reduce_add(a[:] * a[:])).mlir())
 
 
-# CHECK-LABEL: TEST: a_wider_axis_widens_the_vector_not_the_loop
-# N=32 is what vector_reduce_max defaults to. The reduced extent sets the
-# vector length directly, so a wider axis stays one read and one reduction
-# rather than becoming a loop.
+# CHECK-LABEL: TEST: a_wider_axis_is_read_in_vector_width_steps
+# N=32 is what vector_reduce_max defaults to. A reduction reads the axis the
+# same way an elementwise assignment would: in steps of the buffer's vector
+# width, accumulating the partials through a small L1 buffer.
+#
+# This used to widen the vector instead -- the whole axis in one read, however
+# long it was -- and that does not scale: a [.., 768] row dies in the backend
+# with `unable to legalize G_EXTRACT_VECTOR_ELT <768 x s16>`, which is exactly
+# the shape layer_norm needs. The accumulator is an L1 round-trip and not an
+# scf.for iter_arg because a loop-carried vector is what LLVM splits into
+# sub-512-bit pieces AIE2 will not legalize; every hand-written kernel this
+# models does the same round-trip.
+# CHECK: vector.transfer_read {{.*}} vector<16xbf16>
+# CHECK: scf.for
+# CHECK: arith.addf {{.*}} : vector<16xbf16>
+# CHECK: vector.reduction <add>, {{.*}} : vector<16xbf16> into bf16
+@run
+def a_wider_axis_is_read_in_vector_width_steps():
+    print(build(lambda a: air.ops.reduce_add(a[:]), N=32).mlir())
+
+
+# CHECK-LABEL: TEST: a_width_as_wide_as_the_axis_is_one_read
+# The width is the caller's knob, and it means here what it means everywhere
+# else: allocate the operand at the axis's own width and the reduction is a
+# single read and a single vector.reduction, with no loop and no accumulator.
 # CHECK: vector.transfer_read {{.*}} vector<32xbf16>
 # CHECK: vector.reduction <add>, {{.*}} : vector<32xbf16> into bf16
 # CHECK-NOT: vector.reduction
 @run
-def a_wider_axis_widens_the_vector_not_the_loop():
-    print(build(lambda a: air.ops.reduce_add(a[:]), N=32).mlir())
+def a_width_as_wide_as_the_axis_is_one_read():
+    print(build(lambda a: air.ops.reduce_add(a[:]), N=32, vector=32).mlir())
+
+
+# CHECK-LABEL: TEST: a_reduction_operand_may_broadcast
+# The variance idiom: sum((x - mean)^2) with mean a per-row scalar. numpy
+# stretches mean across the reduced axis and so does this -- the widest operand
+# fixes what the axis means, and a [.., 1] operand beside it is a scalar being
+# splatted into it, which is the memref.load + vector.broadcast below.
+# CHECK: memref.load
+# CHECK: vector.broadcast
+# CHECK: vector.reduction <add>
+@run
+def a_reduction_operand_may_broadcast():
+    print(
+        build(
+            lambda a: air.ops.reduce_add(a[:] * a[:]),
+            N=16,
+            scalar=True,
+        ).mlir()
+    )


### PR DESCRIPTION
Two more examples onto `air.api`, and the reduction change they both needed.

## `[air.api] Reduce a long axis in vector-width steps`

`ops.reduce_add` read the whole axis as one vector, however long it was. That
does not scale: a `[.., 768]` row — layer_norm's shape — dies in the backend
with `unable to legalize G_EXTRACT_VECTOR_ELT <768 x s16>`.

I measured 384, 512, 1024 and 2048 as well, and they all pass, so **there is no
clean cap to key on** and the fix is deliberately not a threshold. A reduction
now reads its axis the way an elementwise assignment reads it: in steps of the
operand's own vector width. The width becomes the caller's knob and means the
same thing everywhere — allocate at the axis's own width and it is still a
single read and a single `vector.reduction`.

Three details that are not obvious and each cost a wrong first attempt:

* **The partials go through an L1 scratch, not an `scf.for` iter_arg.** A
  loop-carried vector is what LLVM splits into sub-512-bit pieces AIE2 will not
  legalize — the failure `ops.dot` documents. Every hand-written kernel this
  models does the same round-trip.
* **The scratch is allocated at the top of the herd body**, not where the
  reduction is written. A reduction sits inside the row loop, so allocating
  there would emit one alloc per trip and leave the dealloc outside the region
  dominating it. One buffer per `(dtype, lanes)` serves every reduction in the
  body.
* **The first step seeds the accumulator.** Seeding with an identity vector is
  the obvious thing to write and is wrong for `reduce_max`: the identity there
  is the type's minimum, not the zero `_Region` carries as its padding value, so
  seeding with padding would floor every maximum at 0. Peeling the first step
  needs no identity at all and is the same shape for both reductions.

Two related fixes the same examples forced:

* **A cast at the top of a reduce operand.** Leaves were checked against the
  destination's element type, so `reduce_add(ops.cast(row[:], f32))` — how a
  mean is computed — was refused for having bf16 leaves under an f32
  destination. Each leaf is now checked against its own region.
* **Reduce operands broadcast.** A variance is
  `reduce_add((x - mean) * (x - mean))` with a per-row scalar mean, and numpy
  stretches it. The widest operand fixes what the collapsed axis means and the
  others broadcast to it, through the same broadcast-aware read the elementwise
  path already uses. The `a_reduction_does_not_broadcast_its_operands` error
  case becomes `a_reduction_operand_that_does_not_broadcast` — the rule is now
  numpy's, so a genuinely mismatched extent is still refused.

## Conversions

**`layer_norm`** — both reductions in f32, epilogue in bf16 vectors, with
`ops.cast` marking the boundary. weight and bias share one flat `[2N]` buffer
(AIE per-tile routing caps at ~3 L3 streams and in+weight+bias+out is four), and
the halves are read straight out of it as `param[0:N]` and `param[N : 2 * N]` —
ordinary elementwise operands since #1922. The predecessor carved them out with
`memref.subview` plus a hand-added `arith.addi(j, N)`, and built the
`vector.broadcast` of the scalar mean and rstd by hand across three loop nests.

**`weighted_rms_norm`** — same shape at N=2048. Two things the predecessor
needed and this does not: the L1 scratch that broke the `mulf`→`addf` def-use
chain aievec rejects (the multiply here feeds a `vector.reduction`, not an add),
and the hand-built broadcast of `rstd`.

**Both return the module, not the launch**, unlike the other converted examples.
smolvla's vision builders do `str(build_layer_norm(...))` and
`rms_gemms_rope_bfp16_multi` imports `build_module` from weighted_rms_norm, so
the signature and the return type are a contract. `build_launch` returns the
launch and `build_module` wraps it; `.build()` emits a bare `module {}` with no
attributes, which is what `@module_builder` emitted. Both imports were
re-verified after the conversion.

## Gating

**The sweep blast radius is four files, and that is the whole story of this PR:**
the two conversions (which cannot build on the old emitter at all), plus the two
pre-existing reductions whose axis exceeds their buffer's width —
`vector_reduce_max` (N=32) and `rms_norm` (N=64). Everything else is
byte-identical across 67 converted examples.

* **`vector_reduce_max` has an npu1 lit and PASSES on hardware.** That gates the
  stepped path *and* the `reduce_max` seeding on real silicon, and it is the
  only hardware gate any of this work can get — everything else here is
  npu2-only and the dev box is Phoenix.
* `rms_norm` recompiles for npu2 with an `air.insts.bin` still byte-identical to
  its own predecessor, so the stepping did not disturb it.
* `layer_norm` (M=64, N=768) and `weighted_rms_norm` (M=64, N=2048) both compile
  for npu2 with byte-identical `air.insts.bin` against their predecessors, same
  cores, flows, locks, shim allocations and tiles. Both declare more buffers —
  ping-pong plus the reduction scratch.
* 29/29 api lits, `check-air-python` 42, `check-air-mlir` 530 + 7 XFAIL.

**Not gated locally: AIE2P.** Neither norm runs on npu1, so the hx370 runner is
the first thing that will execute them.
