### PR TITLE
[programming_examples] air.api: conv1d_depthwise and dual_herd_packet_switch

### DIFF
--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -25,6 +25,7 @@ scalarise.
 """
 
 import argparse
+import time
 
 import numpy as np
 from ml_dtypes import bfloat16

--- a/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
+++ b/programming_examples/channel_examples/dual_herd_packet_switch/dual_herd_packet_switch.py
@@ -1,186 +1,94 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Two herds sharing the shim, on air.api.
 
-# Dual-herd example demonstrating automatic packet-switched shim DMA sharing.
-#
-# Two 8x1 herds coexist on the same NPU2 device:
-#   - add_herd: element-wise add (C_add = A0 + B0)
-#   - mul_herd: element-wise mul (C_mul = A1 * B1)
-#
-# Data movement is expressed via air.dma_memcpy_nd (no explicit channels).
-# The compiler automatically:
-#   1. Converts DMAs to channels (air-dma-to-channel)
-#   2. Detects that 4 input channels exceed the 2-per-column shim DMA limit
-#   3. Upgrades input channels to channel_type="npu_dma_packet" for packet-switched
-#      time-multiplexing of shim DMA MM2S ports
+One segment holding two independent herds -- an element-wise add and an
+element-wise multiply, on separate inputs and separate outputs:
+
+    c_add = a0 + b0        add_herd
+    c_mul = a1 * b1        mul_herd
+
+Six L3 tensors and two herds means more shim DMA traffic than there are
+dedicated channels, which is the point: `air-dma-to-channel` infers the channels
+from the transfers and the shim shares them, packet-switched. Nothing here
+declares a channel, and nothing needs to -- the two herds are written exactly as
+they would be alone, and the sharing is the compiler's business.
+
+Each core takes one tile: `tx * tile_size` is ordinary Python arithmetic on the
+coordinate where the predecessor built an `arith.muli` per transfer, three times
+per herd.
+
+The compute is `tile_c[:] = tile_a[:] + tile_b[:]` and `* tile_b[:]`, replacing
+`linalg.elemwise_binary` with an explicit BinaryFn and a cast attribute. Same
+values, and the DSL vectorises rather than handing the pipeline a named op to
+scalarise.
+"""
 
 import argparse
-import time
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16
 from air.backend.xrt import XRTBackend
-import air.dialects.linalg.opdsl.lang as linalg_lang
+from air.backend.xrt_runner import XRTRunner
 
 HERD_SIZE = 8
 INOUT_DATATYPE = bfloat16
 
 
-# elemwise_binary is deprecated from upstream; define as custom linalg op.
-@linalg_lang.linalg_structured_op
-def elemwise_binary(
-    lhs=linalg_lang.TensorDef(linalg_lang.TV.T1),
-    rhs=linalg_lang.TensorDef(linalg_lang.TV.T2),
-    O=linalg_lang.TensorDef(linalg_lang.U, output=True),
-    fun=linalg_lang.BinaryFnAttrDef(default=linalg_lang.BinaryFn.add),
-    cast=linalg_lang.TypeFnAttrDef(default=linalg_lang.TypeFn.cast_signed),
-):
-    O[None] = fun(cast(linalg_lang.U, lhs[None]), cast(linalg_lang.U, rhs[None]))
+def build_module(tile_size, dtype=bf16):
+    total = tile_size * HERD_SIZE
 
+    # Inputs first, then outputs: the XRT invocation passes them in that order.
+    a0 = air.tensor([total], dtype)
+    b0 = air.tensor([total], dtype)
+    a1 = air.tensor([total], dtype)
+    b1 = air.tensor([total], dtype)
+    c_add = air.tensor([total], dtype)
+    c_mul = air.tensor([total], dtype)
 
-def build_module(tile_size):
-    total_size = tile_size * HERD_SIZE
+    with air.launch(name="dual_herd_elemwise") as launch:
 
-    @module_builder
-    def build():
-        xrt_dtype = type_mapper(INOUT_DATATYPE)
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
 
-        # L3 memref types
-        l3_type = MemRefType.get([total_size], xrt_dtype)
+                @seg.body
+                def _():
 
