### PR TITLE
[air.api] Allow a loop body to allocate; report an out-of-region buffer instead of aborting

### DIFF
--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -96,8 +96,15 @@ def enter_region():
     _BRANCH_DEPTH += 1
 
 
-def exit_region(aborted, what="air.sequential"):
-    """Close it, recording ``what`` if its body did not run to the end."""
+def exit_region(aborted, what):
+    """Close it, recording ``what`` if its body did not run to the end.
+
+    ``what`` is required rather than defaulted. The two constructs are reported
+    differently on purpose -- a loop left early is fixed by restructuring its
+    bounds, a truncated branch arm is not a loop problem at all -- so a caller
+    that forgot to say which one it was would silently mislabel the diagnostic,
+    which is the failure this pair was split up to prevent.
+    """
     global _DEPTH, _BRANCH_DEPTH
     _DEPTH -= 1
     _BRANCH_DEPTH -= 1

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -32,6 +32,7 @@ __all__ = [
     "aborted_regions",
     "enter_region",
     "exit_region",
+    "branch_depth",
 ]
 
 # Names of the regions whose body exited early (break / return / an exception
@@ -45,14 +46,23 @@ __all__ = [
 # problem at all. A single counter reported both as "left a loop early".
 _ABORTED = []
 
-# How many air.sequential bodies are currently open. air.alloc consults this: an
-# allocation inside a loop is freed by the herd after the loop closes, and the
-# dealloc would not be dominated by its alloc.
+# How many nested bodies -- loop or branch -- are currently open.
 _DEPTH = 0
+
+# Of those, how many are ops.branch arms. An allocation inside a loop is fine:
+# free_buffers anchors each dealloc in the block its alloc lives in, so both
+# land inside the loop body, which is what the hand-written kernels write and
+# what lets the pipeline rotate the buffer between trips. A branch arm is the
+# case that is still refused -- see air.alloc.
+_BRANCH_DEPTH = 0
 
 
 def loop_depth():
     return _DEPTH
+
+
+def branch_depth():
+    return _BRANCH_DEPTH
 
 
 def enter_body():
@@ -80,15 +90,17 @@ def aborted_regions():
 
 
 def enter_region():
-    """Count one more open nested region (a loop body, or an ``ops.branch``)."""
-    global _DEPTH
+    """Count one more open ``ops.branch`` arm."""
+    global _DEPTH, _BRANCH_DEPTH
     _DEPTH += 1
+    _BRANCH_DEPTH += 1
 
 
 def exit_region(aborted, what="air.sequential"):
     """Close it, recording ``what`` if its body did not run to the end."""
-    global _DEPTH
+    global _DEPTH, _BRANCH_DEPTH
     _DEPTH -= 1
+    _BRANCH_DEPTH -= 1
     if aborted:
         _ABORTED.append(what)
 

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -614,7 +614,11 @@ def _block_position(block, op):
 
 
 def _lift_into(op, ops_in_home):
-    """``op``'s ancestor that sits directly in ``ops_in_home``, or None.
+    """The index in ``ops_in_home`` of ``op``'s ancestor there, or None.
+
+    An index rather than the op itself because the caller is comparing
+    positions -- it wants the latest use, and ``ops_in_home`` is in block
+    order, so the larger index wins.
 
     Walks outward by parent rather than by block, which matters: ``.block`` on
     a top-level operation does not return None, it trips an assertion inside
@@ -662,7 +666,7 @@ def _last_use_anchor(value, ignore=None):
             raise RuntimeError(
                 f"a buffer is used outside the region it was allocated in: the "
                 f"allocation sits in a {_region_name(home)} that has already "
-                f"closed by the time {op.name} reads it, so it does not reach "
+                f"closed by the time {op.name} uses it, so it does not reach "
                 "that far. Allocate it in the scope where it is read -- above "
                 "the loop or the ops.branch rather than inside one."
             )

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -775,6 +775,10 @@ class SegmentContext:
         # segment, which is what keeps every existing example's operand list
         # byte-identical.
         self.leaves = []
+        # The segment body's own block, bound while the body is traced. It is
+        # the top of the scope a nested herd is emitted into, and so the place
+        # a walk up the block chain has to stop -- see _staged_in_scope.
+        self._entry_block = None
 
     def __enter__(self):
         return self
@@ -902,6 +906,7 @@ class SegmentContext:
             for t, v in zip(tensors, bound[len(outer_leaves) :]):
                 t.value = v
             previous, _CURRENT_SEGMENT = _CURRENT_SEGMENT, segment_self
+            segment_self._entry_block = args[0].owner
             try:
                 fn(*coords)
                 free_buffers(segment_self._buffers)
@@ -927,6 +932,50 @@ def segment(grid=None, name=None):
 def _needs(obj, kernel):
     """Phrase one claim on a herd's single link_with slot, for a conflict."""
     return f"calls {kernel} from {obj!r}" if kernel else f"declares link_with={obj!r}"
+
+
+def _staged_in_scope(segment):
+    """The segment's L2 buffers that are still live where a herd is going.
+
+    ``air.herd`` is IsolatedFromAbove, so an L2 buffer the body reaches has to
+    be passed in as an operand, and the tracer cannot know which ones the body
+    touches until it has run it -- so it passes every one it can.
+
+    "Can" is the point. A buffer allocated inside an ``air.sequential`` at
+    segment scope dies with that loop: by the time a *later* herd is emitted,
+    its ``memref.alloc`` sits in a region that has already been closed, and
+    naming it as an operand is not merely wasteful but ill-formed -- it does not
+    dominate the use. The staging loop in the int4 GEMV is exactly this shape:
+    an L2 tile allocated per trip, filled from L3 and forwarded to L1 over a
+    channel, with a herd beside it that never touches the buffer at all.
+
+    Left unfiltered that operand reaches ``free_buffers``, which walks the
+    buffer's uses out to the block its alloc lives in, finds an ``air.herd``
+    that is not under that block, and walks off the top of the IR -- aborting
+    the process inside MLIR rather than raising. So the filter is what the
+    surrounding comment always claimed: only the ones in scope here.
+    """
+    if segment is None:
+        return []
+    from air.ir import InsertionPoint
+
+    top = segment._entry_block
+    if top is None:
+        return list(segment._buffers)
+    # The blocks whose values are visible here: this one and its ancestors, up
+    # to the segment body. The walk stops there rather than running to the
+    # module, because `block.owner.operation.block` on the top-level block
+    # aborts the process instead of returning None.
+    visible, block = set(), InsertionPoint.current.block
+    while True:
+        visible.add(block)
+        if block == top:
+            break
+        owner = block.owner
+        if owner is None:
+            break
+        block = owner.operation.block
+    return [b for b in segment._buffers if b.value.owner.operation.block in visible]
 
 
 class HerdContext:
@@ -1144,7 +1193,7 @@ class HerdContext:
         # tensors, and the tracer cannot know what the body will touch until it
         # has run it.
         enclosing = current_segment(required=False)
-        staged = list(enclosing._buffers) if enclosing is not None else []
+        staged = _staged_in_scope(enclosing)
         # The herd is the first thing that knows how many of a shared buffer's
         # leading dimensions are cores, so it is where their L1 charge is gated.
         _charge_shared_l1(enclosing, len(self.grid), self.name)
@@ -1330,7 +1379,7 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     from air.dialects.memref import AllocOp
     from air.extras import types as T
 
-    from ._loop import loop_depth
+    from ._loop import branch_depth
 
     if scope is None:
         raise ValueError(
@@ -1379,14 +1428,29 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     # the herd body, so the alloc does not land in the loop the caller is
     # standing in and the dominance argument below does not apply. Only
     # HerdContext.scratch sets it, and it is not part of the public signature.
-    if space == "L1" and loop_depth() and not _hoisted:
+    #
+    # A loop body used to be refused here too, on the grounds that the herd
+    # frees its buffers after the loop has closed. That was not so:
+    # free_buffers anchors each dealloc in the block the *alloc* lives in, so a
+    # buffer allocated in a loop is already released inside that loop, which is
+    # both dominated and what the hand-written kernels write. The refusal cost
+    # real IR -- hoisting the int4 GEMV's per-trip L1 tiles above their loop
+    # gives the pipeline one buffer to rotate instead of a fresh one per trip,
+    # which is the ping-pong the kernel is built around.
+    #
+    # A branch arm is still refused. Both arms of an ops.branch write to the
+    # same enclosing scope, so which alloc a later use refers to is a question
+    # the tracer cannot answer, and the failure would be a silently wrong
+    # buffer rather than a verifier error.
+    if space == "L1" and branch_depth() and not _hoisted:
         raise NotImplementedError(
-            "air.alloc inside an air.sequential or ops.branch body is not "
-            "supported: the herd frees its buffers once the body is finished, "
-            "which is outside the region, so the dealloc would not be dominated "
-            "by its alloc. Hoist the allocation above it -- a loop reuses the "
-            "buffer across trips, which is what a loop is for, and a buffer only "
-            "some cores read still costs the same L1 on every core."
+            "air.alloc inside an ops.branch body is not supported: the arm is a "
+            "region the buffer cannot outlive, so a use after the branch would "
+            "not be dominated by its alloc. Hoist the allocation above the "
+            "branch -- both arms then name the same buffer, which is what a "
+            "branch that fills a tile two different ways means. Allocating "
+            "inside an air.sequential is fine: the buffer is freed inside that "
+            "loop."
         )
     # 0 is meaningful -- it selects the scalar path. Negative is not, and it
     # would otherwise pass a caller's own `tile % width` guard unnoticed, since

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -613,6 +613,26 @@ def _block_position(block, op):
     raise AssertionError("operation is not in the block it reports as its parent")
 
 
+def _lift_into(op, ops_in_home):
+    """``op``'s ancestor that sits directly in ``ops_in_home``, or None.
+
+    Walks outward by parent rather than by block, which matters: ``.block`` on
+    a top-level operation does not return None, it trips an assertion inside
+    MLIR and takes the process with it. Anything that walks past the op it was
+    looking for therefore has to notice by running out of parents, not by
+    asking each one where it lives.
+    """
+    while op is not None:
+        for i, other in enumerate(ops_in_home):
+            if other == op:
+                return i
+        try:
+            op = op.parent
+        except (ValueError, IndexError):
+            return None
+    return None
+
+
 def _last_use_anchor(value, ignore=None):
     """The op in ``value``'s own block after which ``value`` is no longer read.
 
@@ -620,20 +640,41 @@ def _last_use_anchor(value, ignore=None):
     is finished, so each use is walked out to the ancestor that sits directly
     in the block the alloc was emitted into. ``ignore`` drops one op from the
     scan, so that a dealloc can ask where the last *other* use was.
+
+    A use that is *not* under that block has no such ancestor, and this is
+    where that has to be caught. The buffer would be read where its allocation
+    does not reach -- a loop or a branch arm it was declared in has closed --
+    and the walk would otherwise run off the top of the IR and abort. Both
+    known instances were real: an L2 buffer allocated in a staging loop and
+    handed to a later herd, and an L1 buffer allocated in one arm of an
+    ops.branch and read after the branch.
     """
     home = value.owner.operation.block
+    ops_in_home = [o.operation for o in home.operations]
     anchor = value.owner.operation
     best = _block_position(home, anchor)
     for use in value.uses:
         op = use.owner.operation
         if ignore is not None and op == ignore:
             continue
-        while op.block != home:
-            op = op.parent
-        position = _block_position(home, op)
+        position = _lift_into(op, ops_in_home)
+        if position is None:
+            raise RuntimeError(
+                f"a buffer is used outside the region it was allocated in: the "
+                f"allocation sits in a {_region_name(home)} that has already "
+                f"closed by the time {op.name} reads it, so it does not reach "
+                "that far. Allocate it in the scope where it is read -- above "
+                "the loop or the ops.branch rather than inside one."
+            )
         if position > best:
-            anchor, best = op, position
+            anchor, best = ops_in_home[position], position
     return home, anchor
+
+
+def _region_name(block):
+    """Name the construct owning ``block``, for a diagnostic."""
+    owner = block.owner
+    return owner.name if owner is not None else "region"
 
 
 def free_buffers(buffers):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -563,19 +563,6 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: alloc_inside_sequential
-# The herd frees its buffers after the body, which is outside the loop, so the
-# dealloc would not be dominated by its alloc.
-# CHECK: NotImplementedError: air.alloc inside an air.sequential or ops.branch body
-@expect(NotImplementedError, "alloc_inside_sequential")
-def _():
-    def body(h, tx, ty, A, B, C):
-        for _ in air.sequential(0, 64, 32):
-            air.alloc([32, 32], bf16, scope=h.private())
-
-    _trace(body)
-
-
 # CHECK-LABEL: TEST: break_out_of_sequential
 # An air.sequential body is traced once and stands for every trip, so breaking out
 # truncates all of them rather than shortening the loop.
@@ -2098,10 +2085,11 @@ def _():
 
 
 # CHECK-LABEL: TEST: alloc_inside_a_branch
-# The herd frees its buffers after the body, outside the region, so the dealloc
-# would not be dominated by the alloc. It is also the wrong instinct: L1 is
-# charged per core whether or not that core's branch runs.
-# CHECK: NotImplementedError: air.alloc inside an air.sequential or ops.branch body
+# The buffer cannot outlive the arm, so a use after the branch would not be
+# dominated by the alloc. It is also the wrong instinct: L1 is charged per core
+# whether or not that core's branch runs. A loop body, by contrast, is allowed:
+# its dealloc lands inside the loop beside the alloc.
+# CHECK: NotImplementedError: air.alloc inside an ops.branch body
 @expect(NotImplementedError, "alloc_inside_a_branch")
 def _():
     def body(h, tx, ty, A, B, C):

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -578,6 +578,27 @@ def _():
     _trace(body)
 
 
+# CHECK-LABEL: TEST: buffer_read_after_its_loop_closed
+# A buffer allocated in a loop does not reach past it. Placement walks each use
+# out to the block the alloc lives in, and a use that is not under that block
+# has no such ancestor -- which used to walk off the top of the IR and abort the
+# process inside MLIR rather than report anything. Both real instances were this
+# shape: an L2 staging buffer handed to a later herd, and an L1 buffer allocated
+# in one arm of an ops.branch and read after it.
+# CHECK: RuntimeError: a buffer is used outside the region it was allocated in
+@expect(RuntimeError, "buffer_read_after_its_loop_closed")
+def _():
+    def body(h, tx, ty, A, B, C):
+        escaped = None
+        for _ in air.sequential(0, 64, 32):
+            escaped = air.alloc([32, 32], bf16, scope=h.private())
+            escaped[:] = 1.0
+        # The loop has closed; the allocation does not reach this far.
+        escaped[:] = escaped[:] + 1.0
+
+    _trace(body)
+
+
 # CHECK-LABEL: TEST: dot_alpha_unimplemented
 # CHECK: NotImplementedError: air.api.ops.dot(alpha=...) is not implemented
 @expect(NotImplementedError, "dot_alpha_unimplemented")

--- a/python/test/api/lifetime.py
+++ b/python/test/api/lifetime.py
@@ -117,3 +117,87 @@ def use_inside_a_loop_holds_it():
                         air.ops.store(b, B[i : i + 1, 0:N])
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: allocated_in_a_loop_is_freed_in_that_loop
+# The mirror of the test above, and the reason a loop body may allocate at all.
+# Placement is anchored on the block the *alloc* is in, so a per-trip buffer is
+# released inside the loop rather than after it -- which is what the pipeline
+# needs in order to rotate a fresh buffer per trip instead of reusing one.
+# Both the alloc and the dealloc are inside the scf.for, in that order.
+# CHECK: scf.for
+# CHECK: memref.alloc
+# CHECK: memref.dealloc
+@run
+def allocated_in_a_loop_is_freed_in_that_loop():
+    A = air.tensor([N, N], i32)
+    B = air.tensor([N, N], i32)
+
+    with air.launch(name="per_trip") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    b = air.alloc([N], i32, scope=h.private(), vector=0)
+                    for i in air.sequential(0, N):
+                        a = air.alloc([N], i32, scope=h.private())
+                        air.ops.load(a, A[i : i + 1, 0:N])
+                        b[:] = a[:] + 1
+                        air.ops.store(b, B[i : i + 1, 0:N])
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: an_l2_buffer_in_a_loop_is_not_a_herd_operand
+# air.herd is IsolatedFromAbove, so the tracer passes it every L2 buffer the
+# enclosing segment has -- but only the ones actually in scope where the herd
+# is going. A buffer allocated inside an air.sequential is not: its alloc sits
+# in a region that closed before the herd was emitted, so naming it as an
+# operand does not dominate the use. It also used to abort the process, in
+# free_buffers, rather than raise.
+#
+# The staging buffer is allocated and freed inside the loop, and the herd's
+# operand list names the two L3 tensors and nothing else -- in particular not
+# the memory-space-1 buffer the loop above it just finished with.
+# CHECK: air.segment
+# CHECK: scf.for
+# CHECK: memref.alloc() : memref<8xi32, 1
+# CHECK: memref.dealloc
+# CHECK: air.herd{{.*}}args({{[^)]*}}) : memref<8x8xi32>, memref<8x8xi32> {
+@run
+def an_l2_buffer_in_a_loop_is_not_a_herd_operand():
+    A = air.tensor([N, N], i32)
+    B = air.tensor([N, N], i32)
+    stage = air.channel("stage", size=[1])
+    drain = air.channel("drain", size=[1])
+
+    with air.launch(name="staged") as launch:
+
+        @launch.body
+        def _():
+            for _ in air.sequential(0, N):
+                stage.put(A[0:1, 0:N])
+
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    for _ in air.sequential(0, N):
+                        l2 = air.alloc([N], i32, scope=seg.private())
+                        stage.get(l2)
+                        drain.put(l2)
+
+                    with air.herd([range(1)], name="h", shape=(1,)) as h:
+
+                        @h.body
+                        def _(tx):
+                            l1 = air.alloc([N], i32, scope=h.private(), vector=0)
+                            for _ in air.sequential(0, N):
+                                drain.get(l1)
+                                l1[:] = l1[:] + 1
+                                air.ops.store(l1, B[0:1, 0:N])
+
+    print(launch.mlir())


### PR DESCRIPTION
Two pre-existing bugs and a diagnostic, all found while converting the int4 GEMV
and confirmed against `main`. No example changes; no IR changes.

### 1. `air.alloc` refused a loop body for a reason that did not hold

The guard said the herd frees its buffers after the body, so a dealloc for a
buffer allocated in a loop would not be dominated by its alloc. That is not what
happens: `free_buffers` anchors each dealloc in the block the *alloc* lives in,
so a per-trip buffer was always going to be released inside its own loop.

The refusal cost real IR. Hoisting a kernel's per-trip L1 tiles above their loop
hands the pipeline one buffer to rotate instead of a fresh one per trip — the
ping-pong those kernels are built around.

A branch arm stays refused. Only half of that refusal is earned, and the
measurement is in the commit message so the next person does not have to redo
it: an allocation *contained* in an arm behaves correctly if allowed, while one
that *escapes* the arm needs the diagnostic in (3). Lifting it belongs with the
example that needs it.

### 2. A herd was handed L2 buffers that were already dead — and it aborted

`air.herd` is IsolatedFromAbove, so the tracer passes it every L2 buffer the
enclosing segment has. The comment said "every live one"; the code said every
one. A buffer allocated inside an `air.sequential` is not live at a herd emitted
after that loop — its alloc sits in a region that has closed — and naming it as
an operand does not dominate the use.

### 3. That failure arrived as a process abort, not an error

Both of the above reached `_last_use_anchor`, which walked each use outward
asking `.block` on the way up. On a top-level operation that is not a query — it
trips an assertion inside MLIR and takes the process with it:

```
python3.12: IRCore.cpp:1199: ... Assertion `!mlirBlockIsNull(block)' failed.
```

with no Python frame naming the buffer, the region, or the DSL call that built
it. `_lift_into` now walks by parent rather than by block, so running past the
target is noticed by running out of parents, and the caller raises:

```
a buffer is used outside the region it was allocated in: the allocation sits in
a scf.if that has already closed by the time memref.load reads it
```

### Verification

- **Zero drift**: all 72 sweepable converted examples emit byte-identical
  modules before and after, with the same single pre-existing failure.
- api lits 30/30, full python suite 43/43, `black` clean, `pyflakes` set
  unchanged from baseline.
- Every new test was mutation-checked in both directions: reverting the
  `_staged_in_scope` filter and restoring the loop-wide refusal each fail their
  own test, and both former abort paths were re-run to confirm they now raise.
- Re-gated after rebasing onto `main` post-#1931; wheel pin verified unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)