### PR TITLE
[air.api] ops.argmax, plus silu_and_mul, gelu_and_mul and mnist_fc/argmax

### DIFF
--- a/programming_examples/gelu_and_mul/gelu_and_mul.py
+++ b/programming_examples/gelu_and_mul/gelu_and_mul.py
@@ -1,233 +1,139 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""GELU (tanh approximation) + elementwise multiply, on air.api.
 
-"""GELU + Elementwise Multiply Kernel
-
-Element-wise GELU (tanh approximation) and multiply:
     output[i] = GELU(gate[i]) * up[i]
-    GELU(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
 
-This is the `gelu_pytorch_tanh` GLU activation Gemma3 uses where Llama uses
-SiLU, so this example is the GELU twin of `silu_and_mul/` -- same dataflow,
-same herd sizing, same arg layout, only the external microkernel differs
-(gelu_and_mul.cc -> gelu_and_mul.o).
+The activation stays in C++: `air.extern("gelu_and_mul_bf16", link_with="gelu_and_mul.o")`
+declares the microkernel and stamps link_with on both the declaration and the
+herd, so the body here is pure dataflow. This is the twin of `silu_and_mul/` --
+same dataflow, same herd sizing, same argument layout, only the microkernel
+differs.
 
 Each tile uses 3 independent shim DMAs (gate in, up in, out) and NPU2 has 8
-shim DMA channels, so the herd is capped at `herd_x * herd_y <= 8` tiles; the
-best config is `herd_x=8, herd_y=1` (full chip width, 8 tiles in one row).
+shim DMA channels, so the herd is capped at `herd_x * herd_y <= 8` tiles; 8x1
+and 2x4 place, 8x2 / 4x4 / 8x4 do not. The best config is herd_x=8, herd_y=1,
+the full chip width.
+
+**Two entry points over one body.** `build_module` takes a flat [n] interface
+and `build_module_2d` takes [rows, cols], which is what the FFN GEMMs produce.
+The predecessor wrote the second as a separate builder that inserted three
+`memref.collapse_shape` ops at launch scope; here the 2-D tensor region is
+reshaped to [n] where it is sliced, so one body serves both and the collapse is
+part of the access pattern rather than an op.
+
+Both return the **module**, not the launch, and keep their signatures: the
+llms/ FFN builders import them and stitch the result by positional operand
+index, so the argument order (gate, up, out) and the `@gelu_and_mul_bf16` symbol
+are a contract.
+
+The tile offset is ordinary Python arithmetic on the coordinates,
+
+    loop_iv + (tx * herd_y + ty) * tile_n
+
+where the predecessor built the same expression as a three-symbol AffineMap.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.memref import collapse_shape as memref_collapse_shape
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i32
 from air.backend.xrt import XRTBackend
-
-range_ = for_
-
-
-def _tile_offset_map(herd_y, tile_n):
-    """offset = loop_iv + (tx * herd_y + ty) * tile_n."""
-    return AffineMap.get(
-        0,
-        3,
-        [
-            AffineExpr.get_add(
-                AffineSymbolExpr.get(0),
-                AffineExpr.get_mul(
-                    AffineExpr.get_add(
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(1),
-                            AffineConstantExpr.get(herd_y),
-                        ),
-                        AffineSymbolExpr.get(2),
-                    ),
-                    AffineConstantExpr.get(tile_n),
-                ),
-            )
-        ],
-    )
+from air.backend.xrt_runner import XRTRunner
 
 
-@module_builder
-def build_module(n, tile_n, np_dtype_in, herd_x=8, herd_y=None):
-    xrt_dtype = type_mapper(np_dtype_in)
-    if herd_y is None:
-        herd_y = 1  # NPU2: herd_x*herd_y <= 8 tiles (3 shim DMAs/tile, 8 shim channels)
-    total_tiles = herd_x * herd_y
-    assert (
-        n % (tile_n * total_tiles) == 0
-    ), f"n ({n}) must be divisible by tile_n * total_tiles ({tile_n * total_tiles})"
+def build_launch(shape, tile_n, dtype=bf16, herd_x=8, herd_y=1, name=None):
+    """One body for both interfaces; `shape` is [n] or [rows, cols].
 
