### PR TITLE
[air.api] Assign into a region of a buffer, plus matrix_multiplication/int4_awq and conv2d

### DIFF
--- a/programming_examples/conv2d/conv2d.py
+++ b/programming_examples/conv2d/conv2d.py
@@ -1,37 +1,49 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""2D convolution (NHWC input, HWCiCo filter) on one AIE tile, on air.api.
 
-"""2D Convolution Example
+Valid convolution, stride 1::
 
-Implements a simple 2D convolution (NHWC layout, HWC filter) on a single
-AIE tile using scalar load/store operations.
+    output[oh, ow, co] = sum over (kh, kw, ci) of
+        input[oh + kh, ow + kw, ci] * filter[kh, kw, ci, co]
 
-Input:  [1, H, W, Ci] i32
-Filter: [Kh, Kw, Ci, Co] i32
-Output: [1, Ho, Wo, Co] i32
+Written out, that is six loops with three loads, a multiply, an add and a store
+at the bottom, and this is one of the kernels where that *is* the design: no
+axis of it is tile-shaped, so there is nothing here for a whole-tile expression
+to say. The DSL version is the same six loops::
 
-Where Ho = H - Kh + 1, Wo = W - Kw + 1 (valid convolution, stride=1).
+    for oh, ow, co, kh, kw, ci in nested air.sequential(...):
+        out[oh, ow, co] = out[oh, ow, co] + in[oh + kh, ow + kw, ci] * flt[kh, kw, ci, co]
 
-Data flows:
-  1. DMA input tile and filter from L3 to L1
-  2. Compute convolution on AIE tile
-  3. DMA output tile from L1 to L3
+Two pieces of the DSL carry it, and both are ordinary numpy spellings:
+
+* **A fully-integer subscript is a scalar.** ``out[oh, ow, co]`` names one
+  element, not a one-element tile, so assigning to it emits a store and no loop
+  of its own. That is what keeps the emitted nest six deep rather than twelve.
+* **A region's offset may be a loop variable.** ``in[oh + kh, ow + kw, ci]`` is
+  the sliding window, and the shift reaches the load as one ``affine.apply`` --
+  the same way every index in this DSL is built.
+
+The kernel's own shape is therefore unchanged from the predecessor this
+replaces: same nine ``scf.for``, same three ``memref.load``, same two
+``memref.store``, same three DMAs, same herd. The one spelling difference is
+``affine.apply`` where the predecessor wrote ``arith.addi`` for ``oh + kh``.
+
+The batch axis is dropped on the way into L1 and restored on the way out -- N is
+1, so ``[1, Ho, Wo, Co]`` and ``[Ho, Wo, Co]`` are the same buffer.
 """
 
 import argparse
 
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+import numpy as np
+
+from air import api as air
+from air.api import ops
+from air.api.types import i32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
-
-# Small default sizes for a simple demonstration
+# Small default sizes for a simple demonstration.
 H_DEFAULT = 8
 W_DEFAULT = 8
 CI_DEFAULT = 4
@@ -40,90 +52,61 @@ KH = 3
 KW = 3
 
 
-@module_builder
-def build_module(H, W, Ci, Co, Kh, Kw, np_dtype):
-    assert (
-        H >= Kh and W >= Kw
-    ), f"Invalid convolution: require H >= Kh and W >= Kw, got H={H}, W={W}, Kh={Kh}, Kw={Kw}"
-    xrt_dtype = type_mapper(np_dtype)
+def build_module(H, W, Ci, Co, Kh, Kw, dtype=i32):
+    if H < Kh or W < Kw:
+        raise ValueError(
+            f"invalid convolution: require H >= Kh and W >= Kw, got H={H}, "
+            f"W={W}, Kh={Kh}, Kw={Kw}"
+        )
+
     Ho = H - Kh + 1
     Wo = W - Kw + 1
 
-    # L3 types: NHWC input/output, HWCiCo filter
-    l3InTy = MemRefType.get([1, H, W, Ci], xrt_dtype)
-    l3FilterTy = MemRefType.get([Kh, Kw, Ci, Co], xrt_dtype)
-    l3OutTy = MemRefType.get([1, Ho, Wo, Co], xrt_dtype)
+    IN = air.tensor([1, H, W, Ci], dtype)
+    FILTER = air.tensor([Kh, Kw, Ci, Co], dtype)
+    OUT = air.tensor([1, Ho, Wo, Co], dtype)
 
-    # L1 types: drop the batch dimension (N=1) since we process one
-    # sample. The DMA copies the full extent which matches because N=1.
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1InTy = MemRefType.get([H, W, Ci], xrt_dtype, memory_space=l1_mem_space)
-    l1FilterTy = MemRefType.get([Kh, Kw, Ci, Co], xrt_dtype, memory_space=l1_mem_space)
-    l1OutTy = MemRefType.get([Ho, Wo, Co], xrt_dtype, memory_space=l1_mem_space)
+    with air.launch(name="conv2d") as launch:
 
-    @FuncOp.from_py_func(l3InTy, l3FilterTy, l3OutTy)
-    def conv2d(arg_in, arg_filter, arg_out):
+        @launch.body
+        def _():
+            with air.herd(range(1), name="herd_0", shape=(1,)) as h:
 
-        @herd(
-            name="herd_0",
-            sizes=[1, 1],
-            operands=[arg_in, arg_filter, arg_out],
-        )
-        def herd_body(_tx, _ty, _sx, _sy, l3_in, l3_filter, l3_out):
-            l1_in = AllocOp(l1InTy, [], [])
-            l1_filter = AllocOp(l1FilterTy, [], [])
-            l1_out = AllocOp(l1OutTy, [], [])
+                @h.body
+                def _(tx):
+                    l1_in = air.alloc([H, W, Ci], dtype, scope=h.private())
+                    l1_filter = air.alloc([Kh, Kw, Ci, Co], dtype, scope=h.private())
+                    l1_out = air.alloc([Ho, Wo, Co], dtype, scope=h.private())
 
-            # DMA input and filter to L1
-            dma_memcpy_nd(l1_in, l3_in)
-            dma_memcpy_nd(l1_filter, l3_filter)
+                    # The batch axis is 1, so it drops on the way in.
+                    ops.load(l1_in, IN)
+                    ops.load(l1_filter, FILTER)
 
-            zero = arith.ConstantOp(xrt_dtype, 0)
+                    for oh in air.sequential(Ho):
+                        for ow in air.sequential(Wo):
+                            for co in air.sequential(Co):
+                                l1_out[oh, ow, co] = 0
 
-            # Initialize output to zero
-            for oh in range_(Ho):
-                for ow in range_(Wo):
-                    for co in range_(Co):
-                        store(zero, l1_out, [oh, ow, co])
-                        yield_([])
-                    yield_([])
-                yield_([])
+                    for oh in air.sequential(Ho):
+                        for ow in air.sequential(Wo):
+                            for co in air.sequential(Co):
+                                for kh in air.sequential(Kh):
+                                    for kw in air.sequential(Kw):
+                                        for ci in air.sequential(Ci):
+                                            l1_out[oh, ow, co] = (
+                                                l1_out[oh, ow, co]
+                                                + l1_in[oh + kh, ow + kw, ci]
+                                                * l1_filter[kh, kw, ci, co]
+                                            )
 
-            # Convolution: output[oh, ow, co] += input[oh+kh, ow+kw, ci] * filter[kh, kw, ci, co]
-            for oh in range_(Ho):
-                for ow in range_(Wo):
-                    for co in range_(Co):
-                        for kh in range_(Kh):
-                            for kw in range_(Kw):
-                                for ci in range_(Ci):
-                                    ih = arith.addi(oh, kh)
-                                    iw = arith.addi(ow, kw)
-                                    in_val = load(l1_in, [ih, iw, ci])
-                                    f_val = load(l1_filter, [kh, kw, ci, co])
-                                    prod = arith.muli(in_val, f_val)
-                                    acc = load(l1_out, [oh, ow, co])
-                                    new_acc = arith.addi(acc, prod)
-                                    store(new_acc, l1_out, [oh, ow, co])
-                                    yield_([])
-                                yield_([])
-                            yield_([])
-                        yield_([])
-                    yield_([])
-                yield_([])
+                    ops.store(l1_out, OUT)
 
-            # DMA output from L1 to L3
-            dma_memcpy_nd(l3_out, l1_out)
-
-            DeallocOp(l1_in)
-            DeallocOp(l1_filter)
-            DeallocOp(l1_out)
+    return launch
 
 
-if __name__ == "__main__":
-    INPUT_DATATYPE = np.int32
-
+def parse_args():
     parser = argparse.ArgumentParser(
-        prog="run.py",
+        prog="conv2d.py",
         description="Builds, runs, and tests the 2D convolution example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
@@ -146,26 +129,38 @@ if __name__ == "__main__":
         default="xclbin",
         dest="output_format",
     )
-    args = parser.parse_args()
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
 
     Ho = args.H - KH + 1
     Wo = args.W - KW + 1
 
-    mlir_module = build_module(args.H, args.W, args.Ci, args.Co, KH, KW, INPUT_DATATYPE)
+    launch = build_module(args.H, args.W, args.Ci, args.Co, KH, KW)
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
     np.random.seed(0)
     input_data = np.random.randint(0, 4, size=(1, args.H, args.W, args.Ci)).astype(
-        INPUT_DATATYPE
+        np.int32
     )
     filter_data = np.random.randint(0, 4, size=(KH, KW, args.Ci, args.Co)).astype(
-        INPUT_DATATYPE
+        np.int32
     )
 
-    # Reference convolution (NHWC layout)
-    output_ref = np.zeros((1, Ho, Wo, args.Co), dtype=INPUT_DATATYPE)
+    # Reference convolution (NHWC layout).
+    output_ref = np.zeros((1, Ho, Wo, args.Co), dtype=np.int32)
     for oh in range(Ho):
         for ow in range(Wo):
             for co in range(args.Co):