-        # L1 tile memref types
-        mem_space_l1 = IntegerAttr.get(T.i32(), MemorySpace.L1)
-        l1_type = MemRefType.get(
-            shape=[tile_size],
-            element_type=xrt_dtype,
-            memory_space=mem_space_l1,
-        )
+                    def elementwise(name, x, y, out, combine):
+                        """One herd: every core does one tile of one operator."""
+                        with air.herd(
+                            [range(HERD_SIZE)], name=name, shape=(HERD_SIZE,)
+                        ) as herd:
 
-        # No explicit channel declarations — air-dma-to-channel will infer
-        # them from the dma_memcpy_nd ops inside the herds.
+                            @herd.body
+                            def _(tx):
+                                tile_x = air.alloc(
+                                    [tile_size], dtype, scope=herd.private()
+                                )
+                                tile_y = air.alloc(
+                                    [tile_size], dtype, scope=herd.private()
+                                )
+                                tile_out = air.alloc(
+                                    [tile_size], dtype, scope=herd.private()
+                                )
 
-        @FuncOp.from_py_func(l3_type, l3_type, l3_type, l3_type, l3_type, l3_type)
-        def dual_herd_elemwise(a0, b0, a1, b1, c_add, c_mul):
+                                lo = tx * tile_size
+                                ops.load(tile_x, x[lo : lo + tile_size])
+                                ops.load(tile_y, y[lo : lo + tile_size])
 
-            @launch(operands=[a0, b0, a1, b1, c_add, c_mul])
-            def launch_body(a0_, b0_, a1_, b1_, c_add_, c_mul_):
+                                tile_out[:] = combine(tile_x[:], tile_y[:])
 
-                @segment(name="seg", operands=[a0_, b0_, a1_, b1_, c_add_, c_mul_])
-                def segment_body(a0_s, b0_s, a1_s, b1_s, c_add_s, c_mul_s):
+                                ops.store(tile_out, out[lo : lo + tile_size])
 
-                    # --- Herd 0: element-wise add ---
-                    @herd(
-                        name="add_herd",
-                        sizes=[HERD_SIZE, 1],
-                        operands=[a0_s, b0_s, c_add_s],
-                    )
-                    def add_herd_body(tx, ty, sx, sy, a0_h, b0_h, c_add_h):
-                        tile_a = AllocOp(l1_type, [], [])
-                        tile_b = AllocOp(l1_type, [], [])
-                        tile_c = AllocOp(l1_type, [], [])
+                    elementwise("add_herd", a0, b0, c_add, lambda p, q: p + q)
+                    elementwise("mul_herd", a1, b1, c_mul, lambda p, q: p * q)
 
-                        # L3 -> L1 via dma_memcpy_nd
-                        dma_memcpy_nd(
-                            tile_a,
-                            a0_h,
-                            src_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            src_sizes=[tile_size],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            tile_b,
-                            b0_h,
-                            src_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            src_sizes=[tile_size],
-                            src_strides=[1],
-                        )
-
-                        elemwise_binary(
-                            tile_a,
-                            tile_b,
-                            outs=[tile_c],
-                            fun=linalg_lang.BinaryFn.add,
-                            cast=linalg_lang.TypeFn.cast_signed,
-                        )
-
-                        # L1 -> L3 via dma_memcpy_nd
-                        dma_memcpy_nd(
-                            c_add_h,
-                            tile_c,
-                            dst_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            dst_sizes=[tile_size],
-                            dst_strides=[1],
-                        )
-
-                        DeallocOp(tile_a)
-                        DeallocOp(tile_b)
-                        DeallocOp(tile_c)
-
-                    # --- Herd 1: element-wise mul ---
-                    @herd(
-                        name="mul_herd",
-                        sizes=[HERD_SIZE, 1],
-                        operands=[a1_s, b1_s, c_mul_s],
-                    )
-                    def mul_herd_body(tx, ty, sx, sy, a1_h, b1_h, c_mul_h):
-                        tile_a = AllocOp(l1_type, [], [])
-                        tile_b = AllocOp(l1_type, [], [])
-                        tile_c = AllocOp(l1_type, [], [])
-
-                        dma_memcpy_nd(
-                            tile_a,
-                            a1_h,
-                            src_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            src_sizes=[tile_size],
-                            src_strides=[1],
-                        )
-                        dma_memcpy_nd(
-                            tile_b,
-                            b1_h,
-                            src_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            src_sizes=[tile_size],
-                            src_strides=[1],
-                        )
-
-                        elemwise_binary(
-                            tile_a,
-                            tile_b,
-                            outs=[tile_c],
-                            fun=linalg_lang.BinaryFn.mul,
-                            cast=linalg_lang.TypeFn.cast_signed,
-                        )
-
-                        dma_memcpy_nd(
-                            c_mul_h,
-                            tile_c,
-                            dst_offsets=[
-                                arith.MulIOp(tx, arith.ConstantOp(T.index(), tile_size))
-                            ],
-                            dst_sizes=[tile_size],
-                            dst_strides=[1],
-                        )
-
-                        DeallocOp(tile_a)
-                        DeallocOp(tile_b)
-                        DeallocOp(tile_c)
-
-    return build()
+    return launch
 
 
 if __name__ == "__main__":