-    l3MemrefTy = MemRefType.get([n], xrt_dtype)
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-
-    gelu_mul_func = FuncOp(
-        "gelu_and_mul_bf16",
-        ([l1MemrefTy, l1MemrefTy, l1MemrefTy, T.i32()], []),
-        visibility="private",
-    )
-    gelu_mul_func.attributes["link_with"] = StringAttr.get("gelu_and_mul.o")
-    gelu_mul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-
-    @FuncOp.from_py_func(l3MemrefTy, l3MemrefTy, l3MemrefTy)
-    def gelu_and_mul(arg0, arg1, arg2):
-        # arg0 = gate [n], arg1 = up [n], arg2 = output [n]
-
-        @launch(operands=[arg0, arg1, arg2])
-        def gelu_mul_launch(l_gate, l_up, l_out):
-
-            @segment(name="gelu_mul_seg", operands=[l_gate, l_up, l_out])
-            def gelu_mul_seg(s_gate, s_up, s_out):
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_gate, s_up, s_out],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_gate, l3_up, l3_out):
-                    l1_gate = AllocOp(l1MemrefTy, [], [])
-                    l1_up = AllocOp(l1MemrefTy, [], [])
-                    l1_out = AllocOp(l1MemrefTy, [], [])
-
-                    tile_n_i32 = ConstantOp(T.i32(), tile_n)
-                    offset_map = _tile_offset_map(herd_y, tile_n)
-
-                    for loop_iv in range_(0, n, tile_n * total_tiles):
-                        offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
-
-                        dma_memcpy_nd(
-                            l1_gate,
-                            l3_gate,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            l1_up,
-                            l3_up,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-
-                        CallOp(gelu_mul_func, [l1_gate, l1_up, l1_out, tile_n_i32])
-
-                        dma_memcpy_nd(
-                            l3_out,
-                            l1_out,
-                            dst_offsets=[offset],
-                            dst_sizes=[tile_n],
-                            dst_strides=[1],
-                        )
-                        yield_([])
-
-                    DeallocOp(l1_gate)
-                    DeallocOp(l1_up)
-                    DeallocOp(l1_out)
-
-                herd_body.attributes["link_with"] = StringAttr.get("gelu_and_mul.o")
-
-
-@module_builder
-def build_module_2d(rows, cols, tile_n, np_dtype_in, herd_x=8, herd_y=1):
-    """Build GeGLU module with 2D memref inputs: memref<rows x cols x bf16>.
-
-    Same computation as build_module but accepts 2D memrefs for compatibility
-    with GEMM outputs. Collapses 2D -> 1D at the segment level before passing
-    to the herd. This is the entry point the Gemma3 prefill's `gelu_mul` ELF
-    uses (gate/up come straight out of the FFN GEMMs as [seq, hidden]).
+    `name` is the emitted func's symbol. The two entry points keep the two names
+    the predecessor emitted, because the llms/ stitchers slice these modules by
+    symbol as well as by operand position.
     """
-    n = rows * cols
-    xrt_dtype = type_mapper(np_dtype_in)
+    n = 1
+    for extent in shape:
+        n *= int(extent)
     total_tiles = herd_x * herd_y
-    assert n % (tile_n * total_tiles) == 0
+    if n % (tile_n * total_tiles):
+        raise ValueError(
+            f"n ({n}) must be divisible by tile_n * herd tiles "
+            f"({tile_n * total_tiles}): every tile takes the same number of "
+            "elements, and there is no remainder path."
+        )
+    if total_tiles > 8:
+        raise ValueError(
+            f"herd_x * herd_y is {total_tiles}: each tile needs 3 shim DMAs "
+            "and NPU2 has 8 shim channels, so more than 8 tiles does not place."
+        )
 
-    l3_2d_ty = MemRefType.get([rows, cols], xrt_dtype)
-    l3_1d_ty = MemRefType.get([n], xrt_dtype)
-    l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1TileTy = MemRefType.get(
-        shape=[tile_n], element_type=xrt_dtype, memory_space=l1_space
+    gate = air.tensor(list(shape), dtype)
+    up = air.tensor(list(shape), dtype)
+    out = air.tensor(list(shape), dtype)
+
+    def flat(t):
+        """The tensor as one [n] run, whatever rank it was declared at.
+
+        A rank-2 region reshaped to [n] is the access pattern the predecessor
+        built with memref.collapse_shape -- the elements are already contiguous,
+        so this renames the walk rather than moving anything.
+        """
+        whole = t[tuple(slice(0, int(e)) for e in shape)]
+        return whole if len(shape) == 1 else whole.reshape(n)
+
+    activation = air.extern(
+        "gelu_and_mul_bf16", link_with="gelu_and_mul.o", scalars=[i32]
     )
 
-    gelu_mul_func = FuncOp(
-        "gelu_and_mul_bf16",
-        ([l1TileTy, l1TileTy, l1TileTy, T.i32()], []),
-        visibility="private",
-    )
-    gelu_mul_func.attributes["link_with"] = StringAttr.get("gelu_and_mul.o")
-    gelu_mul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name=name or "gelu_and_mul") as launch:
 
-    @FuncOp.from_py_func(l3_2d_ty, l3_2d_ty, l3_2d_ty)
-    def gelu_and_mul_2d(arg0, arg1, arg2):
+        @launch.body
+        def _():
+            with air.segment(name="gelu_mul_seg") as seg:
 
-        @launch(operands=[arg0, arg1, arg2])
-        def gelu_mul_launch(l_gate, l_up, l_out):
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_x), range(herd_y)],
+                        name="herd_0",
+                        shape=(herd_x, herd_y),
+                    ) as herd:
 
-            gate_1d = memref_collapse_shape(l3_1d_ty, l_gate, [[0, 1]])
-            up_1d = memref_collapse_shape(l3_1d_ty, l_up, [[0, 1]])
-            out_1d = memref_collapse_shape(l3_1d_ty, l_out, [[0, 1]])
+                        @herd.body
+                        def _(tx, ty):
+                            l1_gate = air.alloc([tile_n], dtype, scope=herd.private())
+                            l1_up = air.alloc([tile_n], dtype, scope=herd.private())
+                            l1_out = air.alloc([tile_n], dtype, scope=herd.private())
 
-            @segment(name="gelu_mul_seg", operands=[gate_1d, up_1d, out_1d])
-            def gelu_mul_seg(s_gate, s_up, s_out):
+                            for iv in air.sequential(0, n, tile_n * total_tiles):
+                                lo = iv + (tx * herd_y + ty) * tile_n
 
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_gate, s_up, s_out],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_gate, l3_up, l3_out):
-                    l1_gate = AllocOp(l1TileTy, [], [])
-                    l1_up = AllocOp(l1TileTy, [], [])
-                    l1_out = AllocOp(l1TileTy, [], [])
+                                ops.load(l1_gate, flat(gate)[lo : lo + tile_n])
+                                ops.load(l1_up, flat(up)[lo : lo + tile_n])
 
-                    tile_n_i32 = ConstantOp(T.i32(), tile_n)
-                    offset_map = _tile_offset_map(herd_y, tile_n)
+                                activation(l1_gate, l1_up, l1_out, tile_n)
 
-                    for loop_iv in range_(0, n, tile_n * total_tiles):
-                        offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
+                                ops.store(l1_out, flat(out)[lo : lo + tile_n])
 