@@ -177,28 +172,32 @@ if __name__ == "__main__":
                                 * filter_data[kh, kw, ci, co]
                             )
 
-    if args.compile_mode == "compile-and-run":
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            output_format=args.output_format,
-            instance_name="conv2d",
-            runtime_loop_tiling_sizes=[4, 4],
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_data, filter_data],
-                expected_outputs=[output_ref],
-            )
-        )
-
-    elif args.compile_mode == "compile-only":
+    if args.compile_mode == "compile-only":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             output_format=args.output_format,
             runtime_loop_tiling_sizes=[4, 4],
+            target_device=launch.target,
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        output_format=args.output_format,
+        instance_name="conv2d",
+        runtime_loop_tiling_sizes=[4, 4],
+        target_device=launch.target,
+    )
+    return runner.run_test(
+        mlir_module,
+        inputs=[input_data, filter_data],
+        expected_outputs=[output_ref],
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/matrix_multiplication/int4_awq/matmul_int4_packed.py
+++ b/programming_examples/matrix_multiplication/int4_awq/matmul_int4_packed.py
@@ -1,10 +1,78 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-#
-# int4-AWQ GEMM (prefill). 2D herd over (M, N), with K accumulated per-PE
-# inside the herd; per-PE drain into a 4D L2 C [herd_m, herd_n, tile_m,
-# tile_n]. Uses matmul_int4_bf16_packed from mv_int4_bf16.cc (packed
-# Q+S+Z weight BO; bf16 activation and output).
+"""int4-AWQ GEMM (prefill), on air.api.
+
+A 2-D herd over (M, N), with K accumulated per-PE inside the herd and a per-PE
+drain into a 4-D L2 C ``[herd_m, herd_n, tile_m, tile_n]``. The arithmetic is
+entirely in ``mv_int4_bf16.cc`` -- dequantisation, the mmul and the f32->bf16
+convert are three hand-written AIE kernels -- so what the DSL expresses here is
+the *schedule* and the *data movement*, and nothing else::
+
+    air.launch (m_outer, n_outer)
+      air.segment
+        L2: A [herd_m, tile_m, tile_k_l2] (bf16)
+            B [herd_n, k_per_l2, tile_bytes] (packed Q+S+Z bytes)
+            C [herd_m, herd_n, tile_m, tile_n] (bf16)
+        for m_o in air.sequential(m_per_segment)
+            for k2 in air.sequential(k / tile_k_l2)
+                L3 -> L2 for A and B
+                herd
+                    zero the f32 accumulator
+                    for j in air.sequential(k_per_l2)
+                        L2 -> L1, then dequant + mmul into the accumulator
+                    convert to bf16 and drain to L2
+            L2 -> L3
+
+Three things are worth pointing at.
+
+**The packed weight tensor is already blocked, so its transfers are plain
+subscripts.** ``pack_inputs`` lays the Q+S+Z bytes out as ``[N_div, K_div,
+tile_bytes]``, one contiguous run per ``(n_outer, k_outer)`` tile, which is why
+the L1 weight buffer is a flat ``[tile_bytes]`` and its fill is
+``l2_b[ty, j, :]``. The int4 nibbles, the scales and the zero points never
+appear as types in the IR: to the DMA they are bytes, and to the kernel they are
+whatever ``mv_int4_bf16.cc`` says they are.
+
+**Every L2 staging axis here is one somebody divides along.** A's fill is
+``.reshape(herd_m, tile_m, tile_k_l2)`` over a plain ``[m, k]`` region: the
+split of the row axis into a per-core axis and a within-tile axis *is* the DMA's
+access pattern, and nothing is copied. It is tempting to go further, since
+row-major ``[a, b, c]`` and ``[a*b, c]`` hold the same bytes in the same order
+and ``l2_a[tx*tile_m : ...]`` would walk the same addresses -- but at Llama
+prefill scale that buffer is 512 KB, over what one memtile holds, and
+``air-split-l2-memref-for-buffer-constraint`` has to divide it. It can do that
+along a declared ``herd_m`` axis and not along a fused one: flattened, it aborts
+in ``tileChannelOpByFactor`` on an invalid affine map.
+
+The predecessor's two *unit* axes go the other way, and for the same reason
+inverted -- nothing is ever split along them. Their strides were hand-written
+and arbitrary (a size-1 axis is never stepped), which is exactly why they cannot
+be derived: asking for ``[herd_m, 1, tile_m, tile_k_l2]`` makes the reshape
+invent a stride, and at ``M=32`` the invented one happens to equal its
+neighbour's, which is enough for the L2 split to fuse two per-core puts into one
+4-D BD instead. Declaring only the axes that mean something removes the choice.
+C keeps all four of its axes because the drain out of it is a genuine transpose.
+
+**The accumulator is f32 and lives in L1 across the whole K loop.** Partial sums
+must not round to bf16 between kernel calls, so ``zero_vectorized_f32_mn`` seeds
+it once per herd entry and ``f32_to_bf16_mn`` converts once at the end. This is
+also why ``TILE_K_L2`` defaults to ``K``: with one segment-level K iteration the
+accumulator survives every ``K_CHUNK`` step.
+
+``m_per_segment`` is unchanged and still load-bearing. Shim DMA BD chains on
+AIE2P fold zero-stride launch-axis loops into a single multi-dim BD but unroll
+non-zero-stride ones into a BD per iteration. M iterations have a non-zero
+stride, so at full Llama prefill (M=2048, tile_m=16, herd_m=8) the launch M axis
+would need 16 BDs per chain -- past the per-shim-channel BD ID pool. Moving
+those iterations into the segment's ``air.sequential`` makes the launch M axis 1
+and the loop a single BD repeated at runtime.
+
+The module is built for **npu2**: the kernel object is compiled
+``--target=aie2p``, both lits are ``REQUIRES: ryzen_ai_npu2``, and the widest
+configuration wants an 8-column part. ``build_module`` returns the module rather
+than the launch, because the int4 prefill stitchers under
+``llms/llama32_1b_int4/`` call it for one and match its signature positionally.
+"""
 
 import argparse
 import sys
@@ -12,34 +80,8 @@ import sys
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import (
-    AffineConstantExpr,
-    AffineExpr,
-    AffineMap,
-    AffineSymbolExpr,
-    BF16Type,
-    F32Type,
-    IntegerAttr,
-    IntegerType,
-    MemRefType,
-    ShapedType,
-    StridedLayoutAttr,
-    StringAttr,
-    UnitAttr,
-)
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import (
-    MemorySpace,
-    T,
-    dma_memcpy_nd,
-    herd,
-    launch,
-    module_builder,
-    segment,
-)
-from air.dialects.func import CallOp, FuncOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.scf import for_, yield_
+from air import api as air
+from air.api.types import bf16, f32, i8
 from air.backend.xrt import XRTBackend
 from air.backend.xrt_runner import XRTRunner
 
@@ -105,26 +147,17 @@ def cpu_reference(W_q, W_s, W_z, A):
     return C.astype(bfloat16)
 
 
-@module_builder
 def build_module(
     m, k, n, gs, tile_m, tile_k_l2, tile_k_l1, tile_n, herd_m, herd_n, m_per_segment=1
 ):
-    """Build the int4-AWQ packed GEMM.
+    """Build the int4-AWQ packed GEMM and return the MLIR module.
 
     `m_per_segment` lets the segment body iterate M outer tiles inside one
-    launch step, instead of putting every M outer tile on its own launch
-    axis position. The total per-PE M tile count is unchanged
-    (`m // (tile_m * herd_m)`); only WHERE the iteration lives moves.
-
-    Why this knob matters: shim DMA BD chains on AIE2P fold zero-stride
-    launch-axis loops into a single multi-dim BD, but unroll non-zero-stride
-    launch-axis loops into separate BDs (one per iteration). M-axis
-    iterations have non-zero stride, so the BD count grows linearly with
-    the launch M axis. At full Llama prefill (M=2048, tile_m=16, herd_m=8)
-    that is 16 BDs per chain — over the per-shim-channel BD ID pool.
-    Setting `m_per_segment = m // (tile_m * herd_m)` absorbs all M
-    iterations into the segment loop (launch M axis = 1), and the segment
-    for loop becomes a single BD repeated at runtime."""
+    launch step, instead of putting every M outer tile on its own launch axis
+    position. The total per-PE M tile count is unchanged
+    (`m // (tile_m * herd_m)`); only WHERE the iteration lives moves -- see the
+    module docstring for why that matters to the shim BD budget.
+    """
     assert m % (tile_m * herd_m) == 0
     assert n % (tile_n * herd_n) == 0
     m_outer_total = m // (tile_m * herd_m)
@@ -153,246 +186,117 @@ def build_module(
     N_div = n // tile_n
     K_div = k // tile_k_l1
 
-    bf16_ty = BF16Type.get()
-    f32_ty = F32Type.get()
-    u8_ty = IntegerType.get_signless(8)
+    # The output block one segment covers: herd_m x herd_n L1 tiles.
+    l2_m, l2_n = tile_m * herd_m, tile_n * herd_n
 
-    A_l3_ty = MemRefType.get([m, k], bf16_ty)
-    B_l3_ty = MemRefType.get([N_div, K_div, tile_bytes], u8_ty)
-    C_l3_ty = MemRefType.get([m, n], bf16_ty)
+    A = air.tensor([m, k], bf16)
+    # Packed weights are bytes to everything on this side of the call: the
+    # nibbles, the bf16 scales and the u8 zero points are unpacked inside
+    # mv_int4_bf16.cc, from one contiguous run per (n_outer, k_outer) tile.
+    B = air.tensor([N_div, K_div, tile_bytes], i8)
+    C = air.tensor([m, n], bf16)
 
-    l1_ms = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l2_ms = IntegerAttr.get(T.i32(), MemorySpace.L2)
+    zero_acc = air.extern("zero_vectorized_f32_mn", link_with=KERNEL_OBJ_NAME)
+    matmul = air.extern("matmul_int4_bf16_packed_f32", link_with=KERNEL_OBJ_NAME)
+    to_bf16 = air.extern("f32_to_bf16_mn", link_with=KERNEL_OBJ_NAME)
 
-    A_l2_ty = MemRefType.get(
-        [herd_m, 1, tile_m, tile_k_l2], bf16_ty, memory_space=l2_ms
-    )
-    B_l2_ty = MemRefType.get(
-        [1, herd_n, k_per_l2, tile_bytes], u8_ty, memory_space=l2_ms
-    )
-    C_l2_ty = MemRefType.get(
-        [herd_m, herd_n, tile_m, tile_n], bf16_ty, memory_space=l2_ms
-    )
+    with air.launch(
+        [range(launch_m_outer), range(N_div // herd_n)], name="matmul_int4_packed"
+    ) as launch:
 
-    A_l1_ty = MemRefType.get([tile_m, tile_k_l1], bf16_ty, memory_space=l1_ms)
-    B_l1_ty = MemRefType.get([tile_bytes], u8_ty, memory_space=l1_ms)
-    # L1 C accumulator: f32. Kept across the host K-chunk loop so partial sums
-    # don't bf16-truncate between calls. Converted to bf16 once at the end.
-    C_l1_acc_ty = MemRefType.get([tile_m, tile_n], f32_ty, memory_space=l1_ms)
-    C_l1_drain_ty = MemRefType.get([tile_m, tile_n], bf16_ty, memory_space=l1_ms)
+        @launch.body
+        def _(li, lj):
+            with air.segment(name="seg") as seg:
 
-    zero_func = FuncOp(
-        "zero_vectorized_f32_mn",
-        ([C_l1_acc_ty], []),
-        visibility="private",
-    )
-    zero_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
-    zero_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+                @seg.body
+                def _():
+                    l2_a = air.alloc(
+                        [herd_m, tile_m, tile_k_l2], bf16, scope=seg.private()
+                    )
+                    l2_b = air.alloc(
+                        [herd_n, k_per_l2, tile_bytes], i8, scope=seg.private()
+                    )
+                    l2_c = air.alloc(
+                        [herd_m, herd_n, tile_m, tile_n], bf16, scope=seg.private()
+                    )
 
-    matmul_func = FuncOp(
-        "matmul_int4_bf16_packed_f32",
-        ([B_l1_ty, A_l1_ty, C_l1_acc_ty], []),
-        visibility="private",
-    )
-    matmul_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
-    matmul_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+                    n_outer = lj * herd_n
+                    col = lj * l2_n
 
-    f32_to_bf16_func = FuncOp(
-        "f32_to_bf16_mn",
-        ([C_l1_acc_ty, C_l1_drain_ty], []),
-        visibility="private",
-    )
-    f32_to_bf16_func.attributes["link_with"] = StringAttr.get(KERNEL_OBJ_NAME)
-    f32_to_bf16_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+                    for m_o in air.sequential(m_per_segment):
+                        row = li * (l2_m * m_per_segment) + m_o * l2_m
 
-    @FuncOp.from_py_func(A_l3_ty, B_l3_ty, C_l3_ty)
-    def matmul_int4_packed(arg_a, arg_b, arg_c):
-        launch_size = [launch_m_outer, n // tile_n // herd_n]
+                        for k2 in air.sequential(k // tile_k_l2):
+                            k_l2_off = k2 * tile_k_l2
+                            k_chunk_off = k2 * k_per_l2
 
-        @launch(operands=[arg_a, arg_b, arg_c], sizes=launch_size)
-        def launch_body(li, lj, lsx, lsy, l3_a, l3_b, l3_c):
-            @segment(name="seg", operands=[li, lj, l3_a, l3_b, l3_c])
-            def segment_body(li_s, lj_s, l3_a_s, l3_b_s, l3_c_s):
-                l2_a = AllocOp(A_l2_ty, [], [])
-                l2_b = AllocOp(B_l2_ty, [], [])
-                l2_c = AllocOp(C_l2_ty, [], [])
-
-                # row_off = li_s * (tile_m * herd_m * m_per_segment)
-                #         + m_o * (tile_m * herd_m)
-                # (m_o is the segment-level M-outer loop induction var;
-                #  when m_per_segment == 1 the loop has one iter and folds.)
-                ix_mo_to_row = AffineMap.get(
-                    0,
-                    2,
-                    [
-                        AffineExpr.get_add(
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(tile_m * herd_m * m_per_segment),
-                            ),
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(tile_m * herd_m),
-                            ),
-                        )
-                    ],
-                )
-                iy_to_n_outer = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0), AffineConstantExpr.get(herd_n)
-                        )
-                    ],
-                )
-                n_outer_off = affine_apply(iy_to_n_outer, [lj_s])
-
-                k_l2_to_k = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0), AffineConstantExpr.get(tile_k_l2)
-                        )
-                    ],
-                )
-                k_l2_to_chunk = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0), AffineConstantExpr.get(k_per_l2)
-                        )
-                    ],
-                )
-                k_chunk_off_l1_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0), AffineConstantExpr.get(tile_k_l1)
-                        )
-                    ],
-                )
-
-                col_off_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_n * herd_n),
-                        )
-                    ],
-                )
-                col_off = affine_apply(col_off_map, [lj_s])
-
-                for m_o in for_(0, m_per_segment):
-                    row_off = affine_apply(ix_mo_to_row, [li_s, m_o])
-                    for i in for_(0, k // tile_k_l2):
-                        k_l2_off = affine_apply(k_l2_to_k, [i])
-                        k_chunk_off = affine_apply(k_l2_to_chunk, [i])
-
-                        dma_memcpy_nd(
-                            l2_a,
-                            l3_a_s,
-                            src_offsets=[0, 0, row_off, k_l2_off],
-                            src_sizes=[herd_m, 1, tile_m, tile_k_l2],
-                            src_strides=[k * tile_m, tile_k_l2, k, 1],
-                        )
-                        dma_memcpy_nd(
-                            l2_b,
-                            l3_b_s,
-                            src_offsets=[0, n_outer_off, k_chunk_off, 0],
-                            src_sizes=[1, herd_n, k_per_l2, tile_bytes],
-                            src_strides=[
-                                K_div * tile_bytes,
-                                K_div * tile_bytes,
-                                tile_bytes,
-                                1,
-                            ],
-                        )
-
-                        @herd(
-                            name="herd_0",
-                            sizes=[herd_m, herd_n],
-                            operands=[l2_a, l2_b, l2_c],
-                        )
-                        def compute_body(_tx, _ty, _sx, _sy, _l2a, _l2b, _l2c):
-                            _l1_a = AllocOp(A_l1_ty, [], [])
-                            _l1_b = AllocOp(B_l1_ty, [], [])
-                            _l1_c_acc = AllocOp(C_l1_acc_ty, [], [])
-                            _l1_c_drain = AllocOp(C_l1_drain_ty, [], [])
-                            CallOp(zero_func, [_l1_c_acc])
-                            for j in for_(0, k_per_l2):
-                                k1_off = affine_apply(k_chunk_off_l1_map, [j])
-                                dma_memcpy_nd(
-                                    _l1_a,
-                                    _l2a,
-                                    src_offsets=[_tx, 0, 0, k1_off],
-                                    src_sizes=[1, 1, tile_m, tile_k_l1],
-                                    src_strides=[
-                                        tile_m * tile_k_l2,
-                                        tile_m * tile_k_l2,
-                                        tile_k_l2,
-                                        1,
-                                    ],
-                                )
-                                dma_memcpy_nd(
-                                    _l1_b,
-                                    _l2b,
-                                    src_offsets=[0, _ty, j, 0],
-                                    src_sizes=[1, 1, 1, tile_bytes],
-                                    src_strides=[
-                                        herd_n * k_per_l2 * tile_bytes,
-                                        k_per_l2 * tile_bytes,
-                                        tile_bytes,
-                                        1,
-                                    ],
-                                )
-                                CallOp(matmul_func, [_l1_b, _l1_a, _l1_c_acc])
-                                yield_([])
-                            CallOp(f32_to_bf16_func, [_l1_c_acc, _l1_c_drain])
-                            dma_memcpy_nd(
-                                _l2c,
-                                _l1_c_drain,
-                                dst_offsets=[_tx, _ty, 0, 0],
-                                dst_sizes=[1, 1, tile_m, tile_n],
-                                dst_strides=[
-                                    herd_n * tile_m * tile_n,
-                                    tile_m * tile_n,
-                                    tile_n,
-                                    1,
+                            # Split the region's row axis into (core,
+                            # within-tile). The split is the DMA's access
+                            # pattern; the buffer stays contiguous.
+                            air.ops.load(
+                                l2_a,
+                                A[
+                                    row : row + l2_m,
+                                    k_l2_off : k_l2_off + tile_k_l2,
+                                ].reshape(herd_m, tile_m, tile_k_l2),
+                            )
+                            air.ops.load(
+                                l2_b,
+                                B[
+                                    n_outer : n_outer + herd_n,
+                                    k_chunk_off : k_chunk_off + k_per_l2,
+                                    :,
                                 ],
                             )
-                            DeallocOp(_l1_a)
-                            DeallocOp(_l1_b)
-                            DeallocOp(_l1_c_acc)
-                            DeallocOp(_l1_c_drain)
 
-                        yield_([])
+                            with air.herd(
+                                [range(herd_m), range(herd_n)],
+                                name="herd_0",
+                                shape=(herd_m, herd_n),
+                            ) as h:
 
-                    dma_memcpy_nd(
-                        l3_c_s,
-                        l2_c,
-                        dst_offsets=[row_off, col_off],
-                        dst_sizes=[herd_m * tile_m, herd_n * tile_n],
-                        dst_strides=[n, 1],
-                        src_offsets=[0, 0, 0, 0],
-                        src_sizes=[herd_m, tile_m, herd_n, tile_n],
-                        src_strides=[
-                            herd_n * tile_m * tile_n,
-                            tile_n,
-                            tile_m * tile_n,
-                            1,
-                        ],
-                    )
-                    yield_([])
+                                @h.body
+                                def _(tx, ty):
+                                    l1_a = air.alloc(
+                                        [tile_m, tile_k_l1], bf16, scope=h.private()
+                                    )
+                                    l1_b = air.alloc(
+                                        [tile_bytes], i8, scope=h.private()
+                                    )
+                                    # f32, and kept across the whole K loop so
+                                    # partial sums never round to bf16 between
+                                    # kernel calls.
+                                    acc = air.alloc(
+                                        [tile_m, tile_n], f32, scope=h.private()
+                                    )
+                                    drain = air.alloc(
+                                        [tile_m, tile_n], bf16, scope=h.private()
+                                    )
 
-                DeallocOp(l2_a)
-                DeallocOp(l2_b)
-                DeallocOp(l2_c)
+                                    zero_acc(acc)
+                                    for j in air.sequential(k_per_l2):
+                                        k1_off = j * tile_k_l1
+                                        air.ops.load(
+                                            l1_a,
+                                            l2_a[tx, :, k1_off : k1_off + tile_k_l1],
+                                        )
+                                        air.ops.load(l1_b, l2_b[ty, j, :])
+                                        matmul(l1_b, l1_a, acc)
+                                    to_bf16(acc, drain)
+
+                                    air.ops.store(drain, l2_c[tx, ty, :, :])
+
+                        # The drain is the inverse walk: bring the M axes back
+                        # outside the N ones, so [herd_m, herd_n, tile_m,
+                        # tile_n] lands as a plain [l2_m, l2_n] block of C.
+                        air.ops.store(
+                            l2_c.transpose(0, 2, 1, 3),
+                            C[row : row + l2_m, col : col + l2_n],
+                        )
+
+    # --target=aie2p built the kernel object and both lits are npu2-only, so the
+    # module is npu2-specific before the herd is even sized.
+    return launch.build(target="npu2")
 
 
 if __name__ == "__main__":

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -197,35 +197,103 @@ def _zero_index_if(needed):
     return _result(arith.ConstantOp(IndexType.get(), 0)) if needed else None
 
 
-def _leaf_index(shape, dst_shape, ivs, zero, base=None):
-    """The indices to read a leaf of ``shape`` at, inside a nest over ``dst_shape``.
+def _axes_of(leaf):
+    """``(sizes, dropped, base)`` for a leaf, whole buffer or region alike.
+
+    A memref index has one entry per axis the *buffer* has, which is ``sizes``.
+    The elementwise shape -- what broadcasting works on -- is ``sizes`` minus
+    the axes an integer subscript took, and that is ``leaf.shape``. Keeping the
+    two apart is the whole of integer indexing: ``gu[i, j]`` reads a scalar and
+    still needs two indices to say which one.
+    """
+    sizes = getattr(leaf, "sizes", None)
+    if sizes is None:
+        # A whole buffer: every axis is walked, from zero.
+        return list(leaf.shape), [False] * len(leaf.shape), None
+    return list(sizes), list(leaf.dropped), leaf.base
+
+
+def _leaf_index(leaf, dst_shape, ivs, zero):
+    """The indices to read ``leaf`` at, inside a nest over ``dst_shape``.
 
     An axis that matches the destination's is walked with the destination's own
     induction variable; an axis of extent 1 against a wider destination is
     pinned at 0, which is what makes the read a broadcast. Axes the operand does
-    not have contribute no index at all.
+    not have contribute no index at all, and an axis an integer subscript took
+    is never walked -- it contributes its offset and nothing else.
 
-    ``base`` is the leaf's own starting offset per axis, non-zero only when the
-    leaf is a *slice* of a buffer rather than the whole of it (``gu[1, :]``).
-    It shifts each axis: a pinned axis becomes the constant, and a walked one
-    becomes ``iv + base``.
+    The offset may be a herd coordinate or a loop variable rather than a
+    constant. It materialises the same way every index in this DSL does: a
+    constant folds, anything else becomes one ``affine.apply``.
 
-    When the shapes are equal and the base is all zeros this returns ``ivs``
-    unchanged, which is what keeps every existing kernel's IR byte-identical --
-    the two new branches are reachable only from a slice leaf.
+    When the shapes are equal, nothing is dropped and the base is all zeros this
+    returns ``ivs`` unchanged, which is what keeps every kernel that predates
+    regions emitting byte-identical IR.
     """
+    sizes, dropped, base = _axes_of(leaf)
+    shape = [s for s, drop in zip(sizes, dropped) if not drop]
     offset = _broadcast_offset(shape, dst_shape)
     index = []
-    for i, extent in enumerate(shape):
-        walks = extent == dst_shape[i + offset]
+    kept = 0
+    for i, extent in enumerate(sizes):
         start = 0 if base is None else base[i]
-        if start == 0:
-            index.append(ivs[i + offset] if walks else zero)
+        if dropped[i]:
+            # An integer subscript: this axis is not part of the element shape,
+            # so no induction variable reaches it.
+            index.append(_materialize_index(start))
+            continue
+        walks = extent == dst_shape[kept + offset]
+        iv = ivs[kept + offset] if walks else None
+        kept += 1
+        if _is_zero(start):
+            index.append(iv if walks else zero)
         elif not walks:
-            index.append(_index_constant(start))
+            index.append(_materialize_index(start))
         else:
-            index.append(_result(arith.AddIOp(ivs[i + offset], _index_constant(start))))
+            index.append(_result(arith.AddIOp(iv, _materialize_index(start))))
     return index
+
+
+def _dst_index(dst, ivs):
+    """Where to write, inside a nest over the destination's element shape.
+
+    A whole buffer is written at the induction variables themselves, which is
+    what every kernel that predates region assignment emits. A region shifts
+    each axis by its own offset, and an axis an integer subscript took is
+    written at that offset alone -- so ``out[i, j, k] = ...`` nests over
+    nothing and stores at exactly ``[i, j, k]``.
+
+    The destination is not broadcast, so this is ``_leaf_index`` with the
+    element shape standing in for the destination's: every kept axis walks.
+    """
+    if getattr(dst, "sizes", None) is None:
+        return ivs
+    return _leaf_index(dst, dst.shape, ivs, None)
+
+
+def _is_zero(start):
+    """Is this offset the literal 0, needing no index arithmetic at all?"""
+    if isinstance(start, int):
+        return start == 0
+    return start.as_const() == 0
+
+
+def _materialize_index(start):
+    """An offset as an index Value: a constant folds, anything else applies.
+
+    A bare induction variable or coordinate -- one term, coefficient 1, no
+    constant -- is passed straight through. ``IndexExpr.materialize`` would wrap
+    it in an identity ``affine.apply``, which is correct but is one op per index
+    per trip; a six-deep nest indexing three buffers is where that shows.
+    """
+    if isinstance(start, int):
+        return _index_constant(start)
+    if len(start.terms) == 1 and start.const == 0:
+        ((leaf, coefficient),) = start.terms.items()
+        if coefficient == 1:
+            return leaf.value
+    value = start.materialize()
+    return _index_constant(value) if isinstance(value, int) else value
 
 
 def _index_constant(value):
@@ -235,6 +303,21 @@ def _index_constant(value):
 def _base_of(leaf):
     """A slice leaf's starting offset per axis; None for a whole buffer."""
     return getattr(leaf, "base", None)
+
+
+def _offset_key(offset):
+    """A hashable identity for one offset, constant or not.
+
+    An offset is an affine form ``sum(c_i * leaf_i) + k``, so two offsets are
+    the same index exactly when their terms and constant agree. Keying on the
+    ``IndexExpr`` object instead would read ``gu[i, :]`` twice for one region,
+    and keying on ``as_const()`` would collapse ``gu[i, :]`` and ``gu[j, :]``
+    onto a shared ``None``, which is the dangerous direction.
+    """
+    if isinstance(offset, int):
+        return ("k", offset)
+    terms = tuple(sorted((id(leaf), c) for leaf, c in offset.terms.items()))
+    return (terms, offset.const)
 
 
 def _read_key(leaf):
@@ -249,7 +332,8 @@ def _read_key(leaf):
     """
     base = _base_of(leaf)
     buffer = getattr(leaf, "buffer", leaf)
-    return (id(buffer), None if base is None else tuple(base), tuple(leaf.shape))
+    key = None if base is None else tuple(_offset_key(o) for o in base)
+    return (id(buffer), key, tuple(leaf.shape))
 
 
 def _check_region(node, dst, dtype, expected=None):
@@ -538,14 +622,14 @@ def _emit_reduce(dst, expr):
     # reduced axis's full extent is a vector read, and one of extent 1 there is
     # a single element splatted across the vector.
     def load(buf, at, region):
-        index = _leaf_index(buf.shape, src_shape, at, zero, _base_of(buf))
+        index = _leaf_index(buf, src_shape, at, zero)
         if buf.shape and buf.shape[-1] == src_shape[-1]:
             return _result(
                 transfer_read(
                     region.vec_ty,
                     buf.value,
                     index,
-                    _minor(len(buf.shape)),
+                    _minor(len(_axes_of(buf)[0])),
                     region.pad,
                     [True],
                 )
@@ -685,11 +769,7 @@ def _emit_argmax(dst, expr):
     bounds = [(0, extent, 1) for extent in src_shape[:-1]]
 
     def load(buf, ivs, region):
-        return _result(
-            memref_load(
-                buf.value, _leaf_index(buf.shape, src_shape, ivs, zero, _base_of(buf))
-            )
-        )
+        return _result(memref_load(buf.value, _leaf_index(buf, src_shape, ivs, zero)))
 
     def at(ivs, column):
         return _eval(
@@ -751,9 +831,11 @@ def _minor(rank):
 
 def _emit_vector(dst, expr, width):
     shape = dst.shape
-    rank = len(shape)
-    # Read a rank-1 vector out of a rank-N memref along the innermost dim.
-    minor = _minor(rank)
+    # Read a rank-1 vector out of a rank-N memref along the innermost dim. The
+    # rank is the *memref's*, which is the destination's element rank unless an
+    # integer subscript dropped an axis -- gu[0, :] writes into a rank-2 memref
+    # while its element shape is rank 1.
+    minor = _minor(len(_axes_of(dst)[0]))
     # One lane count for the whole nest, taken from the destination. A cast does
     # not change how many elements a trip covers, only how wide each one is, so
     # the source is read at the destination's lane count and not at its own
@@ -770,17 +852,19 @@ def _emit_vector(dst, expr, width):
     )
 
     def load(buf, ivs, region):
-        index = _leaf_index(buf.shape, shape, ivs, zero, _base_of(buf))
+        index = _leaf_index(buf, shape, ivs, zero)
         if buf.shape and buf.shape[-1] == shape[-1]:
             # The operand has the destination's innermost extent, so the vector
             # read is the ordinary one -- at the operand's own rank, which is
-            # the destination's unless leading axes were broadcast away.
+            # the destination's unless leading axes were broadcast away. The
+            # permutation map is over the *memref's* rank, which is wider than
+            # the element shape when an integer subscript dropped an axis.
             return _result(
                 transfer_read(
                     region.vec_ty,
                     buf.value,
                     index,
-                    _minor(len(buf.shape)),
+                    _minor(len(_axes_of(buf)[0])),
                     region.pad,
                     [True],
                 )
@@ -793,7 +877,7 @@ def _emit_vector(dst, expr, width):
 
     def body(ivs):
         value = _eval(expr, ivs, regions[dst.dtype], regions, True, load, {})
-        transfer_write(None, value, dst.value, ivs, minor, [True])
+        transfer_write(None, value, dst.value, _dst_index(dst, ivs), minor, [True])
 
     _nest(bounds, body)
 
@@ -808,15 +892,11 @@ def _emit_scalar(dst, expr):
     )
 
     def load(buf, ivs, region):
-        return _result(
-            memref_load(
-                buf.value, _leaf_index(buf.shape, shape, ivs, zero, _base_of(buf))
-            )
-        )
+        return _result(memref_load(buf.value, _leaf_index(buf, shape, ivs, zero)))
 
     def body(ivs):
         value = _eval(expr, ivs, regions[dst.dtype], regions, False, load, {})
-        memref_store(value, dst.value, ivs)
+        memref_store(value, dst.value, _dst_index(dst, ivs))
 
     _nest(bounds, body)
 

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -42,6 +42,7 @@ from air.dialects.vector import (
     transfer_write,
 )
 
+from ._index import Leaf
 from .types import require_computable, require_signless
 
 __all__ = ["emit_elementwise"]
@@ -285,12 +286,17 @@ def _materialize_index(start):
     constant -- is passed straight through. ``IndexExpr.materialize`` would wrap
     it in an identity ``affine.apply``, which is correct but is one op per index
     per trip; a six-deep nest indexing three buffers is where that shows.
+
+    The shortcut tests for a :class:`Leaf` specifically, not for a single term.
+    A :class:`DerivedLeaf` -- ``x // k`` or ``x % k``, which is a leaf because
+    neither operation is linear -- has no SSA value of its own to pass through;
+    it exists precisely to be materialised, and goes the long way.
     """
     if isinstance(start, int):
         return _index_constant(start)
     if len(start.terms) == 1 and start.const == 0:
         ((leaf, coefficient),) = start.terms.items()
-        if coefficient == 1:
+        if coefficient == 1 and isinstance(leaf, Leaf):
             return leaf.value
     value = start.materialize()
     return _index_constant(value) if isinstance(value, int) else value
@@ -313,11 +319,16 @@ def _offset_key(offset):
     ``IndexExpr`` object instead would read ``gu[i, :]`` twice for one region,
     and keying on ``as_const()`` would collapse ``gu[i, :]`` and ``gu[j, :]``
     onto a shared ``None``, which is the dangerous direction.
+
+    The terms are taken as a ``frozenset`` of the mapping's own items, which
+    leaves each leaf to say what makes it itself: a :class:`Leaf` is one
+    coordinate and compares by identity, while a :class:`DerivedLeaf` compares
+    structurally, so two separately built copies of ``(i + 1) % 4`` are one
+    term. Substituting ``id()`` for that would split them and read twice.
     """
     if isinstance(offset, int):
         return ("k", offset)
-    terms = tuple(sorted((id(leaf), c) for leaf, c in offset.terms.items()))
-    return (terms, offset.const)
+    return (frozenset(offset.terms.items()), offset.const)
 
 
 def _read_key(leaf):

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -257,7 +257,7 @@ class _StridedView:
 
     __slots__ = ()
 
-    def _respan(self, offsets, sizes, strides, logical_sizes):
+    def _respan(self, offsets, sizes, strides, logical_sizes, dropped=None):
         """Build another region of the same thing. Implemented by each slice."""
         raise NotImplementedError
 
@@ -274,7 +274,15 @@ class _StridedView:
         offsets, sizes, strides = _reshape_pattern(
             self.sizes, self.strides, self.offsets, shape
         )
-        return self._respan([coerce_index(o) for o in offsets], sizes, strides, sizes)
+        # A reshaped view has no integer-subscript provenance: its axes are not
+        # the axes that were subscripted, so none of them is dropped.
+        return self._respan(
+            [coerce_index(o) for o in offsets],
+            sizes,
+            strides,
+            sizes,
+            [False] * len(sizes),
+        )
 
     def __getitem__(self, key):
         """A sub-region of this region, subscripted like the original array.
@@ -286,11 +294,12 @@ class _StridedView:
         pick of one (row, block) out of it.
         """
         key = _normalize_key(key, len(self.sizes), "region")
-        offsets, sizes = [], []
+        offsets, sizes, dropped = [], [], []
         for dim, (sub, extent) in enumerate(zip(key, self.sizes)):
-            offset, size = _resolve_subscript(sub, extent, dim)
+            offset, size, drop = _resolve_subscript(sub, extent, dim)
             offsets.append(offset)
             sizes.append(size)
+            dropped.append(drop)
         # Added to this region's own offsets, not scaled: an offset is an index
         # along its axis, which the transfer multiplies by that axis's stride --
         # the same convention Tensor.__getitem__ and Buffer.__getitem__ use, and
@@ -298,7 +307,10 @@ class _StridedView:
         combined = [
             coerce_index(base + off) for base, off in zip(self.offsets, offsets)
         ]
-        return self._respan(combined, sizes, list(self.strides), sizes)
+        # An axis this region had already dropped stays dropped: gu[0][2:6] is
+        # rank 1, as it is in numpy.
+        merged = [was or now for was, now in zip(self.dropped, dropped)]
+        return self._respan(combined, sizes, list(self.strides), sizes, merged)
 
     def transpose(self, *axes):
         """This region walked with its axes permuted.
@@ -316,6 +328,8 @@ class _StridedView:
             _permute(self.sizes, axes),
             _permute(self.strides, axes),
             _permute(self.logical_sizes, axes),
+            # A permutation moves each axis whole, so provenance travels with it.
+            _permute(self.dropped, axes),
         )
 
 
@@ -356,12 +370,13 @@ class Tensor(_Reshapable):
 
     def __getitem__(self, key):
         key = _normalize_key(key, len(self.shape), "tensor")
-        offsets, sizes = [], []
+        offsets, sizes, dropped = [], [], []
         for dim, (sub, extent) in enumerate(zip(key, self.shape)):
-            offset, size = _resolve_subscript(sub, extent, dim)
+            offset, size, drop = _resolve_subscript(sub, extent, dim)
             offsets.append(offset)
             sizes.append(size)
-        return TensorSlice(self, offsets, sizes, list(self.strides))
+            dropped.append(drop)
+        return TensorSlice(self, offsets, sizes, list(self.strides), dropped=dropped)
 
     def _whole_view(self):
         """The whole tensor as a region, for reshape/transpose to work on.
@@ -387,7 +402,15 @@ class Tensor(_Reshapable):
 
 
 def _resolve_subscript(sub, extent, dim):
-    """Turn one subscript into an (offset, static size) pair."""
+    """Turn one subscript into an ``(offset, static size, dropped)`` triple.
+
+    ``dropped`` records that the subscript was a bare integer rather than a
+    slice. numpy's rule: ``a[1, :]`` is rank 1 and ``a[1:2, :]`` is rank 2, both
+    naming the same elements. The axis is *kept* in ``sizes`` either way --
+    dropping it there would change every DMA access pattern in the tree -- so
+    the distinction is carried alongside and consulted only when the region is
+    read or written elementwise. See :attr:`BufferSlice.shape`.
+    """
     if isinstance(sub, slice):
         if sub.step not in (None, 1):
             raise NotImplementedError(
@@ -403,32 +426,57 @@ def _resolve_subscript(sub, extent, dim):
             )
         if size <= 0:
             raise ValueError(f"empty slice along dim {dim} (size {size})")
-        return start, size
+        return start, size, False
     # A bare integer index selects one element and keeps the dimension at 1.
-    return coerce_index(sub), 1
+    return coerce_index(sub), 1, True
 
 
 class TensorSlice(_StridedView):
     """An access pattern into a :class:`Tensor`: offsets, static sizes, strides."""
 
-    __slots__ = ("tensor", "offsets", "sizes", "strides", "logical_sizes", "is_view")
+    __slots__ = (
+        "tensor",
+        "offsets",
+        "sizes",
+        "strides",
+        "logical_sizes",
+        "is_view",
+        "dropped",
+    )
 
     def __init__(
-        self, tensor, offsets, sizes, strides, logical_sizes=None, is_view=False
+        self,
+        tensor,
+        offsets,
+        sizes,
+        strides,
+        logical_sizes=None,
+        is_view=False,
+        dropped=None,
     ):
         self.tensor = tensor
         self.offsets = offsets
         self.sizes = sizes
         self.strides = strides
+        # Per axis: did it come from a bare integer subscript? Carried for
+        # symmetry with BufferSlice -- a tensor is L3 and never read
+        # elementwise, so nothing consults it here.
+        self.dropped = list(dropped) if dropped is not None else [False] * len(sizes)
         # Same two fields, and the same meaning, as on BufferSlice: the region's
         # element shape, and whether reshape/transpose produced it -- which is
         # what tells a transfer to check element counts instead of axes.
         self.logical_sizes = list(sizes if logical_sizes is None else logical_sizes)
         self.is_view = is_view
 
-    def _respan(self, offsets, sizes, strides, logical_sizes):
+    def _respan(self, offsets, sizes, strides, logical_sizes, dropped=None):
         return TensorSlice(
-            self.tensor, offsets, sizes, strides, logical_sizes, is_view=True
+            self.tensor,
+            offsets,
+            sizes,
+            strides,
+            logical_sizes,
+            is_view=True,
+            dropped=dropped,
         )
 
     @property
@@ -484,13 +532,18 @@ class Buffer(_Reshapable):
         if self._is_whole(key):
             self._require_compute("read")
             return BufferExpr.leaf(self)
-        key = _normalize_key(key, len(self.shape), "buffer")
-        offsets, sizes = [], []
+        return self._region(key, "buffer")
+
+    def _region(self, key, what):
+        """The region this subscript names, keeping every axis in ``sizes``."""
+        key = _normalize_key(key, len(self.shape), what)
+        offsets, sizes, dropped = [], [], []
         for dim, (sub, extent) in enumerate(zip(key, self.shape)):
-            offset, size = _resolve_subscript(sub, extent, dim)
+            offset, size, drop = _resolve_subscript(sub, extent, dim)
             offsets.append(offset)
             sizes.append(size)
-        return BufferSlice(self, offsets, sizes, list(self.strides))
+            dropped.append(drop)
+        return BufferSlice(self, offsets, sizes, list(self.strides), dropped=dropped)
 
     def _whole_view(self):
         """The whole buffer as a region, for reshape/transpose to work on.
@@ -508,17 +561,16 @@ class Buffer(_Reshapable):
     # -- writing: this is what triggers emission ----------------------------
 
     def __setitem__(self, key, value):
-        if not self._is_whole(key):
-            raise NotImplementedError(
-                "partial assignment into a buffer is not supported yet; a "
-                "partial subscript names a DMA region, so use "
-                "air.api.ops.load(dst, src[...]) to fill one. air.api handles "
-                "whole-tile elementwise assignment (buf[:] = ...) only"
-            )
         self._require_compute("write")
         from ._emit import emit_elementwise
 
-        emit_elementwise(self, BufferExpr.coerce(value))
+        if self._is_whole(key):
+            emit_elementwise(self, BufferExpr.coerce(value))
+            return
+        # A region of the buffer. numpy's rule decides the shape being written:
+        # out[0:8, :] is a rank-2 block and out[i, j, k] is one element, so a
+        # fully-integer subscript writes a scalar and emits no loop at all.
+        emit_elementwise(self._region(key, "buffer"), BufferExpr.coerce(value))
 
     @staticmethod
     def _is_whole(key):
@@ -548,15 +600,36 @@ class Buffer(_Reshapable):
 class BufferSlice(_StridedView):
     """An access pattern into a :class:`Buffer`, for use as a DMA endpoint."""
 
-    __slots__ = ("buffer", "offsets", "sizes", "strides", "logical_sizes", "is_view")
+    __slots__ = (
+        "buffer",
+        "offsets",
+        "sizes",
+        "strides",
+        "logical_sizes",
+        "is_view",
+        "dropped",
+    )
 
     def __init__(
-        self, buffer, offsets, sizes, strides, logical_sizes=None, is_view=False
+        self,
+        buffer,
+        offsets,
+        sizes,
+        strides,
+        logical_sizes=None,
+        is_view=False,
+        dropped=None,
     ):
         self.buffer = buffer
         self.offsets = offsets
         self.sizes = sizes
         self.strides = strides
+        # Per axis: did it come from a bare integer subscript? An integer
+        # selects one element and numpy drops the axis, so this is what makes
+        # gu[1, :] rank 1 and gu[i, j, k] a scalar. The axis stays in `sizes`
+        # -- transfers are built from those, and a DMA pattern must not move --
+        # so only `shape`, which is the elementwise view, consults it.
+        self.dropped = list(dropped) if dropped is not None else [False] * len(sizes)
         # For a micro-tiled buffer the access pattern's rank and the region's
         # rank differ -- a [1, 1, 32, 32] logical region is walked as a
         # [1, 1, 8, 4, 8, 4] pattern. Transfers are shape-checked against the
@@ -587,14 +660,28 @@ class BufferSlice(_StridedView):
     #
     # Only a region that walks the buffer the way the buffer is laid out
     # qualifies. A reshape or transpose does not -- an index into it is not an
-    # index into the buffer -- and neither does a dynamic offset, which has no
-    # constant to fold into a loop nest built at trace time. Both are rejected
-    # by name below rather than silently mis-indexed. A stepped subscript never
-    # reaches here: __getitem__ refuses step != 1 outright.
+    # index into the buffer -- and it is rejected by name below rather than
+    # silently mis-indexed. A stepped subscript never reaches here:
+    # __getitem__ refuses step != 1 outright.
+    #
+    # A *dynamic* offset does qualify. It did not once: the loop nest is built
+    # at trace time from constant extents, and an offset with no constant had
+    # nothing to fold into the index. But an offset is not an extent -- it is
+    # one more term in the index expression, and `iv + coord` materialises as
+    # the same affine.apply every other index in this DSL goes through. Lifting
+    # it is what lets a kernel walk a window with a loop variable, which is the
+    # shape a convolution has.
 
     @property
     def shape(self):
-        return tuple(self.sizes)
+        """The region's *element* shape: sizes, minus the axes an integer took.
+
+        This is the shape arithmetic sees, and it is numpy's: ``gu[1, :]`` is
+        rank 1, ``gu[1:2, :]`` is rank 2, and ``gu[i, j, k]`` is rank 0 -- a
+        scalar. ``sizes`` keeps every axis, so ``ops.load``/``store`` and the
+        channels are untouched by the distinction.
+        """
+        return tuple(s for s, drop in zip(self.sizes, self.dropped) if not drop)
 
     @property
     def vector_width(self):
@@ -602,8 +689,13 @@ class BufferSlice(_StridedView):
 
     @property
     def base(self):
-        """The region's starting index per axis, as Python ints."""
-        return [o.as_const() for o in self.offsets]
+        """The region's starting index per axis, one per axis of ``sizes``.
+
+        Left as :class:`IndexExpr`, not folded to ints: an offset may be a herd
+        coordinate or a loop variable, which has no constant until it is
+        materialised inside the nest that uses it.
+        """
+        return list(self.offsets)
 
     def _as_leaf(self):
         """This region as an elementwise leaf, or a TypeError saying why not."""
@@ -623,13 +715,6 @@ class BufferSlice(_StridedView):
                 f"{list(self.buffer.strides)}, and an index into the view is "
                 "not an index into the buffer. A plain region -- gu[1, :], or a "
                 "subscript of one -- reads elementwise."
-            )
-        if any(b is None for b in self.base):
-            raise TypeError(
-                f"cannot read {self!r} elementwise: its offset depends on a "
-                "coordinate or loop variable, and the loop nest is built at "
-                "trace time from constant extents. Subscript with a constant "
-                "-- gu[1, :] -- or move the region with air.api.ops.load."
             )
         return BufferExpr.leaf(self)
 
@@ -668,9 +753,15 @@ class BufferSlice(_StridedView):
     def materialize_offsets(self):
         return [o.materialize() for o in self.offsets]
 
-    def _respan(self, offsets, sizes, strides, logical_sizes):
+    def _respan(self, offsets, sizes, strides, logical_sizes, dropped=None):
         return BufferSlice(
-            self.buffer, offsets, sizes, strides, logical_sizes, is_view=True
+            self.buffer,
+            offsets,
+            sizes,
+            strides,
+            logical_sizes,
+            is_view=True,
+            dropped=dropped,
         )
 
     def __repr__(self):

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -307,8 +307,15 @@ class _StridedView:
         combined = [
             coerce_index(base + off) for base, off in zip(self.offsets, offsets)
         ]
-        # An axis this region had already dropped stays dropped: gu[0][2:6] is
-        # rank 1, as it is in numpy.
+        # An axis this region had already dropped stays dropped, whatever the
+        # second subscript spells it as: gu[0, :][0:1, 2:6] is rank 1, not
+        # rank 2, because the 0 in the first subscript already took that axis.
+        #
+        # This is where the analogy with numpy runs out, and deliberately so.
+        # numpy would have made gu[0, :] rank 1 outright, so there would be no
+        # second axis left to subscript; here a region keeps every axis in
+        # `sizes` -- a transfer is built from those -- so it is subscripted at
+        # its full rank and drops accumulate instead.
         merged = [was or now for was, now in zip(self.dropped, dropped)]
         return self._respan(combined, sizes, list(self.strides), sizes, merged)
 

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -90,9 +90,14 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: partial_buffer_write
-# CHECK: NotImplementedError: partial assignment into a buffer is not supported
-@expect(NotImplementedError, "partial_buffer_write")
+# CHECK-LABEL: TEST: partial_buffer_write_of_the_wrong_shape
+# Writing into a region is ordinary now, so what is left to get wrong is the
+# shape: an [8, 64] window cannot be filled from the whole [64, 64] tile. The
+# message is the elementwise one, naming both shapes, because that is exactly
+# what the mistake is -- it stopped being "the DSL cannot do this".
+# CHECK: ValueError: shape mismatch in elementwise assignment
+# CHECK-SAME: destination has shape (8, 64) but operand has shape (64, 64)
+@expect(ValueError, "partial_buffer_write_of_the_wrong_shape")
 def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([64, 64], bf16, scope=h.private())
@@ -811,13 +816,20 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: partial_assignment_into_buffer
-# CHECK: NotImplementedError: partial assignment into a buffer is not supported
-@expect(NotImplementedError, "partial_assignment_into_buffer")
+# CHECK-LABEL: TEST: assignment_into_a_reshaped_view
+# Assigning into a region is ordinary now. What is still refused is assigning
+# through a *view*: a reshape walks the buffer with strides that are not the
+# buffer's, so an index into the view is not an index into the buffer and the
+# store would land somewhere else entirely. Same rule, and the same message,
+# as reading one.
+# CHECK: TypeError: cannot read BufferSlice
+# CHECK-SAME: reshaped or transposed view
+@expect(TypeError, "assignment_into_a_reshaped_view")
 def _():
     def body(h, tx, ty, A, B, C):
         a = air.alloc([32, 32], bf16, scope=h.private())
-        a[0:16, :] = 1.0
+        b = air.alloc([16, 64], bf16, scope=h.private())
+        b[:] = a.reshape(16, 64)[0:16, :] * 2.0
 
     _trace(body)
 
@@ -2206,17 +2218,19 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: elementwise_read_at_a_runtime_offset
-# The loop nest is built at trace time out of constant extents, so a region
-# whose offset is a coordinate has no constant to fold into the index.
-# CHECK: TypeError: cannot read BufferSlice
-# CHECK-SAME: depends on a coordinate or loop variable
-@expect(TypeError, "elementwise_read_at_a_runtime_offset")
+# CHECK-LABEL: TEST: elementwise_read_of_a_stepped_region
+# A region's *offset* may be a coordinate or a loop variable -- it is one more
+# term in the index, and materialises as the affine.apply every other index in
+# this DSL goes through. Its *step* may not: a stride other than 1 is a walk
+# the access pattern cannot describe, and it is refused at the subscript rather
+# than at the read.
+# CHECK: NotImplementedError: strided slicing (step=2) is not supported
+@expect(NotImplementedError, "elementwise_read_of_a_stepped_region")
 def _():
     def body(h, tx, ty, A, B, C):
         gu = air.alloc([2, 64], bf16, scope=h.private())
-        out = air.alloc([1, 64], bf16, scope=h.private())
-        out[:] = gu[tx, :] * 2.0
+        out = air.alloc([1, 32], bf16, scope=h.private())
+        out[:] = gu[tx, 0:64:2] * 2.0
 
     _trace(body)
 

--- a/python/test/api/partial_assign.py
+++ b/python/test/api/partial_assign.py
@@ -125,3 +125,31 @@ def one_row_named_twice_is_one_read():
             dst[i, 0, 0] = src[i, 0, 0] * 2 + src[i, 0, 0]
 
     build(body, (8, 8, 4), i32, vector=0)
+
+
+# CHECK-LABEL: TEST: a_wrapped_offset_is_one_leaf_and_one_read
+# `i % 4` is affine but not linear, so it is carried as a leaf of its own rather
+# than in the coefficient map. Two things follow, and neither is automatic.
+#
+# It has no SSA value to pass through -- it exists to be materialised -- so the
+# shortcut that hands a bare induction variable straight to the load has to test
+# for a real coordinate and not merely for "one term", or it reaches for an
+# attribute that is not there.
+#
+# And it compares *structurally*, not by identity: the two spellings below build
+# separate objects for the same expression. The read cache keys on the terms
+# themselves so that each leaf decides what makes it itself, which is what keeps
+# this one load and one affine.apply rather than two of each.
+# CHECK: affine.apply
+# CHECK-NOT: affine.apply
+# CHECK: %[[V:.*]] = memref.load
+# CHECK-NOT: memref.load
+# CHECK: arith.muli %[[V]]
+# CHECK: arith.addi %{{.*}}, %[[V]]
+@run
+def a_wrapped_offset_is_one_leaf_and_one_read():
+    def body(h, src, dst):
+        for i in air.sequential(4):
+            dst[i, 0, 0] = src[(i + 1) % 4, 0, 0] * 2 + src[(i + 1) % 4, 0, 0]
+
+    build(body, (8, 8, 4), i32, vector=0)

--- a/python/test/api/partial_assign.py
+++ b/python/test/api/partial_assign.py
@@ -1,0 +1,127 @@
+# ./python/test/api/partial_assign.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""Assigning into part of a buffer, down to one element.
+
+``out[:] = ...`` writes a whole tile, and for a long time it was the only thing
+that could be written. That covered every kernel whose arithmetic is
+tile-shaped, and none whose arithmetic is not: a convolution accumulates into
+``out[oh, ow, co]`` from ``in[oh + kh, ow + kw, ci]``, and neither of those is a
+tile. Refusing them pushed such a kernel out of the DSL entirely.
+
+What decides the shape being written is numpy's rule, applied to the subscript:
+an integer selects one element and drops its axis, a slice keeps it. So
+``out[0:8, :]`` is a rank-2 block, ``out[1, :]`` is a row, and ``out[i, j, k]``
+is a scalar -- rank 0, with no axis left to loop over and therefore no loop.
+
+The axis an integer took is still there in the access pattern a transfer builds
+from the same subscript. Dropping it there would change every ``ops.load`` in
+the tree, and the two readings do not conflict: ``staged[tx, 0:m, :]`` names
+`m*k` contiguous elements either way.
+"""
+
+from air import api as air
+from air.api.types import bf16, i32
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def build(body, out_shape, dtype=bf16, vector=None):
+    OUT = air.tensor(list(out_shape), dtype)
+    with air.launch(name="partial") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), name="herd_0", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    kw = {} if vector is None else {"vector": vector}
+                    src = air.alloc([8, 8, 4], dtype, scope=h.private(), **kw)
+                    dst = air.alloc(list(out_shape), dtype, scope=h.private(), **kw)
+                    body(h, src, dst)
+                    air.ops.store(dst, OUT)
+
+    print(launch.build(target="npu1"))
+
+
+# CHECK-LABEL: TEST: one_element_emits_no_loop
+# The rank-0 case, and the reason the whole feature is worth having. Every axis
+# was taken by an integer, so there is nothing to iterate: the assignment is
+# three loads, the arithmetic, and one store, sitting directly in whatever loop
+# the kernel itself wrote. No induction variable of the DSL's own appears.
+# CHECK: scf.for %[[I:.*]] = %{{.*}} to %{{.*}} step
+# CHECK-NOT: scf.for
+# CHECK: memref.load %[[SRC:.*]][%[[I]], %[[I]], %[[I]]]
+# CHECK-NOT: scf.for
+# CHECK: memref.store %{{.*}}, %{{.*}}[%[[I]], %[[I]], %[[I]]]
+@run
+def one_element_emits_no_loop():
+    def body(h, src, dst):
+        for i in air.sequential(4):
+            dst[i, i, i] = src[i, i, i] * 2
+
+    build(body, (8, 8, 4), i32, vector=0)
+
+
+# CHECK-LABEL: TEST: a_shifted_window_reads_at_a_loop_variable
+# The convolution shape: the destination element is fixed by the outer loops
+# and the operand is read one kernel offset along. An offset that is a loop
+# variable used to be refused outright; it is one more term in the index, and
+# reaches the load as the single affine.apply every index in this DSL becomes.
+# CHECK: scf.for %[[I:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: scf.for %[[J:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: %[[SH:.*]] = affine.apply #{{.*}}()[%[[I]]]
+# CHECK: memref.load %{{.*}}[%[[SH]], %[[J]], %{{.*}}]
+# CHECK: memref.store %{{.*}}, %{{.*}}[%[[I]], %[[J]], %{{.*}}]
+@run
+def a_shifted_window_reads_at_a_loop_variable():
+    def body(h, src, dst):
+        for i in air.sequential(4):
+            for j in air.sequential(4):
+                dst[i, j, 0] = src[i + 3, j, 1] + 1
+
+    build(body, (8, 8, 4), i32, vector=0)
+
+
+# CHECK-LABEL: TEST: a_block_keeps_its_axes_and_its_loops
+# A slice subscript keeps the axis, so this is rank 2 and nests twice -- over
+# the region's extents, not the buffer's -- and both ends are shifted by the
+# region's own offset. The innermost axis still vectorises: nothing about
+# writing a sub-block makes the write scalar.
+# CHECK: scf.for %[[I:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: scf.for %[[J:.*]] = %{{.*}} to %{{.*}} step %[[W:.*]] {
+# CHECK: vector.transfer_read
+# CHECK: vector.transfer_write %{{.*}}, %{{.*}}[%{{.*}}, %[[J]]]
+@run
+def a_block_keeps_its_axes_and_its_loops():
+    def body(h, src, dst):
+        dst[2:4, :] = dst[0:2, :] * 2.0
+
+    build(body, (4, 64), bf16)
+
+
+# CHECK-LABEL: TEST: one_row_named_twice_is_one_read
+# The read cache keys on what identifies a read -- which buffer, from where,
+# how much -- and "from where" is now an affine form rather than an integer, so
+# it has to compare structurally. A row named twice under a loop variable is
+# still one read.
+# CHECK: memref.load
+# CHECK-NOT: memref.load
+# CHECK: arith.muli
+# CHECK: arith.addi
+@run
+def one_row_named_twice_is_one_read():
+    def body(h, src, dst):
+        for i in air.sequential(4):
+            dst[i, 0, 0] = src[i, 0, 0] * 2 + src[i, 0, 0]
+
+    build(body, (8, 8, 4), i32, vector=0)

--- a/python/test/api/regions.py
+++ b/python/test/api/regions.py
@@ -18,6 +18,12 @@ What a region reads as is decided by its strides. A region that walks the buffer
 the way the buffer is laid out is an ordinary operand at an offset; a reshape or
 a transpose walks it differently, and an index into one of those is not an index
 into the buffer.
+
+What *rank* it reads as is numpy's rule: an integer subscript selects one
+element and drops its axis, a slice keeps it. ``gu[1, :]`` is a row -- rank 1 --
+so the axis the ``1`` took is never walked and never needs an induction
+variable. The axis is still there in the DMA access pattern, where dropping it
+would change every transfer in the tree; only arithmetic sees the shorter shape.
 """
 
 from air import api as air
@@ -52,15 +58,18 @@ def build(body, out_shape=(1, 16)):
 
 
 # CHECK-LABEL: TEST: two_rows_of_one_buffer
-# The swiglu case. Row 0 is read at the loop's own index and row 1 one further
-# down the same memref -- two reads, not one, and no copy to separate them.
+# The swiglu case. Two reads of one memref, not one read and a copy to separate
+# the halves. Each row is addressed by the constant that named it: the integer
+# subscript dropped that axis, so the nest walks only the row, and neither read
+# needs index arithmetic to reach its own half.
 # CHECK: scf.for %[[I:.*]] = %{{.*}} to %{{.*}} step
 # CHECK: scf.for %[[J:.*]] = %{{.*}} to %{{.*}} step
-# CHECK: %[[R0:.*]] = vector.transfer_read %[[BUF:.*]][%[[I]], %[[J]]]
+# CHECK: %[[ZERO:.*]] = arith.constant 0 : index
+# CHECK: %[[R0:.*]] = vector.transfer_read %[[BUF:.*]][%[[ZERO]], %[[J]]]
 # CHECK: %[[ONE:.*]] = arith.constant 1 : index
-# CHECK: %[[SHIFTED:.*]] = arith.addi %[[I]], %[[ONE]] : index
-# CHECK: %[[R1:.*]] = vector.transfer_read %[[BUF]][%[[SHIFTED]], %[[J]]]
+# CHECK: %[[R1:.*]] = vector.transfer_read %[[BUF]][%[[ONE]], %[[J]]]
 # CHECK: arith.mulf %[[R0]], %[[R1]]
+# CHECK: vector.transfer_write %{{.*}}, %{{.*}}[%[[I]], %[[J]]]
 @run
 def two_rows_of_one_buffer():
     build(lambda packed: packed[0, :] * packed[1, :])
@@ -71,9 +80,15 @@ def two_rows_of_one_buffer():
 # worth pinning because such a region is flagged internally as a "view" -- the
 # same flag reshape and transpose set -- and gating on that flag rather than on
 # the strides rejected this outright.
+#
+# The two subscripts also compose the way numpy composes them: the outer one
+# kept the axis and the inner one took element 1 of it, so the result is row 1
+# of the buffer, read at the constant. Anchored inside the vector loop, because
+# the loop bounds above it are also `arith.constant 1 : index`.
+# CHECK: scf.for
+# CHECK: scf.for %[[J:.*]] = %{{.*}} to %{{.*}} step
 # CHECK: %[[ONE:.*]] = arith.constant 1 : index
-# CHECK: arith.addi %{{.*}}, %[[ONE]]
-# CHECK: vector.transfer_read
+# CHECK: vector.transfer_read %{{.*}}[%[[ONE]], %[[J]]]
 @run
 def a_region_of_a_region():
     build(lambda packed: packed[0:2, :][1, :] * 2.0)


### PR DESCRIPTION
Two conversions and the DSL surface one of them needed.

## `matrix_multiplication/int4_awq`

The int4-AWQ prefill GEMM. All of the arithmetic is already in
`mv_int4_bf16.cc` — dequantisation, the mmul and the f32→bf16 convert are three
hand-written AIE kernels reached through `air.extern` — so what moves onto the
DSL is the schedule and the data movement, which is the whole of what the
predecessor hand-wrote: five `AffineMap`s built expression by expression, and
four `air.dma_memcpy_nd` calls whose sizes and strides were worked out by hand.
Those come out of ordinary subscripts.

Gated on **byte-identical `air.insts.bin`** against the predecessor for six
configurations: both lits, all three extra Makefile targets, and
`m_per_segment=16` — the path only the nightly `llama32_1b_int4` stitchers take,
and so the one PR CI cannot see. `build_module` keeps its positional signature
and still returns a `Module`, verified by importing through
`llms/llama32_1b_int4/gemm_builder.py` rather than by inspection.

Two of the predecessor's L2 staging axes turned out to matter in **opposite**
directions, and only the `m_per_segment` gate showed it. A's leading `herd_m`
axis is load-bearing: at Llama scale the buffer is 512 KB, over what a memtile
holds, and `air-split-l2-memref-for-buffer-constraint` can divide it along a
declared per-core axis but not a fused one. The two *unit* axes are the reverse
— nothing is split along them, their strides were arbitrary because a size-1
axis is never stepped, and asking a reshape to produce one makes it invent a
stride that at M=32 collides with its neighbour's and fuses two per-core puts
into one BD. Declaring only the axes that mean something removes the choice.

## `[air.api]` assignment into a region of a buffer

`out[:] = ...` wrote a whole tile and was the only thing that could be written;
anything narrower raised *"partial assignment into a buffer is not supported
yet"*. That covered every kernel whose arithmetic is tile-shaped and none whose
arithmetic is not — a convolution accumulates into `out[oh, ow, co]` from
`in[oh + kh, ow + kw, ci]`, and neither of those is a tile.

What decides the shape being written is numpy's rule applied to the subscript:
an integer selects one element and drops its axis, a slice keeps it. `out[0:8, :]`
is a rank-2 block, `out[1, :]` is a row, `out[i, j, k]` is a scalar. The rank-0
case needed no new machinery — `_emit_scalar` already emits no loop nest for a
rank-0 destination, so single-element assignment falls out of the region case
rather than sitting beside it.

Two supporting changes, both corrections rather than additions:

* **A region's offset may now be a coordinate or a loop variable.** The old
  refusal reasoned that the nest is built at trace time from constant extents —
  but an offset is not an extent, it is one more term in the index, and
  `iv + coord` materialises as the same `affine.apply` every other index in this
  DSL goes through. That restriction was what made a sliding window
  inexpressible.
* The read cache therefore keys on the offset's **affine structure** rather than
  on `as_const()`. Folding to ints would collapse `gu[i, :]` and `gu[j, :]` onto
  a shared `None` and serve one the other's value.

The dropped-axis mask is **compute-only**: `sizes`, `strides` and
`logical_sizes` are untouched and no transfer consults it, so no access pattern
moves and `_squeeze_units` still depends on `staged[tx, 0:m, :]` being
`[1, m, k]`.

## `conv2d`

The consumer of that surface. No axis of a valid convolution is tile-shaped, so
the kernel is six loops with three loads, a multiply, an add and a store at the
bottom — and that *is* the design. The port is those same six loops, and is
structurally identical to the predecessor, which is the bar it is held to:

| | predecessor | port |
|---|---|---|
| `scf.for` | 9 | 9 |
| `memref.load` / `store` | 3 / 2 | 3 / 2 |
| `air.dma_memcpy_nd` / `air.herd` | 3 / 1 | 3 / 1 |

The predecessor's 3 `arith.addi` are 1 `arith.addi` plus 2 `affine.apply` here —
the same two index shifts, spelled the way every index in this DSL is spelled.

## Gates

* **74-example sweep** against a baseline captured before the first edit:
  exactly two files differ — conv2d, and swiglu, whose `gate_up[0, :]` /
  `gate_up[1, :]` now read at the constants 0 and 1 instead of at `%iv` and
  `%iv + 1` over a trip-count-1 loop. Same elements, one `arith.addi` fewer;
  swiglu's `air.insts.bin` is byte-identical.
* **conv2d on npu1 hardware at seven shapes**, predecessor and port back to back
  in one session: the lit's default `8×8×4×4`, plus `16×16×8×8`, `8×8×1×4`,
  `12×10×4×8`, `5×5×2×2`, `16×16×16×16`, `20×20×8×16`. All pass on both sides.
  The lit is `REQUIRES: ryzen_ai` — device-agnostic — so npu1 is the gate it is
  actually run against.
* api lits 30/30 (including the new `python/test/api/partial_assign.py`),
  `check-air-python` 43, `check-air-mlir` 532 + 7 XFAIL.

Three `errors.py` tests changed meaning and are rewritten rather than deleted:
two partial-assignment refusals become a genuine shape mismatch and a view
destination, and the runtime-offset refusal becomes the stepped-slice one it was
standing in for. `regions.py`'s CHECKs are updated to the better IR.

A note on instruments, since it cost a withdrawn commit: **`air.insts.bin` is
blind to core code** — it captures the host DMA/BD stream. It is the right gate
for int4_awq, whose change is data movement, and the wrong one for conv2d, whose
change is compute; there the op-count table against the predecessor plus
hardware is the gate. An earlier conv2d attempt re-expressed the convolution as
a `linalg.matmul` contraction. It passes at all seven shapes, but it is a
rewrite of the algorithm rather than a port, and moving an example onto the DSL
is not supposed to change the AIR IR it produces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