@@ -216,12 +124,21 @@ if __name__ == "__main__":
         default=1,
         help="Number of measurement iterations (default: 1)",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
     tile_size = args.tile_size
     total_size = tile_size * HERD_SIZE
 
-    mlir_module = build_module(tile_size)
+    launch = build_module(tile_size)
+    # build() resolves --target auto, so it runs before launch.target is read.
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -244,6 +161,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             output_format=args.output_format,
             instance_name="dual_herd_elemwise",
+            target_device=launch.target,
         )
 
         compiled_module = backend.compile(mlir_module)
@@ -304,6 +222,7 @@ if __name__ == "__main__":
             verbose=args.verbose,
             output_format=args.output_format,
             instance_name="dual_herd_elemwise",
+            target_device=launch.target,
         )
         exit(
             runner.run_test(

--- a/programming_examples/conv1d_depthwise/conv1d_depthwise.py
+++ b/programming_examples/conv1d_depthwise/conv1d_depthwise.py
@@ -1,62 +1,50 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Causal depthwise 1-D convolution, on air.api.
 
-"""Causal Depthwise 1-D Convolution Kernel (kernel size 3)
+    y[s, c] = sum over t of x_pad[s + t, c] * w[t, c]        t = 0, 1, 2
 
-The convolution inside LFM2's `Lfm2ShortConv` operator:
+Depthwise, so every channel has its own 3-tap filter and there is no reduction
+across channels. The convolution itself stays in C++:
+`air.extern("conv1d_depthwise_bf16", link_with="conv1d_depthwise.o")` declares
+the microkernel and stamps link_with on both the declaration and the herd, so
+the body here is dataflow only.
 
-    y[t, c] = w[0, c]*x[t+0, c] + w[1, c]*x[t+1, c] + w[2, c]*x[t+2, c]
+The input is **pre-padded** by HALO rows on the host, so `x_pad[row]` is already
+the oldest sample feeding `y[row]`: no negative indexing and no masking, just a
+read of `tile_s + HALO` rows where the output is `tile_s`. That overlap is the
+whole reason the two slices differ.
 
-Depthwise — each channel has its own 3 taps, no cross-channel mixing — so the
-channel axis is the vectorization axis and is contiguous in memory.
+Weights are sequence-independent, so this tile's channel slice is loaded once
+above the sequence loop rather than per trip.
 
-**Causality is expressed by pre-padding, not by masking.** The input `x` has
-`seq + 2` rows and the output `y` has `seq`: row `t` of `x` is the sample at
-original position `t - 2`, so `x` row `t` is the oldest sample feeding `y[t]`
-and pairs with tap 0 (oldest-first, matching `nn.Conv1d` cross-correlation
-over a left-padded input). The two leading rows are the **conv state**: zeros
-at the start of a sequence (prefill) or the carried tail of the previous chunk
-(decode). Prefill and decode are therefore the same kernel with a different
-pad — no separate decode variant.
+The herd tiles both axes: `tx` picks a channel block and `ty` a slice of the
+sequence, with the sequence loop striding by `tile_s * herd_y`. Both offsets are
+ordinary Python arithmetic on the coordinates,
 
-`w` is passed TAP-MAJOR, shape `(3, C)`, so each tap's channel slice is
-contiguous (HF stores it channel-major as `(C, 1, 3)`; the host transposes
-once at load).
+    chan = tx * tile_c
+    row  = iv + ty * tile_s
 
-Decomposition: the herd splits the **channel** axis across `herd_x` columns
-(each column owns a contiguous `C/herd_x` channel slice) and the **sequence**
-axis across `herd_y` rows (each row owns every `herd_y`-th `tile_s` block).
-Each tile issues 3 independent shim DMAs (x in, w in, y out).
-
-Note the halo: a tile producing `tile_s` output rows must read `tile_s + 2`
-input rows, so small `tile_s` pays a `2/tile_s` read-amplification.
+where the predecessor built each as its own AffineMap.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i32
 from air.backend.xrt import XRTBackend
-
-range_ = for_
+from air.backend.xrt_runner import XRTRunner
 
 K_TAPS = 3
 HALO = K_TAPS - 1  # 2 rows of left context
 L1_BYTES = 65536  # per-compute-tile L1 on AIE2P
 
 
-@module_builder
-def build_module(seq, channels, tile_s, np_dtype_in, herd_x=8, herd_y=1):
-    xrt_dtype = type_mapper(np_dtype_in)
-
+def build_module(seq, channels, tile_s, np_dtype_in=bfloat16, herd_x=8, herd_y=1):
     assert (
         channels % herd_x == 0
     ), f"channels ({channels}) must be divisible by herd_x ({herd_x})"
@@ -117,116 +105,68 @@ def build_module(seq, channels, tile_s, np_dtype_in, herd_x=8, herd_y=1):
         f"silently wrong results -- do not remove this assert."
     )
 
-    # L3 types. x is pre-padded with HALO rows; y is not.
-    l3XTy = MemRefType.get([seq + HALO, channels], xrt_dtype)
-    l3WTy = MemRefType.get([K_TAPS, channels], xrt_dtype)
-    l3YTy = MemRefType.get([seq, channels], xrt_dtype)
+    dtype = bf16
 
-    # L1 types
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1XTy = MemRefType.get(
-        shape=[tile_s + HALO, tile_c], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-    l1WTy = MemRefType.get(
-        shape=[K_TAPS, tile_c], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
-    l1YTy = MemRefType.get(
-        shape=[tile_s, tile_c], element_type=xrt_dtype, memory_space=l1_mem_space
-    )
+    # x is pre-padded by HALO rows; w is tap-major.
+    X = air.tensor([seq + HALO, channels], dtype)
+    W = air.tensor([K_TAPS, channels], dtype)
+    Y = air.tensor([seq, channels], dtype)
 
-    conv_func = FuncOp(
+    conv = air.extern(
         "conv1d_depthwise_bf16",
-        ([l1XTy, l1WTy, l1YTy, T.i32(), T.i32()], []),
-        visibility="private",
-    )
-    conv_func.attributes["link_with"] = StringAttr.get("conv1d_depthwise.o")
-    conv_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-
-    # global_channel = tx * tile_c
-    chan_map = AffineMap.get(
-        0,
-        1,
-        [AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(tile_c))],
-    )
-    # global_row = loop_iv + ty * tile_s
-    row_map = AffineMap.get(
-        0,
-        2,
-        [
-            AffineExpr.get_add(
-                AffineSymbolExpr.get(0),
-                AffineExpr.get_mul(
-                    AffineSymbolExpr.get(1), AffineConstantExpr.get(tile_s)
-                ),
-            )
-        ],
+        link_with="conv1d_depthwise.o",
+        scalars=[i32, i32],
     )
 
-    @FuncOp.from_py_func(l3XTy, l3WTy, l3YTy)
-    def conv1d_depthwise(arg0, arg1, arg2):
-        # arg0 = x padded [seq+2, C], arg1 = w tap-major [3, C], arg2 = y [seq, C]
+    with air.launch(name="conv1d_depthwise") as launch:
 
-        @launch(operands=[arg0, arg1, arg2])
-        def conv_launch(l_x, l_w, l_y):
+        @launch.body
+        def _():
+            with air.segment(name="conv1d_seg") as seg:
 
-            @segment(name="conv1d_seg", operands=[l_x, l_w, l_y])
-            def conv_seg(s_x, s_w, s_y):
+                @seg.body
+                def _():
+                    with air.herd(
+                        [range(herd_x), range(herd_y)],
+                        name="herd_0",
+                        shape=(herd_x, herd_y),
+                    ) as herd:
 
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_x, herd_y],
-                    operands=[s_x, s_w, s_y],
-                )
-                def herd_body(_tx, _ty, _sx, _sy, l3_x, l3_w, l3_y):
-                    l1_x = AllocOp(l1XTy, [], [])
-                    l1_w = AllocOp(l1WTy, [], [])
-                    l1_y = AllocOp(l1YTy, [], [])
+                        @herd.body
+                        def _(tx, ty):
+                            l1_x = air.alloc(
+                                [tile_s + HALO, tile_c], dtype, scope=herd.private()
+                            )
+                            l1_w = air.alloc(
+                                [K_TAPS, tile_c], dtype, scope=herd.private()
+                            )
+                            l1_y = air.alloc(
+                                [tile_s, tile_c], dtype, scope=herd.private()
+                            )
 
-                    ts_i32 = ConstantOp(T.i32(), tile_s)
-                    tc_i32 = ConstantOp(T.i32(), tile_c)
+                            chan = tx * tile_c
 
-                    chan = affine_apply(chan_map, [_tx])
+                            # Sequence-independent, so once per tile rather
+                            # than once per trip.
+                            ops.load(l1_w, W[:, chan : chan + tile_c])
 
-                    # Weights are seq-independent: load this tile's channel
-                    # slice once, outside the sequence loop.
-                    dma_memcpy_nd(
-                        l1_w,
-                        l3_w,
-                        src_offsets=[0, chan],
-                        src_sizes=[K_TAPS, tile_c],
-                        src_strides=[channels, 1],
-                    )
+                            for iv in air.sequential(0, seq, tile_s * herd_y):
+                                row = iv + ty * tile_s
 
-                    for loop_iv in range_(0, seq, tile_s * herd_y):
-                        row = affine_apply(row_map, [loop_iv, _ty])
+                                # tile_s + HALO in, tile_s out: the overlap is
+                                # the taps' history.
+                                ops.load(
+                                    l1_x,
+                                    X[row : row + tile_s + HALO, chan : chan + tile_c],
+                                )
 
-                        # Read tile_s + HALO rows starting at `row`. Because x
-                        # is pre-padded, x[row] is already the oldest sample
-                        # feeding y[row] — no negative indexing, no masking.
-                        dma_memcpy_nd(
-                            l1_x,
-                            l3_x,
-                            src_offsets=[row, chan],
-                            src_sizes=[tile_s + HALO, tile_c],
-                            src_strides=[channels, 1],
-                        )
+                                conv(l1_x, l1_w, l1_y, tile_s, tile_c)
 
-                        CallOp(conv_func, [l1_x, l1_w, l1_y, ts_i32, tc_i32])
+                                ops.store(
+                                    l1_y, Y[row : row + tile_s, chan : chan + tile_c]
+                                )
 
-                        dma_memcpy_nd(
-                            l3_y,
-                            l1_y,
-                            dst_offsets=[row, chan],
-                            dst_sizes=[tile_s, tile_c],
-                            dst_strides=[channels, 1],
-                        )
-                        yield_([])
-
-                    DeallocOp(l1_x)
-                    DeallocOp(l1_w)
-                    DeallocOp(l1_y)
-
-                herd_body.attributes["link_with"] = StringAttr.get("conv1d_depthwise.o")
+    return launch
 
 
 def conv1d_reference(x_pad, w_tapmajor, seq, channels):
@@ -316,12 +256,19 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     args = parser.parse_args()
 
     if args.perf_iters < 0:
         parser.error("--perf-iters must be >= 0")
 
-    mlir_module = build_module(
+    launch = build_module(
         args.seq,
         args.channels,
         args.tile_s,
@@ -329,6 +276,8 @@ if __name__ == "__main__":
         herd_x=args.herd_x,
         herd_y=args.herd_y,
     )
+    # build() resolves --target auto, so it runs before launch.target is read.
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
         exit(0)
@@ -362,6 +311,7 @@ if __name__ == "__main__":
         # bf16 output rounding, the cleanest tier, so it needs no SiLU-style
         # transcendental slack.
         runner = XRTRunner(
+            target_device=launch.target,
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
@@ -381,6 +331,7 @@ if __name__ == "__main__":
 
     elif args.compile_mode == "compile-only":
         backend = XRTBackend(
+            target_device=launch.target,
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,


### PR DESCRIPTION
Two more examples onto `air.api`. No DSL changes — both are pure dataflow around
an `air.extern` kernel, the shape four earlier conversions already established.

## `conv1d_depthwise`

Causal depthwise 1-D convolution; the convolution itself stays in C++, so the
body is dataflow only. The input is pre-padded by HALO rows on the host, so
`x_pad[row]` is already the oldest sample feeding `y[row]` — no negative
indexing and no masking, which is why the input slice is `tile_s + HALO` rows
and the output slice is `tile_s`. Both offsets are ordinary Python arithmetic on
the coordinates where the predecessor built each as its own `AffineMap`.

**All four measured-config guards are carried over verbatim, with their
reasoning.** They are not style, and this is the part of the conversion worth
reviewing:

* `herd_x=2` **compiles cleanly and returns wrong results** at `tile_s=8`
  (mean_rel_L1 5.0e-1 vs the correct 2.8e-3). It is not an L1 issue — `herd_x=1`
  and `herd_x=4` both pass at *larger* footprints.
* `herd_y>1` is numerically correct on a single invocation and **deadlocks on
  the second** (`ERT_CMD_STATE_TIMEOUT`), so a single `make run` never sees it.
* An over-budget L1 also compiles and returns silently wrong numbers.

Every one of those passes a build and fails only numerically, so dropping the
asserts would re-admit them invisibly. `tile_c` also stays *derived*
(`channels // herd_x`) rather than becoming a parameter, so the L1 budget guard
keeps computing the same number.

## `dual_herd_packet_switch`

One segment holding two independent herds — an element-wise add and an
element-wise multiply on separate inputs and outputs. Six L3 tensors and two
herds is more shim traffic than there are dedicated channels, which is the
point: `air-dma-to-channel` infers the channels from the transfers and the shim
shares them, packet-switched. Nothing declares a channel and nothing needs to.

The two herd bodies differ only in the operator, so they are one local function
called twice rather than a copy-paste pair. `tx * tile_size` replaces an
`arith.muli` built per transfer, three times per herd, and the compute replaces
`linalg.elemwise_binary` (with an explicit `BinaryFn` and cast attribute) with
`+` and `*`.

## Gating

Both examples are npu2-only and the dev box is Phoenix, so the gate is compiling
**both** versions for npu2 and diffing the generated AIE IR and instruction
stream.

| example | result |
|---|---|
| `conv1d_depthwise` (seq=64, channels=512, tile_s=8, herd_x=8) | byte-identical `air.insts.bin`; 24 buffers, 8 cores, 24 dma_bds, 24 flows, 48 locks, 24 shim allocations, 24 tiles — all identical |
| `dual_herd_packet_switch` (tile_size=1024) | byte-identical `air.insts.bin`; 48 buffers, 16 cores, 48 dma_bds, 16 flows, 96 locks, 48 shim allocations, 32 tiles, and **32 `aie.packet_flow`** — the thing the example exists to produce |

Both re-verified after rebasing onto current `main`.

Plus: 29/29 api lits, `check-air-python` 42, `check-air-mlir` 532 + 7 XFAIL, and
the byte-identical IR sweep over all 70 previously-converted examples unchanged
(72 converted now).

**Not gated locally: AIE2P.** Neither example runs on npu1, so the hx370 runner
is the first thing that will execute them.

## Blockers found while scoping, for the record

* `ffn_swiglu/decode` and `ffn_swiglu/prefill` need **multi-launch modules** —
  four `air.launch`es in one function with the intermediates as function
  arguments. A `LaunchContext` owns every tensor declared before it, one launch
  per module, so this is not expressible today. That stitching is exactly what
  those examples demonstrate.
* `conv2d_14x14` hand-builds 6-D gather wraps (`sizes=[1,1,2,98,8,8]`,
  `strides=[50176,12544,6272,8,784,1]`) that are not derivable from subscripts.