-                        dma_memcpy_nd(
-                            l1_gate,
-                            l3_gate,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            l1_up,
-                            l3_up,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        CallOp(gelu_mul_func, [l1_gate, l1_up, l1_out, tile_n_i32])
-                        dma_memcpy_nd(
-                            l3_out,
-                            l1_out,
-                            dst_offsets=[offset],
-                            dst_sizes=[tile_n],
-                            dst_strides=[1],
-                        )
-                        yield_([])
+    return launch
 
-                    DeallocOp(l1_gate)
-                    DeallocOp(l1_up)
-                    DeallocOp(l1_out)
 
-                herd_body.attributes["link_with"] = StringAttr.get("gelu_and_mul.o")
+def build_module(n, tile_n, np_dtype_in=bfloat16, herd_x=8, herd_y=None, target="npu2"):
+    """Flat [n] interface. Signature is the llms/ builders' contract."""
+    return build_launch(
+        [n], tile_n, bf16, herd_x, herd_y or 1, name="gelu_and_mul"
+    ).build(target=target)
+
+
+def build_module_2d(
+    rows, cols, tile_n, np_dtype_in=bfloat16, herd_x=8, herd_y=1, target="npu2"
+):
+    """[rows, cols] interface, for gate/up straight out of the FFN GEMMs."""
+    return build_launch(
+        [rows, cols], tile_n, bf16, herd_x, herd_y, name="gelu_and_mul_2d"
+    ).build(target=target)
 
 
 def gelu_reference(x):

--- a/programming_examples/mnist_fc/argmax/run.py
+++ b/programming_examples/mnist_fc/argmax/run.py
@@ -2,170 +2,92 @@
 #
 # Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
 # SPDX-License-Identifier: MIT
-#
-# Row-wise argmax: out[row] = argmax_col(A[row, col])
-# For each row, find the column index of the maximum element.
-# Input: [ne1, ne0] f32 (ne0 contiguous), Output: [ne1] i32.
-#
-# GGML layout: [ne0, ne1] where ne0 is contiguous.
-# GGML op: argmax [10, 500] -> [500, 1]
-#   ne0=10 (classes, contiguous, reduced), ne1=500 (batch, rows, tiled).
-# In numpy row-major: input is (ne1=500, ne0=10), output is (500,) i32.
-# Argmax is over ne0 (axis=1, columns) for each row.
+"""Row-wise argmax on air.api: out[row] = argmax_col(A[row, col]).
+
+One line of compute:
+
+    out[:] = ops.argmax(tile[:, 0:ne0])
+
+`ops.argmax` answers "which one" where `ops.reduce_max` answers "how big", so
+its destination is an integer buffer whatever the operand's type is, and ties go
+to the lowest index (a strict `>`), which is numpy's rule and the classifier
+convention. It is the one reduction that is a scalar loop rather than a
+`vector.reduction`: the running maximum and the index that produced it have to
+travel together, and no vector reduction carries an index. The pair rides in the
+loop's `iter_args`, which is fine because they are scalars -- it is a
+loop-carried *vector* that AIE2 will not legalize.
+
+The `[:, 0:ne0]` region is how the padding is handled. Columns are padded to a
+multiple of 16 for DMA alignment, and reducing the padded tail would let a zero
+outrank a genuinely negative logit; the predecessor kept a separate `ne0_actual`
+bound on its scalar loop, and here it is a slice of the operand, which is what
+numpy would write.
+
+MNIST context: GGML argmax [10, 500] -> [500, 1]. ne0=10 (classes, contiguous,
+reduced), ne1=500 (batch, rows, tiled across the herd). In numpy row-major the
+input is (500, 10) and the output (500,) i32.
+"""
 
 import argparse
 import math
+
 import numpy as np
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, subview, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import f32, i32
 from air.backend.xrt import XRTBackend
-from air.extras import types as extrasT
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
 
-range_ = for_
 
+def build_module(num_rows, num_cols, tile_rows, herd_n, ne0_actual, target="npu2"):
+    """Row-wise argmax over the first `ne0_actual` of `num_cols` padded columns."""
+    if num_rows % (tile_rows * herd_n):
+        raise ValueError(
+            f"padded rows ({num_rows}) must be a multiple of tile_rows * herd_n "
+            f"({tile_rows * herd_n}); the caller pads."
+        )
+    if not 0 < ne0_actual <= num_cols:
+        raise ValueError(
+            f"ne0_actual ({ne0_actual}) must be in 1..num_cols ({num_cols})"
+        )
 
-@module_builder
-def build_module(num_rows, num_cols, tile_rows, herd_n, ne0_actual):
-    """Build row-wise argmax module.
+    A = air.tensor([num_rows, num_cols], f32)
+    OUT = air.tensor([num_rows], i32)
 
-    num_rows = ne1 (padded, tiled across herd).
-    num_cols = ne0 (padded, contiguous, reduced per row).
-    ne0_actual = actual number of columns to reduce over.
-    """
-    assert num_rows % (tile_rows * herd_n) == 0
+    with air.launch(
+        [range(1), range(num_rows // (tile_rows * herd_n))], name="argmax"
+    ) as launch:
 
-    xrt_dtype_f32 = type_mapper(np.float32)
-    xrt_dtype_i32 = IntegerType.get_signless(32)
-    index_type = IndexType.get()
-    l1_mem_space = IntegerAttr.get(extrasT.i32(), MemorySpace.L1)
+        @launch.body
+        def _(lx, ly):
+            with air.segment(name="argmax_seg") as seg:
 
-    # L3 MemRefTypes
-    # Input: (ne1, ne0) = (num_rows, num_cols)
-    memrefTyA = MemRefType.get([num_rows, num_cols], xrt_dtype_f32)
-    # Output: (ne1,) = (num_rows,) i32
-    memrefTyOut = MemRefType.get([num_rows], xrt_dtype_i32)
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(1), range(herd_n)], name="herd_0", shape=(1, herd_n)
+                    ) as herd:
 
-    # L1: load tile_rows rows, each with num_cols columns
-    l1TileTy = MemRefType.get(
-        shape=[tile_rows, num_cols],
-        element_type=xrt_dtype_f32,
-        memory_space=l1_mem_space,
-    )
-    l1OutTy = MemRefType.get(
-        shape=[tile_rows], element_type=xrt_dtype_i32, memory_space=l1_mem_space
-    )
-
-    @FuncOp.from_py_func(memrefTyA, memrefTyOut)
-    def argmax(arg_a, arg_out):
-        launch_size = [1, num_rows // tile_rows // herd_n]
-
-        @launch(operands=[arg_a, arg_out], sizes=launch_size)
-        def launch_body(
-            launch_ivx, launch_ivy, launch_sizex, launch_sizey, l3_a, l3_out
-        ):
-
-            @segment(
-                name="argmax_seg",
-                operands=[launch_ivy, l3_a, l3_out],
-            )
-            def segment_body(launch_ivy_s, l3_a_s, l3_out_s):
-                c_tile_rows_herd_n = ConstantOp(
-                    IntegerAttr.get(IndexType.get(), tile_rows * herd_n), None
-                )
-                launch_offset_row = arith.MulIOp(launch_ivy_s, c_tile_rows_herd_n)
-
-                @herd(
-                    name="herd_0",
-                    sizes=[1, herd_n],
-                    operands=[
-                        launch_offset_row,
-                        l3_a_s,
-                        l3_out_s,
-                    ],
-                )
-                def herd_body(tx, ty, _sx, _sy, _loff_row, _l3_a, _l3_out):
-                    l1_tile = AllocOp(l1TileTy, [], [])
-                    l1_out = AllocOp(l1OutTy, [], [])
-
-                    # row_offset = launch_offset_row + ty * tile_rows
-                    row_offset_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(1),
-                                    AffineConstantExpr.get(tile_rows),
-                                ),
+                        @herd.body
+                        def _(tx, ty):
+                            tile = air.alloc(
+                                [tile_rows, num_cols], f32, scope=herd.private()
                             )
-                        ],
-                    )
-                    row_offset = affine_apply(row_offset_map, [_loff_row, ty])
+                            out = air.alloc([tile_rows], i32, scope=herd.private())
 
