### PR TITLE
[AIRMiscPasses] Size a split channel offset's affine map from its expression

### DIFF
--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1654,35 +1654,49 @@ FailureOr<Value> tileChannelOpByFactor(
     // (potentially overlapping access pattern).
     affine::AffineApplyOp newApplyOp = nullptr;
 
-    // Methods to compose affine expression for offset at each split.
-    auto composeAffineExprWithOffsetAndAffineMap = [](AffineExpr originalExpr,
-                                                      AffineMap affineMap,
-                                                      std::optional<int> offset,
-                                                      MLIRContext *ctx) {
-      int const_in = offset ? *offset : 0;
-      if (affineMap) {
-        auto original_map = affineMap;
-        if (original_map.getNumSymbols() > 0) {
-          original_map =
-              original_map.replace(getAffineSymbolExpr(0, ctx),
-                                   getAffineConstantExpr(const_in, ctx), 0, 1);
-        } else if (original_map.getNumDims() > 0) {
-          original_map =
-              original_map.replace(getAffineDimExpr(0, ctx),
-                                   getAffineConstantExpr(const_in, ctx), 1, 0);
-        }
-        AffineExpr add = originalExpr + original_map.getResult(0);
-        return AffineMap::get(0, 1, add);
-      }
-      AffineExpr add = originalExpr + getAffineConstantExpr(const_in, ctx);
-      return AffineMap::get(0, 1, add);
+    // The composed expression inherits the ORIGINAL offset apply's symbols, and
+    // that is not always exactly one: a launch offset built from two induction
+    // variables (e.g. row = iv * tile + batch * rows_per_batch) carries two.
+    // Size the map from the expression rather than assuming a single symbol,
+    // or AffineMap::get asserts on an invalid map.
+    auto mapForExpr = [](AffineExpr e, MLIRContext *ctx) {
+      unsigned numSyms = 0;
+      e.walk([&](AffineExpr sub) {
+        if (auto sym = dyn_cast<AffineSymbolExpr>(sub))
+          numSyms = std::max(numSyms, sym.getPosition() + 1);
+      });
+      return AffineMap::get(0, std::max(numSyms, 1u), e);
     };
-    auto composeAffineExprFromSizes = [](AffineExpr originalExpr,
-                                         int originalMemrefSize, int factor,
-                                         int i) {
+
+    // Methods to compose affine expression for offset at each split.
+    auto composeAffineExprWithOffsetAndAffineMap =
+        [mapForExpr](AffineExpr originalExpr, AffineMap affineMap,
+                     std::optional<int> offset, MLIRContext *ctx) {
+          int const_in = offset ? *offset : 0;
+          if (affineMap) {
+            auto original_map = affineMap;
+            if (original_map.getNumSymbols() > 0) {
+              original_map = original_map.replace(
+                  getAffineSymbolExpr(0, ctx),
+                  getAffineConstantExpr(const_in, ctx), 0, 1);
+            } else if (original_map.getNumDims() > 0) {
+              original_map = original_map.replace(
+                  getAffineDimExpr(0, ctx),
+                  getAffineConstantExpr(const_in, ctx), 1, 0);
+            }
+            AffineExpr add = originalExpr + original_map.getResult(0);
+            return mapForExpr(add, ctx);
+          }
+          AffineExpr add = originalExpr + getAffineConstantExpr(const_in, ctx);
+          return mapForExpr(add, ctx);
+        };
+    auto composeAffineExprFromSizes = [mapForExpr](AffineExpr originalExpr,
+                                                   int originalMemrefSize,
+                                                   int factor, int i,
+                                                   MLIRContext *ctx) {
       AffineExpr add =
           originalExpr + i * llvm::divideCeilSigned(originalMemrefSize, factor);
-      return AffineMap::get(0, 1, add);
+      return mapForExpr(add, ctx);
     };
 
     AffineMap map;
@@ -1694,7 +1708,7 @@ FailureOr<Value> tileChannelOpByFactor(
           originalExpr, splitInfoAffineMap, splitInfoSplitOffset, ctx);
     } else
       map = composeAffineExprFromSizes(originalExpr, originalMemrefSize, factor,
-                                       i);
+                                       i, ctx);
     newApplyOp = affine::AffineApplyOp::create(rewriter, loc, map,
                                                originalApplyOperands);
     if (affineApplyOp)

--- a/mlir/lib/Transform/AIRMiscPasses.cpp
+++ b/mlir/lib/Transform/AIRMiscPasses.cpp
@@ -1659,7 +1659,8 @@ FailureOr<Value> tileChannelOpByFactor(
     // variables (e.g. row = iv * tile + batch * rows_per_batch) carries two.
     // Size the map from the expression rather than assuming a single symbol,
     // or AffineMap::get asserts on an invalid map.
-    auto mapForExpr = [](AffineExpr e, MLIRContext *ctx) {
+    // AffineMap::get takes its context from the expression, so no ctx here.
+    auto mapForExpr = [](AffineExpr e) {
       unsigned numSyms = 0;
       e.walk([&](AffineExpr sub) {
         if (auto sym = dyn_cast<AffineSymbolExpr>(sub))
@@ -1685,18 +1686,17 @@ FailureOr<Value> tileChannelOpByFactor(
                   getAffineConstantExpr(const_in, ctx), 1, 0);
             }
             AffineExpr add = originalExpr + original_map.getResult(0);
-            return mapForExpr(add, ctx);
+            return mapForExpr(add);
           }
           AffineExpr add = originalExpr + getAffineConstantExpr(const_in, ctx);
-          return mapForExpr(add, ctx);
+          return mapForExpr(add);
         };
     auto composeAffineExprFromSizes = [mapForExpr](AffineExpr originalExpr,
                                                    int originalMemrefSize,
-                                                   int factor, int i,
-                                                   MLIRContext *ctx) {
+                                                   int factor, int i) {
       AffineExpr add =
           originalExpr + i * llvm::divideCeilSigned(originalMemrefSize, factor);
-      return mapForExpr(add, ctx);
+      return mapForExpr(add);
     };
 
     AffineMap map;
@@ -1708,7 +1708,7 @@ FailureOr<Value> tileChannelOpByFactor(
           originalExpr, splitInfoAffineMap, splitInfoSplitOffset, ctx);
     } else
       map = composeAffineExprFromSizes(originalExpr, originalMemrefSize, factor,
-                                       i, ctx);
+                                       i);
     newApplyOp = affine::AffineApplyOp::create(rewriter, loc, map,
                                                originalApplyOperands);
     if (affineApplyOp)

--- a/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
+++ b/mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir
@@ -2495,3 +2495,95 @@ func.func @test_preserve_channel_type(%arg0: memref<512x1024xbf16>, %arg1: memre
   }
   return
 }