-                    # DMA: load tile_rows rows, all num_cols columns
-                    dma_memcpy_nd(
-                        l1_tile,
-                        _l3_a,
-                        src_offsets=[row_offset, 0],
-                        src_sizes=[tile_rows, num_cols],
-                        src_strides=[num_cols, 1],
-                    )
+                            row = (ly * herd_n + ty) * tile_rows
+                            ops.load(tile, A[row : row + tile_rows, :])
 
-                    # Scalar argmax per row over ne0_actual columns
-                    c0 = ConstantOp(index_type, 0)
-                    c1 = ConstantOp(index_type, 1)
-                    c_tile_rows_cst = ConstantOp(index_type, tile_rows)
-                    c_ne0_actual = ConstantOp(index_type, ne0_actual)
-                    neg_inf = arith.ConstantOp(
-                        xrt_dtype_f32,
-                        FloatAttr.get(xrt_dtype_f32, float("-inf")),
-                    )
-                    c0_i32 = arith.ConstantOp(xrt_dtype_i32, 0)
+                            # Only the real columns: the padded tail is zero, and
+                            # a zero would outrank a negative logit.
+                            out[:] = ops.argmax(tile[:, 0:ne0_actual])
 
-                    for row in range_(c0, c_tile_rows_cst, c1):
-                        # Argmax over ne0_actual columns for this row
-                        for col, (current_max_val, current_max_idx), results in range_(
-                            c0,
-                            c_ne0_actual,
-                            c1,
-                            iter_args=[neg_inf, c0_i32],
-                        ):
-                            val = load(l1_tile, [row, col])
-                            cmp = arith.CmpFOp(
-                                arith.CmpFPredicate.OGT,
-                                val,
-                                current_max_val,
-                            )
-                            new_max_val = arith.SelectOp(cmp, val, current_max_val)
-                            col_i32 = arith.IndexCastOp(xrt_dtype_i32, col)
-                            new_max_idx = arith.SelectOp(cmp, col_i32, current_max_idx)
-                            yield_([new_max_val, new_max_idx])
+                            ops.store(out, OUT[row : row + tile_rows])
 
-                        store(results[1], l1_out, [row])
-                        yield_([])
-
-                    # DMA output back to L3
-                    dma_memcpy_nd(
-                        _l3_out,
-                        l1_out,
-                        dst_offsets=[row_offset],
-                        dst_sizes=[tile_rows],
-                        dst_strides=[1],
-                    )
-
-                    DeallocOp(l1_tile)
-                    DeallocOp(l1_out)
+    return launch.build(target=target)
 
 
 if __name__ == "__main__":

--- a/programming_examples/silu_and_mul/silu_and_mul.py
+++ b/programming_examples/silu_and_mul/silu_and_mul.py
@@ -1,249 +1,139 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""SiLU + elementwise multiply, on air.api.
 
-"""SiLU + Elementwise Multiply Kernel
+    output[i] = SiLU(gate[i]) * up[i]
 
-Element-wise SiLU and multiply: output[i] = SiLU(gate[i]) * up[i]
-where SiLU(x) = x * sigmoid(x)
+The activation stays in C++: `air.extern("silu_and_mul_bf16", link_with="silu_and_mul.o")`
+declares the microkernel and stamps link_with on both the declaration and the
+herd, so the body here is pure dataflow. This is the twin of `gelu_and_mul/` --
+same dataflow, same herd sizing, same argument layout, only the microkernel
+differs.
 
-Uses an external C++ kernel (silu_and_mul.cc) compiled with Peano.
-The kernel streams the data in tiles across a configurable `herd_x x herd_y`
-AIE grid (`--herd-x` / `--herd-y`). Each tile uses 3 independent shim DMAs
-(gate in, up in, out), and NPU2 has 8 shim DMA channels, so the herd is
-capped at `herd_x * herd_y <= 8` tiles (more exhausts the shim channels;
-e.g. 8x1 and 2x4 place, but 8x2 / 4x4 / 8x4 do not). The best config is
-`herd_x=8, herd_y=1` (full chip width, 8 tiles in one row).
+Each tile uses 3 independent shim DMAs (gate in, up in, out) and NPU2 has 8
+shim DMA channels, so the herd is capped at `herd_x * herd_y <= 8` tiles; 8x1
+and 2x4 place, 8x2 / 4x4 / 8x4 do not. The best config is herd_x=8, herd_y=1,
+the full chip width.
+
+**Two entry points over one body.** `build_module` takes a flat [n] interface
+and `build_module_2d` takes [rows, cols], which is what the FFN GEMMs produce.
+The predecessor wrote the second as a separate builder that inserted three
+`memref.collapse_shape` ops at launch scope; here the 2-D tensor region is
+reshaped to [n] where it is sliced, so one body serves both and the collapse is
+part of the access pattern rather than an op.
+
+Both return the **module**, not the launch, and keep their signatures: the
+llms/ FFN builders import them and stitch the result by positional operand
+index, so the argument order (gate, up, out) and the `@silu_and_mul_bf16` symbol
+are a contract.
+
+The tile offset is ordinary Python arithmetic on the coordinates,
+
+    loop_iv + (tx * herd_y + ty) * tile_n
+
+where the predecessor built the same expression as a three-symbol AffineMap.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.memref import collapse_shape as memref_collapse_shape
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i32
 from air.backend.xrt import XRTBackend
-
-range_ = for_
-
-
-@module_builder
-def build_module(n, tile_n, np_dtype_in, herd_x=8, herd_y=None):
-    xrt_dtype = type_mapper(np_dtype_in)
-    if herd_y is None:
-        herd_y = 1  # NPU2: herd_x*herd_y <= 8 tiles (3 shim DMAs/tile, 8 shim channels)
-    total_tiles = herd_x * herd_y
-    assert (
-        n % (tile_n * total_tiles) == 0
-    ), f"n ({n}) must be divisible by tile_n * total_tiles ({tile_n * total_tiles})"
-
-    # L3 types
-    l3MemrefTy = MemRefType.get([n], xrt_dtype)
-
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1MemrefTy = MemRefType.get(
-        shape=[tile_n], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-
-    # External kernel declaration
-    silu_mul_func = FuncOp(
-        "silu_and_mul_bf16",
-        ([l1MemrefTy, l1MemrefTy, l1MemrefTy, T.i32()], []),
-        visibility="private",
-    )
-    silu_mul_func.attributes["link_with"] = StringAttr.get("silu_and_mul.o")
-    silu_mul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-
-    @FuncOp.from_py_func(l3MemrefTy, l3MemrefTy, l3MemrefTy)
-    def silu_and_mul(arg0, arg1, arg2):
-        # arg0 = gate [n], arg1 = up [n], arg2 = output [n]
-
-        @launch(operands=[arg0, arg1, arg2])
-        def silu_mul_launch(l_gate, l_up, l_out):
-
-            @segment(name="silu_mul_seg", operands=[l_gate, l_up, l_out])
-            def silu_mul_seg(s_gate, s_up, s_out):
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_gate, s_up, s_out],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_gate, l3_up, l3_out):
-                    l1_gate = AllocOp(l1MemrefTy, [], [])
-                    l1_up = AllocOp(l1MemrefTy, [], [])
-                    l1_out = AllocOp(l1MemrefTy, [], [])
-
-                    tile_n_i32 = ConstantOp(T.i32(), tile_n)
-
-                    for loop_iv in range_(0, n, tile_n * total_tiles):
-                        # Compute linear tile index: tx * herd_y + ty
-                        offset_map = AffineMap.get(
-                            0,
-                            3,
-                            [
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(0),
-                                    AffineExpr.get_mul(
-                                        AffineExpr.get_add(
-                                            AffineExpr.get_mul(
-                                                AffineSymbolExpr.get(1),
-                                                AffineConstantExpr.get(herd_y),
-                                            ),
-                                            AffineSymbolExpr.get(2),
-                                        ),
-                                        AffineConstantExpr.get(tile_n),
-                                    ),
-                                )
-                            ],
-                        )
-                        offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
-
-                        dma_memcpy_nd(
-                            l1_gate,
-                            l3_gate,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            l1_up,
-                            l3_up,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-
-                        CallOp(silu_mul_func, [l1_gate, l1_up, l1_out, tile_n_i32])
-
-                        dma_memcpy_nd(
-                            l3_out,
-                            l1_out,
-                            dst_offsets=[offset],
-                            dst_sizes=[tile_n],
-                            dst_strides=[1],
-                        )
-                        yield_([])
-
-                    DeallocOp(l1_gate)
-                    DeallocOp(l1_up)
-                    DeallocOp(l1_out)
-
-                herd_body.attributes["link_with"] = StringAttr.get("silu_and_mul.o")
+from air.backend.xrt_runner import XRTRunner
 
 
-@module_builder
-def build_module_2d(rows, cols, tile_n, np_dtype_in, herd_x=8, herd_y=1):
-    """Build SwiGLU module with 2D memref inputs: memref<rows x cols x bf16>.
+def build_launch(shape, tile_n, dtype=bf16, herd_x=8, herd_y=1, name=None):
+    """One body for both interfaces; `shape` is [n] or [rows, cols].
 
-    Same computation as build_module but accepts 2D memrefs for compatibility
-    with GEMM outputs. Collapses 2D → 1D at the segment level before
-    passing to the herd.
+    `name` is the emitted func's symbol. The two entry points keep the two names
+    the predecessor emitted, because the llms/ stitchers slice these modules by
+    symbol as well as by operand position.
     """
-    n = rows * cols
-    xrt_dtype = type_mapper(np_dtype_in)
+    n = 1
+    for extent in shape:
+        n *= int(extent)
     total_tiles = herd_x * herd_y
-    assert n % (tile_n * total_tiles) == 0
+    if n % (tile_n * total_tiles):
+        raise ValueError(
+            f"n ({n}) must be divisible by tile_n * herd tiles "
+            f"({tile_n * total_tiles}): every tile takes the same number of "
+            "elements, and there is no remainder path."
+        )
+    if total_tiles > 8:
+        raise ValueError(
+            f"herd_x * herd_y is {total_tiles}: each tile needs 3 shim DMAs "
+            "and NPU2 has 8 shim channels, so more than 8 tiles does not place."
+        )
 
-    l3_2d_ty = MemRefType.get([rows, cols], xrt_dtype)
-    l3_1d_ty = MemRefType.get([n], xrt_dtype)
-    l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1TileTy = MemRefType.get(
-        shape=[tile_n], element_type=xrt_dtype, memory_space=l1_space
+    gate = air.tensor(list(shape), dtype)
+    up = air.tensor(list(shape), dtype)
+    out = air.tensor(list(shape), dtype)
+
+    def flat(t):
+        """The tensor as one [n] run, whatever rank it was declared at.
+
+        A rank-2 region reshaped to [n] is the access pattern the predecessor
+        built with memref.collapse_shape -- the elements are already contiguous,
+        so this renames the walk rather than moving anything.
+        """
+        whole = t[tuple(slice(0, int(e)) for e in shape)]
+        return whole if len(shape) == 1 else whole.reshape(n)
+
+    activation = air.extern(
+        "silu_and_mul_bf16", link_with="silu_and_mul.o", scalars=[i32]
     )
 
-    silu_mul_func = FuncOp(
-        "silu_and_mul_bf16",
-        ([l1TileTy, l1TileTy, l1TileTy, T.i32()], []),
-        visibility="private",
-    )
-    silu_mul_func.attributes["link_with"] = StringAttr.get("silu_and_mul.o")
-    silu_mul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name=name or "silu_and_mul") as launch:
 
-    @FuncOp.from_py_func(l3_2d_ty, l3_2d_ty, l3_2d_ty)
-    def silu_and_mul_2d(arg0, arg1, arg2):
+        @launch.body
+        def _():
+            with air.segment(name="silu_mul_seg") as seg:
 
-        @launch(operands=[arg0, arg1, arg2])
-        def silu_mul_launch(l_gate, l_up, l_out):
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_x), range(herd_y)],
+                        name="herd_0",
+                        shape=(herd_x, herd_y),
+                    ) as herd:
 
-            # Collapse 2D → 1D at segment level
-            gate_1d = memref_collapse_shape(l3_1d_ty, l_gate, [[0, 1]])
-            up_1d = memref_collapse_shape(l3_1d_ty, l_up, [[0, 1]])
-            out_1d = memref_collapse_shape(l3_1d_ty, l_out, [[0, 1]])
+                        @herd.body
+                        def _(tx, ty):
+                            l1_gate = air.alloc([tile_n], dtype, scope=herd.private())
+                            l1_up = air.alloc([tile_n], dtype, scope=herd.private())
+                            l1_out = air.alloc([tile_n], dtype, scope=herd.private())
 