+
+// -----
+
+// A split channel offset composed from a TWO-symbol affine.apply. The offset on
+// the split dimension is `%arg3 * 256 + %arg4 * 8`, which is what a launch axis
+// built from two induction variables produces (e.g. a batched image axis added
+// to the tile row). tileChannelOpByFactor used to wrap the composed expression
+// in a hardcoded one-symbol AffineMap, which asserts on willBeValidAffineMap.
+
+// CHECK: [[$M0:#map[0-9]*]] = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 8)>
+// CHECK: [[$M1:#map[0-9]+]] = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 8 + 64)>
+// CHECK: [[$M2:#map[0-9]+]] = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 8 + 128)>
+// CHECK: [[$M3:#map[0-9]+]] = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 8 + 192)>
+// CHECK-LABEL: func.func @test_two_symbol_split_offset
+// CHECK: affine.apply [[$M0]]()
+// CHECK: affine.apply [[$M1]]()
+// CHECK: affine.apply [[$M2]]()
+// CHECK: affine.apply [[$M3]]()
+// CHECK-COUNT-4: memref.alloc() : memref<64x256xbf16, 1 : i32>
+
+#map = affine_map<()[s0, s1] -> (s0 * 256 + s1 * 8)>
+#mapc = affine_map<()[s0] -> (s0 * 256)>
+#map1 = affine_map<()[s0] -> (s0 * 64)>
+air.channel @channel_1 [1, 1]
+air.channel @channel_0 [4, 4]
+func.func @test_two_symbol_split_offset(%arg0: memref<512x1024xbf16>, %arg1: memref<1024x512xbf16>, %arg2: memref<512x512xbf16>) {
+  %c2 = arith.constant 2 : index
+  %0 = air.launch async (%arg3, %arg4) in (%arg5=%c2, %arg6=%c2) args(%arg7=%arg2) : memref<512x512xbf16> attributes {id = 1 : i32} {
+    %c512 = arith.constant 512 : index
+    %c1 = arith.constant 1 : index
+    %c256 = arith.constant 256 : index
+    %async_token, %results = air.execute -> (index) {
+      %3 = affine.apply #map()[%arg3, %arg4]
+      air.execute_terminator %3 : index
+    }
+    %async_token_0, %results_1 = air.execute -> (index) {
+      %3 = affine.apply #mapc()[%arg4]
+      air.execute_terminator %3 : index
+    }
+    %1 = air.channel.get async [%async_token, %async_token_0]  @channel_1[] (%arg7[%results, %results_1] [%c256, %c256] [%c512, %c1]) {id = 3 : i32} : (memref<512x512xbf16>)
+    %2 = air.segment @segment_0 async  {
+      %c64 = arith.constant 64 : index
+      %c1_2 = arith.constant 1 : index
+      %c4 = arith.constant 4 : index
+      %c0 = arith.constant 0 : index
+      %c256_3 = arith.constant 256 : index
+      %3 = air.wait_all async 
+      %4 = air.wait_all async 
+      %async_token_4, %results_5 = air.execute -> (memref<256x256xbf16, 1 : i32>) {
+        %alloc = memref.alloc() : memref<256x256xbf16, 1 : i32>
+        air.execute_terminator %alloc : memref<256x256xbf16, 1 : i32>
+      }
+      %5 = scf.parallel (%arg8, %arg9) = (%c0, %c0) to (%c4, %c4) step (%c1_2, %c1_2) init (%async_token_4) -> !air.async.token {
+        %async_token_7, %results_8 = air.execute -> (index) {
+          %9 = affine.apply #map1()[%arg8]
+          air.execute_terminator %9 : index
+        }
+        %async_token_9, %results_10 = air.execute -> (index) {
+          %9 = affine.apply #map1()[%arg9]
+          air.execute_terminator %9 : index
+        }
+        %8 = air.channel.get async [%async_token_4, %async_token_9, %async_token_7]  @channel_0[%arg8, %arg9] (%results_5[%results_8, %results_10] [%c64, %c64] [%c256_3, %c1_2]) {id = 24 : i32} : (memref<256x256xbf16, 1 : i32>)
+        scf.reduce(%8 : !air.async.token) {
+        ^bb0(%arg10: !air.async.token, %arg11: !air.async.token):
+          %9 = air.wait_all async [%arg10, %arg11] 
+          scf.reduce.return %9 : !air.async.token
+        }
+      }
+      %6 = air.herd @herd_0 async [%async_token_4]  tile (%arg8, %arg9) in (%arg10=%c4, %arg11=%c4) attributes {id = 3 : i32, x_loc = 0 : i64, y_loc = 2 : i64} {
+        %c64_7 = arith.constant 64 : index
+        %c256_8 = arith.constant 256 : index
+        %c4_9 = arith.constant 4 : index
+        %c16 = arith.constant 16 : index
+        %c1_10 = arith.constant 1 : index
+        %c0_11 = arith.constant 0 : index
+        %async_token_12, %results_13 = air.execute -> (memref<16x16x4x4xbf16, 2 : i32>) {
+          %alloc = memref.alloc() : memref<16x16x4x4xbf16, 2 : i32>
+          air.execute_terminator %alloc : memref<16x16x4x4xbf16, 2 : i32>
+        }
+        %8 = air.channel.put async [%async_token_12]  @channel_0[%arg8, %arg9] (%results_13[%c0_11, %c0_11, %c0_11] [%c64_7, %c16, %c4_9] [%c4_9, %c256_8, %c1_10]) {id = 41 : i32} : (memref<16x16x4x4xbf16, 2 : i32>)
+        %async_token_14 = air.execute [%8] {
+          memref.dealloc %results_13 : memref<16x16x4x4xbf16, 2 : i32>
+        }
+      }
+      %7 = air.channel.put async [%3, %4, %6]  @channel_1[] (%results_5[] [] []) {id = 42 : i32} : (memref<256x256xbf16, 1 : i32>)
+      %async_token_6 = air.execute [%7] {
+        memref.dealloc %results_5 : memref<256x256xbf16, 1 : i32>
+      }
+    }
+  }
+  return
+}


### PR DESCRIPTION
`tileChannelOpByFactor` composes the per-split offset expression from whatever
`affine.apply` already drives the channel's offset on the split dimension, then
wraps it with a hardcoded `AffineMap::get(0, 1, add)`.

That is only correct when the original apply has exactly one symbol. An offset
built from two induction variables — `row = iv * tile + batch * rows_per_batch`,
which is what a batched launch axis produces — carries two, so the composed
expression references `s1` while the map declares one symbol and
`AffineMap::get` asserts on `willBeValidAffineMap`.

Derive the symbol count by walking the composed expression instead.
Single-symbol offsets, which is every case in tree before this patch, produce
the same map as before.

## Testing

New case `@test_two_symbol_split_offset` in
`mlir/test/Transform/AIRMiscPasses/air_split_l2_memref.mlir`: `test0` with the
split-dimension offset changed from `#map()[%arg3]` to
`#map()[%arg3, %arg4]`. It asserts on the parent commit and produces the
expected four two-symbol maps here.

`ninja check-air-mlir`: 530 passed, 7 expectedly failed — unchanged.

Found while giving FlashAttention a batched image launch axis.