-            @segment(name="silu_mul_seg", operands=[gate_1d, up_1d, out_1d])
-            def silu_mul_seg(s_gate, s_up, s_out):
+                            for iv in air.sequential(0, n, tile_n * total_tiles):
+                                lo = iv + (tx * herd_y + ty) * tile_n
 
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_gate, s_up, s_out],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_gate, l3_up, l3_out):
-                    l1_gate = AllocOp(l1TileTy, [], [])
-                    l1_up = AllocOp(l1TileTy, [], [])
-                    l1_out = AllocOp(l1TileTy, [], [])
+                                ops.load(l1_gate, flat(gate)[lo : lo + tile_n])
+                                ops.load(l1_up, flat(up)[lo : lo + tile_n])
 
-                    tile_n_i32 = ConstantOp(T.i32(), tile_n)
+                                activation(l1_gate, l1_up, l1_out, tile_n)
 
-                    for loop_iv in range_(0, n, tile_n * total_tiles):
-                        offset_map = AffineMap.get(
-                            0,
-                            3,
-                            [
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(0),
-                                    AffineExpr.get_mul(
-                                        AffineExpr.get_add(
-                                            AffineExpr.get_mul(
-                                                AffineSymbolExpr.get(1),
-                                                AffineConstantExpr.get(herd_y),
-                                            ),
-                                            AffineSymbolExpr.get(2),
-                                        ),
-                                        AffineConstantExpr.get(tile_n),
-                                    ),
-                                )
-                            ],
-                        )
-                        offset = affine_apply(offset_map, [loop_iv, _tx, _ty])
+                                ops.store(l1_out, flat(out)[lo : lo + tile_n])
 
-                        dma_memcpy_nd(
-                            l1_gate,
-                            l3_gate,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            l1_up,
-                            l3_up,
-                            src_offsets=[offset],
-                            src_sizes=[tile_n],
-                            src_strides=[1],
-                        )
-                        CallOp(silu_mul_func, [l1_gate, l1_up, l1_out, tile_n_i32])
-                        dma_memcpy_nd(
-                            l3_out,
-                            l1_out,
-                            dst_offsets=[offset],
-                            dst_sizes=[tile_n],
-                            dst_strides=[1],
-                        )
-                        yield_([])
+    return launch
 
-                    DeallocOp(l1_gate)
-                    DeallocOp(l1_up)
-                    DeallocOp(l1_out)
 
-                herd_body.attributes["link_with"] = StringAttr.get("silu_and_mul.o")
+def build_module(n, tile_n, np_dtype_in=bfloat16, herd_x=8, herd_y=None, target="npu2"):
+    """Flat [n] interface. Signature is the llms/ builders' contract."""
+    return build_launch(
+        [n], tile_n, bf16, herd_x, herd_y or 1, name="silu_and_mul"
+    ).build(target=target)
+
+
+def build_module_2d(
+    rows, cols, tile_n, np_dtype_in=bfloat16, herd_x=8, herd_y=1, target="npu2"
+):
+    """[rows, cols] interface, for gate/up straight out of the FFN GEMMs."""
+    return build_launch(
+        [rows, cols], tile_n, bf16, herd_x, herd_y, name="silu_and_mul_2d"
+    ).build(target=target)
 
 
 def silu_reference(x):

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -340,7 +340,10 @@ def emit_elementwise(dst, expr):
     # destination's, so it is dispatched before the elementwise shape check
     # rather than being taught to it.
     if expr.kind == "reduce":
-        _emit_reduce(dst, expr)
+        if expr.op == "argmax":
+            _emit_argmax(dst, expr)
+        else:
+            _emit_reduce(dst, expr)
         return
 
     # A bare scalar on the right-hand side is a fill (`acc[:] = 0.0`), which is
@@ -620,6 +623,91 @@ def _reduce_lanes(leaf, axis):
     if not width or width >= axis or axis % width:
         return axis
     return width
+
+
+def _emit_argmax(dst, expr):
+    """``dst[:] = ops.argmax(x[:])`` -- the index of the innermost maximum.
+
+    A scalar loop, not a ``vector.reduction``: the running maximum and the index
+    that produced it have to travel together, and no vector reduction carries an
+    index. They ride in the loop's ``iter_args``, which is safe because they are
+    scalars -- it is a loop-carried *vector* AIE2 refuses.
+
+    The first element seeds the pair rather than an identity, for the same
+    reason the stepped reduction peels its first step: the identity for a
+    maximum is the type's minimum, and there is no need to name it.
+    """
+    from air.dialects.arith import CmpFOp, CmpIOp, IndexCastOp, SelectOp
+
+    operand = expr.args[0]
+    index_dtype = dst.dtype
+    require_signless(index_dtype, "the destination of air.api.ops.argmax")
+    if index_dtype.is_float:
+        raise TypeError(
+            f"air.api.ops.argmax writes an index, so its destination has to be "
+            f"an integer buffer; this one is {index_dtype}. Use "
+            "air.api.ops.reduce_max for the value itself."
+        )
+
+    leaves = operand.leaves()
+    src_shape = _broadcast_shape([leaf.shape for leaf in leaves])
+    if src_shape is None:
+        raise ValueError(
+            f"shape mismatch inside a reduction: operands have shapes "
+            f"{[tuple(leaf.shape) for leaf in leaves]} and do not broadcast "
+            f"together"
+        )
+    value_dtype = leaves[0].dtype
+    _check_reduce_regions(operand, value_dtype)
+
+    kept = tuple(list(src_shape[:-1]) + [1])
+    dropped = tuple(src_shape[:-1])
+    keepdims = tuple(dst.shape) == kept
+    if not keepdims and tuple(dst.shape) != dropped:
+        raise ValueError(
+            f"shape mismatch in a reduction: reducing {src_shape} along its "
+            f"innermost axis gives {kept} (keeping the axis) or {dropped} "
+            f"(dropping it), but the destination is {tuple(dst.shape)}"
+        )
+
+    axis = src_shape[-1]
+    regions = {d: _Region(d, 0, False) for d in _regions_in(operand, value_dtype, [])}
+    zero = _result(arith.ConstantOp(IndexType.get(), 0))
+    bounds = [(0, extent, 1) for extent in src_shape[:-1]]
+
+    def load(buf, ivs, region):
+        return _result(
+            memref_load(
+                buf.value, _leaf_index(buf.shape, src_shape, ivs, zero, _base_of(buf))
+            )
+        )
+
+    def at(ivs, column):
+        return _eval(
+            operand, ivs + [column], regions[value_dtype], regions, False, load, {}
+        )
+
+    greater = CmpFOp if value_dtype.is_float else CmpIOp
+    predicate = _CMP_F["gt"] if value_dtype.is_float else _CMP_I["gt"]
+
+    def body(ivs):
+        best = at(ivs, zero)
+        first = _result(arith.ConstantOp(index_dtype.mlir(), 0))
+        for column, (running, chosen), results in range_(
+            1, axis, 1, iter_args=[best, first]
+        ):
+            candidate = at(ivs, column)
+            wins = _result(greater(predicate, candidate, running))
+            as_index = _result(IndexCastOp(index_dtype.mlir(), column))
+            yield_(
+                [
+                    _result(SelectOp(wins, candidate, running)),
+                    _result(SelectOp(wins, as_index, chosen)),
+                ]
+            )
+        memref_store(results[1], dst.value, ivs + [zero] if keepdims else ivs)
+
+    _nest(bounds, body)
 
 
 def _check_reduce_regions(node, dtype):

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -657,7 +657,16 @@ def _emit_argmax(dst, expr):
             f"{[tuple(leaf.shape) for leaf in leaves]} and do not broadcast "
             f"together"
         )
-    value_dtype = leaves[0].dtype
+    # The type the comparison happens in, which is the operand's *result* type
+    # and not its leaves': `argmax(ops.cast(row[:], f32))` compares in f32 while
+    # its leaves are bf16, and taking the leaf type would both evaluate the
+    # walk in the wrong region and compare at the wrong width.
+    value_dtype = operand.element_dtype() or leaves[0].dtype
+    # Checked here for the same reason the other reductions check their
+    # destination: without it an f16 or unsigned operand reaches arith.cmpf /
+    # arith.cmpi, which have no form for either.
+    require_computable(value_dtype, "the operand of air.api.ops.argmax")
+    require_signless(value_dtype, "the operand of air.api.ops.argmax")
     _check_reduce_regions(operand, value_dtype)
 
     kept = tuple(list(src_shape[:-1]) + [1])

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -59,6 +59,7 @@ __all__ = [
     "fma",
     "reduce_add",
     "reduce_max",
+    "argmax",
     "relu",
     "tanh",
     "exp",
@@ -773,7 +774,9 @@ def fma(a, b, c):
 
 
 def _reduce(name, key, x):
-    if not isinstance(x, (Buffer, BufferExpr)):
+    from ._value import BufferSlice
+
+    if not isinstance(x, (Buffer, BufferExpr, BufferSlice)):
         raise TypeError(
             f"air.api.ops.{name} expects a buffer slice, got {type(x).__name__}"
         )
@@ -842,6 +845,30 @@ def reduce_max(x):
     side.
     """
     return _reduce("reduce_max", "max", x)
+
+
+def argmax(x):
+    """The *index* of the maximum along the innermost axis.
+
+        out[:] = air.api.ops.argmax(logits[:])      # out is an integer buffer
+
+    The odd one out among the reductions: `reduce_max` answers "how big" and
+    this answers "which one", so its destination is an integer buffer whatever
+    the operand's type is. Ties go to the lowest index, which is numpy's rule
+    and the classifier convention -- the comparison is a strict `>`, so a later
+    equal element does not displace an earlier one.
+
+    Reduce only part of an axis by handing it a region: `argmax(a[:, 0:k])`
+    looks at the first k columns, which is what a padded classifier output
+    needs.
+
+    Unlike the other reductions this is a scalar loop rather than a
+    `vector.reduction`: the running maximum and its index have to travel
+    together, and there is no vector reduction that carries an index. The pair
+    rides in the loop's `iter_args`, which is fine precisely because they are
+    scalars -- it is a loop-carried *vector* that AIE2 will not legalize.
+    """
+    return _reduce("argmax", "argmax", x)
 
 
 def _unary(name, x):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2219,3 +2219,19 @@ def _():
         out[:] = gu[tx, :] * 2.0
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: argmax_into_a_float_buffer
+# argmax answers "which one", not "how big", so its destination is an index.
+# Writing it into a float buffer is the reduce_max/argmax mix-up, and the
+# message names the other one.
+# CHECK: TypeError: air.api.ops.argmax writes an index
+# CHECK-SAME: air.api.ops.reduce_max for the value itself
+@expect(TypeError, "argmax_into_a_float_buffer")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], bf16, scope=h.private())
+        out = air.alloc([64], bf16, scope=h.private())
+        out[:] = ops.argmax(a[:])
+
+    _trace(body)

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2235,3 +2235,19 @@ def _():
         out[:] = ops.argmax(a[:])
 
     _trace(body)
+
+
+# CHECK-LABEL: TEST: argmax_of_an_f16_operand
+# The comparison is an arith.cmpf on the operand's type, and there is no f16
+# form. Checked on the operand rather than only the destination, which is an
+# index and says nothing about what is being compared.
+# CHECK: NotImplementedError: the operand of air.api.ops.argmax is not supported
+# CHECK-SAME: air.api.f16
+@expect(NotImplementedError, "argmax_of_an_f16_operand")
+def _():
+    def body(h, tx, ty, A, B, C):
+        a = air.alloc([64, 16], f16, scope=h.private())
+        out = air.alloc([64], i32, scope=h.private())
+        out[:] = ops.argmax(a[:])
+
+    _trace(body)

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -320,3 +320,34 @@ def argmax_carries_the_index_in_iter_args():
 @run
 def argmax_over_part_of_an_axis():
     print(build_argmax(cols=16, reduced=10))
+
+
+# CHECK-LABEL: TEST: argmax_compares_in_the_cast_type
+# `argmax(cast(x, f32))` compares in f32 even though its leaves are bf16. The
+# type the comparison happens in is the operand's *result* type, not its
+# leaves': reading it off a leaf would evaluate the walk in the wrong region and
+# compare at the wrong width, silently.
+# CHECK: arith.extf
+# CHECK: arith.cmpf ogt, %{{.*}}, %{{.*}} : f32
+@run
+def argmax_compares_in_the_cast_type():
+    from air.api.types import f32, i32
+
+    A = air.tensor([32, 16], bf16)
+    OUT = air.tensor([32], i32)
+
+    with air.launch(name="amc") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([32, 16], bf16, scope=h.private())
+                    o = air.alloc([32], i32, scope=h.private())
+                    air.ops.load(a, A[0:32, :])
+                    o[:] = air.ops.argmax(air.ops.cast(a[:], f32))
+                    air.ops.store(o, OUT[0:32])
+
+    print(launch.mlir())

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -271,3 +271,52 @@ def operands_broadcast_against_each_other():
 @run
 def the_scratch_outlives_a_strip_mined_run():
     print(build(lambda a: air.ops.reduce_add(a[:]), M=1024, N=32, tile=256).mlir())
+
+
+def build_argmax(cols, reduced):
+    from air.api.types import f32, i32
+
+    A = air.tensor([32, cols], f32)
+    OUT = air.tensor([32], i32)
+
+    with air.launch(name="am") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([32, cols], f32, scope=h.private())
+                    o = air.alloc([32], i32, scope=h.private())
+                    air.ops.load(a, A[0:32, :])
+                    o[:] = air.ops.argmax(a[:, 0:reduced])
+                    air.ops.store(o, OUT[0:32])
+
+    return launch.mlir()
+
+
+# CHECK-LABEL: TEST: argmax_carries_the_index_in_iter_args
+# The one reduction that is a scalar loop: the running maximum and the index
+# that produced it travel together, and no vector reduction carries an index.
+# Scalars in iter_args are fine -- it is a loop-carried *vector* AIE2 refuses.
+# The comparison is a strict > so ties keep the lowest index, as numpy does.
+# CHECK: scf.for {{.*}} iter_args
+# CHECK: arith.cmpf ogt
+# CHECK: arith.index_cast
+# CHECK: arith.select
+# CHECK: arith.select
+@run
+def argmax_carries_the_index_in_iter_args():
+    print(build_argmax(cols=16, reduced=16))
+
+
+# CHECK-LABEL: TEST: argmax_over_part_of_an_axis
+# A padded classifier output: 10 real columns in a 16-wide tile. Reducing the
+# padded tail would let a zero outrank a negative logit, so the operand is a
+# region and the loop stops at 10.
+# CHECK: %[[N:.*]] = arith.constant 10 : index
+# CHECK: scf.for %{{.*}} to %[[N]] step
+@run
+def argmax_over_part_of_an_axis():
+    print(build_argmax(cols=16, reduced=10))


### PR DESCRIPTION
Three more examples onto `air.api`, and one new op.

Two of these were on my own blocked list, and both entries turned out to be
misreadings rather than missing capability. That is most of what this PR is.

## `silu_and_mul` and `gelu_and_mul`

The twins: same dataflow, same herd sizing, same argument layout, only the
microkernel differs. The activation stays in C++ via `air.extern`, so both
bodies are pure dataflow — which is what the examples are for.

**One body serves both entry points.** The predecessor wrote `build_module_2d`
as a separate builder that inserted three `memref.collapse_shape` ops at launch
scope. A rank-2 *tensor region* already reshapes to `[n]`, so the collapse
becomes part of the access pattern and the two builders now differ only in the
shape they declare and the symbol they emit.

**The contract is pinned, deliberately.** `silu_and_mul` is imported by four
`llms/` FFN builders — `o_ffn_int4_multi`, `o_ffn_bfp16_multi`, qwen3 and qwen25
prefill — which stitch its module **by positional operand index and by symbol**.
Those consumers are nightly-only and invisible to PR CI, which is the class of
breakage that shipped in #1832. So this pins the argument order `(gate, up,
out)`, the `@silu_and_mul_bf16` extern symbol, and **both entry function names**
(`silu_and_mul` / `silu_and_mul_2d`). My first attempt silently renamed the
second one, which is exactly the failure that would have gone green here and red
in the nightly.

## `ops.argmax` and `mnist_fc/argmax`

`reduce_max` answers "how big"; there was no way to ask "which one".

I had recorded argmax as blocked on "`air.sequential` has no `iter_args`". That
was the wrong framing: only a loop-carried **vector** fails to legalize on AIE2.
The predecessor carries two *scalars* in `scf.for` iter_args and works, which
was the evidence already sitting in the file. `ops.argmax` emits exactly that.

It is the odd one out among the reductions and the code says so: its destination
is an integer buffer whatever the operand's type is, and it lowers to a scalar
loop rather than a `vector.reduction`, because the running maximum and the index
that produced it have to travel together and no vector reduction carries an
index. Ties go to the lowest index — a strict `>`, numpy's rule and the
classifier convention. The first element seeds the pair rather than an identity,
as the stepped reduction does, so no type minimum has to be named.

`argmax(a[:, 0:k])` reduces part of an axis, which is how the example excludes
its padded tail: columns are padded to a multiple of 16 for DMA alignment, and
reducing the padding would let a zero outrank a genuinely negative logit. The
predecessor carried a separate `ne0_actual` bound on its scalar loop. This
needed `_reduce` to accept a `BufferSlice` — its type check predated #1922 and
rejected one with the message "expects a buffer slice, got BufferSlice".

`mnist_fc/argmax` completes the pair; `mnist_fc/relu` converted in #1922.

## Gating

Every example here is npu2-only and the dev box is Phoenix, so the gate is
compiling **both** versions for npu2 and diffing the generated AIE IR and
instruction stream. **All five configurations produce a byte-identical
`air.insts.bin`:**

| config | result |
|---|---|
| `silu_and_mul` 1-D | byte-identical `air.insts.bin` |
| `silu_and_mul` 2-D | byte-identical `air.insts.bin` |
| `gelu_and_mul` 1-D | byte-identical `air.insts.bin` |
| `gelu_and_mul` 2-D | byte-identical `air.insts.bin` |
| `mnist_fc/argmax` | byte-identical `air.insts.bin`, identical structure (8 buffers, 4 cores, 8 dma_bds, 8 flows, 16 locks, 8 shim allocations, 14 tiles) |

Plus: 29/29 api lits, `check-air-python` 42, `check-air-mlir` 530 + 7 XFAIL, and
the byte-identical IR sweep over all 67 previously-converted examples unchanged
(70 converted now).

`vector_reduce_max` still **PASSES on npu1 hardware** — it is the only example
in reach of this box's silicon and it covers the reduction machinery these
changes sit on.

**Not gated locally: AIE2P.** None of the three new conversions run on npu1, so
the hx370 runner is the first thing that will execute them.
