### PR TITLE
[air.api] flash_attention/dataflow_based, and the three features it needs

### DIFF
--- a/programming_examples/flash_attention/dataflow_based/attn.py
+++ b/programming_examples/flash_attention/dataflow_based/attn.py
@@ -72,6 +72,25 @@ def build_module(
     """
     mmul_m, mmul_k, mmul_n = [8, 8, 8] if arch == "aie2p" else [4, 8, 4]
 
+    if dv != dk:
+        # Refused rather than attempted. The two are separate parameters and
+        # the shapes below name whichever one they carry, but one buffer is
+        # genuinely dimensioned by both: v_l1 is [dk, lkp], the shape the
+        # matmul kernel's signature fixes, holding a [lkp, dv] tile that the
+        # DMA has already reordered. Splitting dk from dv means reshaping that
+        # and re-deriving the packed access pattern around it, which is a
+        # change to the kernel contract rather than to this file.
+        #
+        # The predecessor took dv too and used it for nothing: every one of its
+        # types was built from dk, including memref_input_v_lk_dv, so dv != dk
+        # produced a kernel whose V operand had the wrong shape. Failing here
+        # says so, instead of surfacing as a slice out of bounds during tracing.
+        raise ValueError(
+            f"dk={dk} and dv={dv} must be equal; this kernel has only ever been "
+            "built and run with dv == dk, and its V tile is shaped by the "
+            "matmul kernel's signature rather than by dv"
+        )
+
     ncs = num_cascade_stages
     cps = (lk // lkp) // ncs  # K/V chunks each column walks
     tq = lq
@@ -83,7 +102,7 @@ def build_module(
     # host passes one. The pipeline folds it into G before the max, so nothing
     # in the body reads it while the mask is zero.
     air.tensor([lq, lk], bf16)  # the mask, read only by the pipeline (see above)
-    OUT = air.tensor([lq, dk], bf16)
+    OUT = air.tensor([lq, dv], bf16)
 
     # Q and K share the L3->L2 bundle: they are never in flight together, Q
     # being staged once before the loop and K once per trip.
@@ -163,14 +182,14 @@ def build_module(
                         air.alloc([lkp, dv], bf16, scope=seg.private())
                         for _ in range(ncs)
                     ]
-                    result_l2 = air.alloc([lq, dk], bf16, scope=seg.private())
+                    result_l2 = air.alloc([lq, dv], bf16, scope=seg.private())
 
                     # The running state of the online softmax. per_core, not
                     # shared: each column keeps its own whole copy, and it has
                     # to outlive the herd that writes it.
                     up = air.alloc([tq, 1], bf16, scope=seg.per_core())
                     sp = air.alloc([tq, 1], bf16, scope=seg.per_core())
-                    Gp = air.alloc([tq, dk], bf16, scope=seg.per_core())
+                    Gp = air.alloc([tq, dv], bf16, scope=seg.per_core())
                     a_l1 = air.alloc([tq, dk], bf16, scope=seg.per_core())
 
                     for c in range(ncs):
@@ -296,7 +315,7 @@ def build_module(
                                 )
                                 air.dealloc(g_copy)
 
-                                gv = air.alloc([tq, dk], bf16, scope=h_soft.private())
+                                gv = air.alloc([tq, dv], bf16, scope=h_soft.private())
                                 gv_back.get(gv, indices=[tx, ty])
                                 accum_gp(gv, Gp)
                                 air.dealloc(gv)
@@ -322,7 +341,7 @@ def build_module(
                             def _(tx, ty):
                                 v_l1 = air.alloc([dk, lkp], bf16, scope=h_gv.private())
                                 g = air.alloc([tq * lkp], bf16, scope=h_gv.private())
-                                acc = air.alloc([tq, dk], bf16, scope=h_gv.private())
+                                acc = air.alloc([tq, dv], bf16, scope=h_gv.private())
                                 zero_gp(acc)
                                 g_to_matmul.get(g, indices=[tx, ty])
                                 l2_v.get(v_l1, indices=[tx, ty])
@@ -358,7 +377,7 @@ def build_module(
                                 and only one of them runs on any given core.
                                 """
                                 gp_in = air.alloc(
-                                    [tq, dk], bf16, scope=h_merge.private()
+                                    [tq, dv], bf16, scope=h_merge.private()
                                 )
                                 up_in = air.alloc(
                                     [tq, 1], bf16, scope=h_merge.private()

--- a/programming_examples/flash_attention/dataflow_based/attn.py
+++ b/programming_examples/flash_attention/dataflow_based/attn.py
@@ -1,25 +1,53 @@
 # Copyright (C) 2025, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-import argparse
-from math import cos, sin, sqrt, exp
+"""Flash attention as a dataflow pipeline across a cascade of cores.
 
-import air
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp, DeallocOp, load, store
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.dialects import scf, affine, arith
-from air.backend.xrt_runner import XRTRunner, type_mapper
-from air.backend.xrt import XRTBackend
+The kernel is online softmax, split over ``num_cascade_stages`` columns. Each
+column walks its own share of the K/V sequence and keeps three running values --
+a per-row maximum ``up``, a per-row sum ``sp``, and the unnormalised output
+``Gp``. When the sequence is exhausted the columns merge pairwise down the
+cascade, rescaling each side by ``exp(local_max - merged_max)``, and column 0
+divides through and writes the result out.
+
+Three things here are worth reading as DSL rather than as attention:
+
+* **``seg.per_core()``** is what lets ``up``/``sp``/``Gp`` survive from one herd
+  to the next. They are L1, but a buffer allocated in a herd body dies with that
+  body, and these are written by three separate herds. Unlike ``seg.shared()``
+  they are not divided between the cores -- every core keeps its own whole copy.
+* **The micro-tiled L2->L1 transfers are one idiom, not three.** Q, K and V each
+  become ``reshape(outer_m, mm, outer_k, kk).transpose(2, 0, 1, 3)``; only which
+  extents play which role differs. See ``_packed``.
+* **The cascade select is nested ``ops.branch`` on the column coordinate.** The
+  predecessor wrote one ``affine.if`` over a two-constraint ``IntegerSet``;
+  ``air-to-aie`` specialises both forms away once the herd is unrolled and the
+  coordinate is a literal (``SpecializeScfIfPattern`` sits beside
+  ``SpecializeAffineIfPattern``), so the cores see the same code either way.
+"""
+
+import argparse
+from math import sqrt
+
+import numpy as np
 from ml_dtypes import bfloat16
 
-range_ = for_
+from air import api as air
+from air.api.types import bf16, i32
+
+KERNEL = "attn.o"
 
 
-@module_builder
+def _packed(buf, outer_m, mm, outer_k, kk):
+    """A [M, K] L2 buffer walked in the block order the matmul kernel wants.
+
+    The hand-written access pattern is ``sizes=[outer_k, outer_m, mm, kk]`` with
+    ``strides=[kk, K*mm, K, 1]``: blocks down the K axis first, then down M,
+    then the block itself. Splitting both axes and permuting reaches exactly
+    that, and nothing moves -- it is a view.
+    """
+    return buf.reshape(outer_m, mm, outer_k, kk).transpose(2, 0, 1, 3)
+
+
 def build_module(
     lk=3072,
     lkp=96,
@@ -30,677 +58,390 @@ def build_module(
     num_cascade_stages=4,
     arch="aie2",
 ):
-    """Build the attention module using Python bindings
+    """Build the attention module.
 
     Args:
-        lk: Total sequence length for K/V matrices (default: 3072)
-        lkp: Chunk size for K/V processing (default: 96)
-        lq: Sequence length for Q matrix (default: 128)
-        dk: Key dimension (default: 64)
-        dv: Value dimension (default: 64)
-        num_q_tiles: Number of tiles to partition Q sequence into (default: 4)
-        num_cascade_stages: Number of cascade pipeline stages (default: 4)
-        arch: Target architecture, "aie2" or "aie2p" (default: "aie2")
+        lk: total sequence length for K/V
+        lkp: chunk of the K/V sequence handled per step
+        lq: sequence length for Q
+        dk: key dimension
+        dv: value dimension
+        num_q_tiles: retained for the caller's signature; the Q tile is lq
+        num_cascade_stages: columns in the cascade
+        arch: "aie2" or "aie2p", which picks the matmul block shape
     """
+    mmul_m, mmul_k, mmul_n = [8, 8, 8] if arch == "aie2p" else [4, 8, 4]
 
-    bf16 = Type.parse("bf16")
-    i32 = IntegerType.get_signless(32)
-    index_type = IndexType.get()
+    ncs = num_cascade_stages
+    cps = (lk // lkp) // ncs  # K/V chunks each column walks
+    tq = lq
 
-    # Architecture-specific matrix multiplication dimensions
-    if arch == "aie2p":
-        mmul_mkn = [8, 8, 8]  # For aie2p
-    else:
-        mmul_mkn = [4, 8, 4]  # For aie2
-    mmul_m, mmul_k, mmul_n = mmul_mkn
+    Q = air.tensor([lq, dk], bf16)
+    K = air.tensor([dk, lk], bf16)
+    V = air.tensor([lk, dv], bf16)
+    # Declared because the kernel's interface takes an additive mask, and the
+    # host passes one. The pipeline folds it into G before the max, so nothing
+    # in the body reads it while the mask is zero.
+    air.tensor([lq, lk], bf16)  # the mask, read only by the pipeline (see above)
+    OUT = air.tensor([lq, dk], bf16)
 
-    # Derived parameters
-    num_chunks = lk // lkp
-    chunks_per_stage = num_chunks // num_cascade_stages
-    tile_size_q = lq
+    # Q and K share the L3->L2 bundle: they are never in flight together, Q
+    # being staged once before the loop and K once per trip.
+    l3_qk = air.channel("L3ToL2Chan1", size=[1, ncs])
+    l3_v = air.channel("L3ToL2Chan3", size=[1, ncs])
+    l2_q = air.channel("L2ToL1Chan1", size=[1, ncs])
+    l2_k = air.channel("L2ToL1Chan2", size=[1, ncs])
+    l2_v = air.channel("L2ToL1Chan3", size=[1, ncs])
+    out_l2 = air.channel("L1ToL2Chan1")
+    out_l3 = air.channel("L2ToL3Chan1")
+    g_to_softmax = air.channel("L1ToL1Chan1", size=[1, ncs])
+    g_to_matmul = air.channel("L1ToL1Chan2", size=[1, ncs])
+    gv_back = air.channel("L1ToL1Chan3", size=[1, ncs])
+    cascade = air.channel("cascade", size=[1, ncs - 1], channel_type="npu_cascade")
 
-    # Memory spaces: L1 = 2 : i32, L2 = 1 : i32
-    l1_space = IntegerAttr.get(i32, 2)  # L1 uses memory space 2
-    l2_space = IntegerAttr.get(i32, 1)  # L2 uses memory space 1
+    zero_gp = air.extern("zero_fill_gp_bf16", link_with=KERNEL)
+    zero_sp = air.extern("zero_fill_sp_bf16", link_with=KERNEL)
+    zero_g = air.extern("zero_fill_g_bf16", link_with=KERNEL)
+    neg_inf_up = air.extern("neg_inf_fill_up_bf16", link_with=KERNEL)
+    matmul_a_b = air.extern("matmul_a_b_bf16", link_with=KERNEL)
+    matmul_g_b = air.extern("matmul_g_b_bf16", link_with=KERNEL)
+    max_g = air.extern("max_g_bf16", link_with=KERNEL)
+    maximum_up_u = air.extern("maximum_up_u_bf16", link_with=KERNEL)
+    exp_g_minus_u = air.extern("exp_g_minus_u", link_with=KERNEL)
+    exp_up_minus_u = air.extern("exp_up_minus_u", link_with=KERNEL)
+    mul_r_gp = air.extern("mul_r_gp", link_with=KERNEL)
+    sum_g = air.extern("sum_g", link_with=KERNEL)
+    accum_sp_r_s = air.extern("accum_sp_r_s", link_with=KERNEL)
+    copy_row = air.extern("vector_copy_32elems", link_with=KERNEL, scalars=[i32])
+    div_gp_sp = air.extern("div_gp_sp", link_with=KERNEL)
+    copy_g = air.extern("vector_copy_32x96elems", link_with=KERNEL, scalars=[i32])
+    add_gp_g = air.extern("add_gp_g", link_with=KERNEL)
+    accum_gp = air.extern("vector_accum_32x64elems", link_with=KERNEL)
 
-    # L1 MemRefTypes (memory space 2 : i32) - used in herd bodies
-    memref_lqp_dv_l1 = MemRefType.get([tile_size_q, dk], bf16, memory_space=l1_space)
-    memref_lqp_l1 = MemRefType.get([tile_size_q, 1], bf16, memory_space=l1_space)
-    memref_lqp_lkp_l1 = MemRefType.get([tile_size_q * lkp], bf16, memory_space=l1_space)
-    memref_dv_lkp_l1 = MemRefType.get([dk, lkp], bf16, memory_space=l1_space)
-    memref_lqp_lkp_l1 = MemRefType.get([tile_size_q * lkp], bf16, memory_space=l1_space)
+    with air.launch([range(1), range(1)], name="attention_bf16") as launch:
 
-    # L2 MemRefTypes (memory space 1 : i32) - segment allocations
-    memref_lqp_dk_l2 = MemRefType.get([tile_size_q, dk], bf16, memory_space=l2_space)
-    memref_dk_lkp_l2 = MemRefType.get([dk, lkp], bf16, memory_space=l2_space)
-    memref_lkp_dv_l2 = MemRefType.get([lkp, dk], bf16, memory_space=l2_space)
-    memref_output_lq_dv_l2 = MemRefType.get([lq, dk], bf16, memory_space=l2_space)
+        @launch.body
+        def _(li, lj):
+            # One Q tile per column. air.parallel rather than a Python loop:
+            # the trips share a set of buffer descriptors, where unrolling
+            # would spend one shim DMA per column.
+            for c in air.parallel(0, ncs):
+                l3_qk.put(Q[c * tq : c * tq + tq, :], indices=[0, c])
 
-    # L3 MemRefTypes (no memory space annotation = default L3)
-    memref_input_q_lq_dk = MemRefType.get([lq, dk], bf16)
-    memref_output_lq_dv = MemRefType.get([lq, dk], bf16)
-    memref_input_k_dk_lk = MemRefType.get([dk, lk], bf16)
-    memref_input_v_lk_dv = MemRefType.get([lk, dk], bf16)
-    memref_input_m_lq_lk = MemRefType.get([lq, lk], bf16)
-
-    # Helper function to create external function declarations
-    def external_func(name, inputs, outputs=None, link_with=None, visibility="private"):
-        if outputs is None:
-            outputs = []
-        func_type = FunctionType.get(inputs, outputs)
-        func = FuncOp(name=name, type=func_type, visibility=visibility)
-        func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
-        if link_with:
-            func.attributes["link_with"] = StringAttr.get(link_with)
-        return func
-
-    # External function declarations
-    external_func("zero_fill_gp_bf16", [memref_lqp_dv_l1], link_with="attn.o")
-    external_func("zero_fill_sp_bf16", [memref_lqp_l1], link_with="attn.o")
-    external_func("zero_fill_g_bf16", [memref_lqp_lkp_l1], link_with="attn.o")
-    external_func("neg_inf_fill_up_bf16", [memref_lqp_l1], link_with="attn.o")
-    external_func(
-        "matmul_a_b_bf16",
-        [memref_lqp_dv_l1, memref_dv_lkp_l1, memref_lqp_lkp_l1],
-        link_with="attn.o",
-    )
-    external_func(
-        "matmul_g_b_bf16",
-        [memref_lqp_lkp_l1, memref_dv_lkp_l1, memref_lqp_dv_l1],
-        link_with="attn.o",
-    )
-    external_func("max_g_bf16", [memref_lqp_lkp_l1, memref_lqp_l1], link_with="attn.o")
-    external_func(
-        "maximum_up_u_bf16", [memref_lqp_l1, memref_lqp_l1], link_with="attn.o"
-    )
-    external_func(
-        "exp_g_minus_u", [memref_lqp_l1, memref_lqp_lkp_l1], link_with="attn.o"
-    )
-    external_func(
-        "exp_up_minus_u",
-        [memref_lqp_l1, memref_lqp_l1, memref_lqp_l1],
-        link_with="attn.o",
-    )
-    external_func("mul_r_gp", [memref_lqp_l1, memref_lqp_dv_l1], link_with="attn.o")
-    external_func("sum_g", [memref_lqp_lkp_l1, memref_lqp_l1], link_with="attn.o")
-    external_func(
-        "accum_sp_r_s",
-        [memref_lqp_l1, memref_lqp_l1, memref_lqp_l1],
-        link_with="attn.o",
-    )
-    external_func(
-        "vector_copy_32elems", [i32, memref_lqp_l1, memref_lqp_l1], link_with="attn.o"
-    )
-    external_func("div_gp_sp", [memref_lqp_l1, memref_lqp_dv_l1], link_with="attn.o")
-    external_func(
-        "vector_copy_32x96elems",
-        [i32, memref_lqp_lkp_l1, memref_lqp_lkp_l1],
-        link_with="attn.o",
-    )
-    external_func("add_gp_g", [memref_lqp_dv_l1, memref_lqp_dv_l1], link_with="attn.o")
-    external_func(
-        "vector_accum_32x64elems",
-        [memref_lqp_dv_l1, memref_lqp_dv_l1],
-        link_with="attn.o",
-    )
-
-    # Channel declarations
-    Channel("L3ToL2Chan1", size=[1, num_cascade_stages])
-    Channel("L3ToL2Chan3", size=[1, num_cascade_stages])
-    Channel("L2ToL1Chan1", size=[1, num_cascade_stages])
-    Channel("L2ToL1Chan2", size=[1, num_cascade_stages])
-    Channel("L2ToL1Chan3", size=[1, num_cascade_stages])
-    Channel("L1ToL2Chan1", size=[])
-    Channel("L1ToL2Chan2", size=[])
-    Channel("L2ToL3Chan1", size=[])
-    Channel("L2ToL3Chan2", size=[])
-    Channel("L1ToL1Chan1", size=[1, num_cascade_stages])
-    Channel("L1ToL1Chan2", size=[1, num_cascade_stages])
-    Channel("L1ToL1Chan3", size=[1, num_cascade_stages])
-    chan_cascade = Channel("cascade", size=[1, num_cascade_stages - 1])
-    chan_cascade.attributes["channel_type"] = StringAttr.get("npu_cascade")
-
-    # Main attention function
-    @FuncOp.from_py_func(
-        memref_input_q_lq_dk,
-        memref_input_k_dk_lk,
-        memref_input_v_lk_dv,
-        memref_input_m_lq_lk,
-        memref_output_lq_dv,
-    )
-    def attention_bf16(arg0, arg1, arg2, arg3, arg4):
-        c1 = ConstantOp(index_type, 1)
-
-        @launch(operands=[arg0, arg1, arg2, arg3, arg4], sizes=[c1, c1])
-        def launch_body(arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13):
-            # Affine map for Q partitioning
-            affine_map_tileq = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0), AffineConstantExpr.get(tile_size_q)
-                    )
-                ],
-            )
-
-            # scf.parallel for L3 to L2 Q matrix transfers
-            par_1 = scf.ForallOp(
-                lower_bounds=[0], upper_bounds=[num_cascade_stages], steps=[1]
-            )
-            with InsertionPoint(par_1.body):
-                apply = affine_apply(affine_map_tileq, [par_1.induction_variables[0]])
-                ChannelPut(
-                    "L3ToL2Chan1",
-                    arg9,
-                    indices=[0, par_1.induction_variables[0]],
-                    offsets=[apply, 0],
-                    sizes=[tile_size_q, dk],
-                    strides=[dk, 1],
-                )
-                scf.InParallelOp()
-
-            # L3 to L2 channel puts for K matrix
-            for i in range(num_cascade_stages):
-                ChannelPut(
-                    "L3ToL2Chan1",
-                    arg10,
-                    indices=[0, i],
-                    offsets=[0, 0, i * lkp],
-                    sizes=[chunks_per_stage, dk, lkp],
-                    strides=[lkp * num_cascade_stages, lk, 1],
+            # K arrives column-major in chunks: column c takes every ncs'th
+            # chunk, which is a slice of the middle axis once lk is split into
+            # (chunk, column, position).
+            for c in range(ncs):
+                l3_qk.put(
+                    K.reshape(dk, cps, ncs * lkp)[
+                        :, :, c * lkp : (c + 1) * lkp
+                    ].transpose(1, 0, 2),
+                    indices=[0, c],
                 )
 
-            # L3 to L2 channel puts for V matrix
-            for i in range(num_cascade_stages):
-                ChannelPut(
-                    "L3ToL2Chan3",
-                    arg11,
-                    indices=[0, i],
-                    offsets=[0, i * lkp, 0],
-                    sizes=[chunks_per_stage, lkp, dv],
-                    strides=[lkp * num_cascade_stages * dv, dv, 1],
+            # V is the same split on its own sequence axis, and needs no
+            # permutation: it is already chunk-major.
+            for c in range(ncs):
+                l3_v.put(
+                    V.reshape(cps, ncs * lkp, dv)[:, c * lkp : (c + 1) * lkp, :],
+                    indices=[0, c],
                 )
 
-            @segment(name="attention_seg", operands=[])
-            def segment_body():
-                # L2 allocations (32x64 Q buffers for 4 columns)
-                alloc = AllocOp(memref_lqp_dk_l2, [], [])
-                alloc_col1 = AllocOp(memref_lqp_dk_l2, [], [])
-                alloc_col2 = AllocOp(memref_lqp_dk_l2, [], [])
-                alloc_col3 = AllocOp(memref_lqp_dk_l2, [], [])
+            with air.segment(name="attention_seg") as seg:
 
-                # K matrix buffers (64x96)
-                alloc_2 = AllocOp(memref_dk_lkp_l2, [], [])
-                alloc_21 = AllocOp(memref_dk_lkp_l2, [], [])
-                alloc_22 = AllocOp(memref_dk_lkp_l2, [], [])
-                alloc_23 = AllocOp(memref_dk_lkp_l2, [], [])
+                @seg.body
+                def _():
+                    q_l2 = [
+                        air.alloc([tq, dk], bf16, scope=seg.private())
+                        for _ in range(ncs)
+                    ]
+                    k_l2 = [
+                        air.alloc([dk, lkp], bf16, scope=seg.private())
+                        for _ in range(ncs)
+                    ]
+                    v_l2 = [
+                        air.alloc([lkp, dv], bf16, scope=seg.private())
+                        for _ in range(ncs)
+                    ]
+                    result_l2 = air.alloc([lq, dk], bf16, scope=seg.private())
 
-                # V matrix buffers (96x64)
-                alloc_3 = AllocOp(memref_lkp_dv_l2, [], [])
-                alloc_31 = AllocOp(memref_lkp_dv_l2, [], [])
-                alloc_32 = AllocOp(memref_lkp_dv_l2, [], [])
-                alloc_33 = AllocOp(memref_lkp_dv_l2, [], [])
+                    # The running state of the online softmax. per_core, not
+                    # shared: each column keeps its own whole copy, and it has
+                    # to outlive the herd that writes it.
+                    up = air.alloc([tq, 1], bf16, scope=seg.per_core())
+                    sp = air.alloc([tq, 1], bf16, scope=seg.per_core())
+                    Gp = air.alloc([tq, dk], bf16, scope=seg.per_core())
+                    a_l1 = air.alloc([tq, dk], bf16, scope=seg.per_core())
 
-                # Output buffer
-                alloc_5 = AllocOp(memref_output_lq_dv_l2, [], [])
-
-                # L1 allocations
-                up = AllocOp(memref_lqp_l1, [], [])
-                sp = AllocOp(memref_lqp_l1, [], [])
-                Gp = AllocOp(memref_lqp_dv_l1, [], [])
-                alloc_6 = AllocOp(memref_lqp_dv_l1, [], [])
-
-                # L3 to L2 channel gets for Q matrix
-                for i in range(num_cascade_stages):
-                    ChannelGet(
-                        "L3ToL2Chan1",
-                        [alloc, alloc_col1, alloc_col2, alloc_col3][i].result,
-                        indices=[0, i],
-                    )
-
-                # L2 to L1 channel puts for Q matrix
-                # Memory [tile_size_q, dk] tiled for matmul: Q is M dimension, dk is K dimension
-                for i in range(num_cascade_stages):
-                    ChannelPut(
-                        "L2ToL1Chan1",
-                        [alloc, alloc_col1, alloc_col2, alloc_col3][i].result,
-                        indices=[0, i],
-                        offsets=[0, 0, 0, 0],
-                        sizes=[dk // mmul_k, tile_size_q // mmul_m, mmul_m, mmul_k],
-                        strides=[mmul_k, dk * mmul_m, dk, 1],
-                    )
-
-                # Herd0 - initialization
-                @herd(
-                    name="herd_0",
-                    sizes=[1, num_cascade_stages],
-                    operands=[alloc_6],
-                    link_with="attn.o",
-                )
-                def herd_body_init(arg22, arg23, arg24, arg25, arg26):
-                    ChannelGet("L2ToL1Chan1", arg26, indices=[arg22, arg23])
-
-                # Herd1 - initialization
-                @herd(
-                    name="herd_1",
-                    sizes=[1, num_cascade_stages],
-                    operands=[up, sp, Gp],
-                    link_with="attn.o",
-                )
-                def herd_body_init(arg22, arg23, arg24, arg25, arg27, arg28, arg29):
-                    CallOp([], "zero_fill_gp_bf16", [arg29])
-                    CallOp([], "zero_fill_sp_bf16", [arg28])
-                    CallOp([], "neg_inf_fill_up_bf16", [arg27])
-
-                # Main loop over lk chunks
-                for arg21 in range_(0, chunks_per_stage, 1):
-                    # Channel gets for K and V matrices
-                    for i in range(num_cascade_stages):
-                        ChannelGet(
-                            "L3ToL2Chan1",
-                            [alloc_2, alloc_21, alloc_22, alloc_23][i].result,
-                            indices=[0, i],
-                        )
-                        ChannelGet(
-                            "L3ToL2Chan3",
-                            [alloc_3, alloc_31, alloc_32, alloc_33][i].result,
-                            indices=[0, i],
+                    for c in range(ncs):
+                        l3_qk.get(q_l2[c], indices=[0, c])
+                    for c in range(ncs):
+                        l2_q.put(
+                            _packed(
+                                q_l2[c], tq // mmul_m, mmul_m, dk // mmul_k, mmul_k
+                            ),
+                            indices=[0, c],
                         )
 
-                    # Channel puts for K matrix to L1
-                    # Memory [dk, lkp] tiled for matmul: dk is K dimension, lkp is N dimension
-                    for i in range(num_cascade_stages):
-                        ChannelPut(
-                            "L2ToL1Chan2",
-                            [alloc_2, alloc_21, alloc_22, alloc_23][i].result,
-                            indices=[0, i],
-                            offsets=[0, 0, 0, 0],
-                            sizes=[lkp // mmul_n, dk // mmul_k, mmul_k, mmul_n],
-                            strides=[mmul_n, lkp * mmul_k, lkp, 1],
-                        )
-
-                    # Channel puts for V matrix to L1
-                    # Memory [lkp, dk] tiled for matmul: lkp is K dimension, dk is N dimension
-                    for i in range(num_cascade_stages):
-                        ChannelPut(
-                            "L2ToL1Chan3",
-                            [alloc_3, alloc_31, alloc_32, alloc_33][i].result,
-                            indices=[0, i],
-                            offsets=[0, 0, 0, 0],
-                            sizes=[dv // mmul_n, lkp // mmul_k, mmul_k, mmul_n],
-                            strides=[mmul_n, dv * mmul_k, dv, 1],
-                        )
-
-                    # Herd0 - computation inside loop
-                    @herd(
+                    # Q into each column's L1, once.
+                    with air.herd(
+                        [range(1), range(ncs)],
                         name="herd_0",
-                        sizes=[1, num_cascade_stages],
-                        operands=[alloc_6],
-                        link_with="attn.o",
-                    )
-                    def herd_body_compute(arg22, arg23, arg24, arg25, arg26):
-                        alloc_56 = AllocOp(memref_dv_lkp_l1, [], [])
-                        G_l1 = AllocOp(memref_lqp_lkp_l1, [], [])
+                        shape=(1, ncs),
+                        link_with=KERNEL,
+                    ) as h_q:
 
-                        CallOp([], "zero_fill_g_bf16", [G_l1.result])
-                        ChannelGet(
-                            "L2ToL1Chan2", alloc_56.result, indices=[arg22, arg23]
-                        )
-                        CallOp(
-                            [], "matmul_a_b_bf16", [arg26, alloc_56.result, G_l1.result]
-                        )
-                        ChannelPut(
-                            "L1ToL1Chan1",
-                            G_l1.result,
-                            indices=[arg22, arg23],
-                            offsets=[0, 0, 0],
-                            sizes=[tile_size_q, lkp // mmul_n, mmul_n],
-                            strides=[mmul_n, tile_size_q * mmul_n, 1],
-                        )
-                        DeallocOp(alloc_56)
-                        DeallocOp(G_l1)
+                        @h_q.body
+                        def _(tx, ty):
+                            l2_q.get(a_l1, indices=[tx, ty])
 
-                    # Herd1 - computation inside loop
-                    @herd(
+                    with air.herd(
+                        [range(1), range(ncs)],
                         name="herd_1",
-                        sizes=[1, num_cascade_stages],
-                        operands=[up, sp, Gp],
-                        link_with="attn.o",
-                    )
-                    def herd_body_compute(
-                        arg22, arg23, arg24, arg25, arg27, arg28, arg29
-                    ):
-                        u_l1 = AllocOp(memref_lqp_l1, [], [])
-                        s_l1 = AllocOp(memref_lqp_l1, [], [])
-                        r_l1 = AllocOp(memref_lqp_l1, [], [])
-                        G_l1 = AllocOp(memref_lqp_lkp_l1, [], [])
+                        shape=(1, ncs),
+                        link_with=KERNEL,
+                    ) as h_init:
 
-                        ChannelGet("L1ToL1Chan1", G_l1.result, indices=[arg22, arg23])
+                        @h_init.body
+                        def _(tx, ty):
+                            zero_gp(Gp)
+                            zero_sp(sp)
+                            neg_inf_up(up)
 
-                        c0_i32 = ConstantOp(i32, 0)
-                        CallOp([], "max_g_bf16", [G_l1.result, u_l1.result])
-                        CallOp([], "maximum_up_u_bf16", [arg27, u_l1.result])
-                        CallOp([], "exp_g_minus_u", [u_l1.result, G_l1.result])
-                        CallOp([], "exp_up_minus_u", [arg27, u_l1.result, r_l1.result])
-                        CallOp([], "mul_r_gp", [r_l1.result, arg29])
-
-                        G_copy_l1 = AllocOp(memref_lqp_lkp_l1, [], [])
-                        CallOp(
-                            [],
-                            "vector_copy_32x96elems",
-                            [c0_i32, G_l1.result, G_copy_l1.result],
-                        )
-                        ChannelPut(
-                            "L1ToL1Chan2",
-                            G_copy_l1.result,
-                            indices=[arg22, arg23],
-                            offsets=[0, 0, 0],
-                            sizes=[lkp // mmul_k, tile_size_q, mmul_k],
-                            strides=[mmul_k, lkp, 1],
-                        )
-                        DeallocOp(G_copy_l1)
-
-                        mmult_res = AllocOp(memref_lqp_dv_l1, [], [])
-                        ChannelGet(
-                            "L1ToL1Chan3", mmult_res.result, indices=[arg22, arg23]
-                        )
-                        CallOp([], "vector_accum_32x64elems", [mmult_res.result, arg29])
-                        DeallocOp(mmult_res)
-
-                        CallOp([], "sum_g", [G_l1.result, s_l1.result])
-                        CallOp([], "accum_sp_r_s", [arg28, r_l1.result, s_l1.result])
-                        CallOp([], "vector_copy_32elems", [c0_i32, s_l1.result, arg28])
-                        CallOp([], "vector_copy_32elems", [c0_i32, u_l1.result, arg27])
-
-                        DeallocOp(u_l1)
-                        DeallocOp(s_l1)
-                        DeallocOp(r_l1)
-                        DeallocOp(G_l1)
-
-                    # Herd2 - computation inside loop
-                    @herd(
-                        name="herd_2", sizes=[1, num_cascade_stages], link_with="attn.o"
-                    )
-                    def herd_body_compute(arg22, arg23, arg24, arg25):
-                        alloc_57 = AllocOp(memref_dv_lkp_l1, [], [])
-                        G_l1 = AllocOp(memref_lqp_lkp_l1, [], [])
-                        arg29 = AllocOp(memref_lqp_dv_l1, [], [])
-
-                        CallOp([], "zero_fill_gp_bf16", [arg29])
-
-                        ChannelGet("L1ToL1Chan2", G_l1.result, indices=[arg22, arg23])
-                        ChannelGet(
-                            "L2ToL1Chan3", alloc_57.result, indices=[arg22, arg23]
-                        )
-                        CallOp(
-                            [], "matmul_g_b_bf16", [G_l1.result, alloc_57.result, arg29]
-                        )
-                        ChannelPut(
-                            "L1ToL1Chan3",
-                            arg29,
-                            indices=[arg22, arg23],
-                            offsets=[0, 0, 0],
-                            sizes=[tile_size_q, dv // mmul_n, mmul_n],
-                            strides=[mmul_n, tile_size_q * mmul_n, 1],
-                        )
-                        DeallocOp(alloc_57)
-                        DeallocOp(G_l1)
-                        DeallocOp(arg29)
-
-                    yield_([])
-
-                # Herd1 - final processing with cascade and affine.if
-                @herd(
-                    name="herd_1",
-                    sizes=[1, num_cascade_stages],
-                    operands=[up, sp, Gp],
-                    link_with="attn.o",
-                )
-                def herd_body_final(arg22, arg23, arg24, arg25, arg27, arg28, arg29):
-                    c1 = ConstantOp(index_type, 1)
-                    r_l1 = AllocOp(memref_lqp_l1, [], [])
-
-                    # affine.if for last cascade stage
-                    affine_set_last = IntegerSet.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(1),
-                                AffineConstantExpr.get(-num_cascade_stages + 1),
-                            ),
-                            AffineSymbolExpr.get(0),
-                            AffineExpr.get_add(
-                                AffineConstantExpr.get(num_cascade_stages - 1),
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(0), AffineConstantExpr.get(-1)
+                    for _chunk in air.sequential(0, cps):
+                        for c in range(ncs):
+                            l3_qk.get(k_l2[c], indices=[0, c])
+                            l3_v.get(v_l2[c], indices=[0, c])
+                        for c in range(ncs):
+                            l2_k.put(
+                                _packed(
+                                    k_l2[c], dk // mmul_k, mmul_k, lkp // mmul_n, mmul_n
                                 ),
-                            ),
-                        ],
-                        [True, False, False],
-                    )
-
-                    affine_if_last = affine.AffineIfOp(
-                        affine_set_last, cond_operands=[arg22, arg23], has_else=True
-                    )
-                    with InsertionPoint(affine_if_last.then_block):
-                        # Last cascade stage: just send to next stage (no receive)
-                        subi = arith.SubIOp(arg23, c1)
-                        ChannelPut("cascade", arg29, indices=[arg22, subi])
-                        ChannelPut("cascade", arg27, indices=[arg22, subi])
-                        ChannelPut("cascade", arg28, indices=[arg22, subi])
-                        affine.AffineYieldOp([])
-
-                    with InsertionPoint(affine_if_last.else_block):
-                        # affine.if for middle cascade stages
-                        affine_set_middle = IntegerSet.get(
-                            0,
-                            2,
-                            [
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(1), AffineConstantExpr.get(-1)
+                                indices=[0, c],
+                            )
+                        for c in range(ncs):
+                            l2_v.put(
+                                _packed(
+                                    v_l2[c], lkp // mmul_k, mmul_k, dv // mmul_n, mmul_n
                                 ),
-                                AffineExpr.get_add(
-                                    AffineConstantExpr.get(num_cascade_stages - 2),
-                                    AffineExpr.get_mul(
-                                        AffineSymbolExpr.get(1),
-                                        AffineConstantExpr.get(-1),
+                                indices=[0, c],
+                            )
+
+                        # G = Q @ K
+                        with air.herd(
+                            [range(1), range(ncs)],
+                            name="herd_0",
+                            shape=(1, ncs),
+                            link_with=KERNEL,
+                        ) as h_qk:
+
+                            @h_qk.body
+                            def _(tx, ty):
+                                k_l1 = air.alloc([dk, lkp], bf16, scope=h_qk.private())
+                                g = air.alloc([tq * lkp], bf16, scope=h_qk.private())
+                                zero_g(g)
+                                l2_k.get(k_l1, indices=[tx, ty])
+                                matmul_a_b(a_l1, k_l1, g)
+                                # G leaves in block order, not row order: the
+                                # consumer reads one n-block down every row
+                                # before moving to the next block. Splitting
+                                # the flat buffer with the block axis outermost
+                                # and swapping it with the row axis reaches
+                                # sizes [tq, lkp/n, n] over strides [n, tq*n,
+                                # 1] -- a view, nothing moves.
+                                g_to_softmax.put(
+                                    g.reshape(lkp // mmul_n, tq, mmul_n).transpose(
+                                        1, 0, 2
                                     ),
-                                ),
-                                AffineSymbolExpr.get(0),
-                                AffineExpr.get_add(
-                                    AffineConstantExpr.get(num_cascade_stages - 1),
-                                    AffineExpr.get_mul(
-                                        AffineSymbolExpr.get(0),
-                                        AffineConstantExpr.get(-1),
+                                    indices=[tx, ty],
+                                )
+                                # Released here rather than at last use: the
+                                # predecessor batches its frees at the end of
+                                # the body, and herd fusion is sensitive to
+                                # what sits between two herds.
+                                air.dealloc(k_l1)
+                                air.dealloc(g)
+
+                        # Online softmax over this chunk, and accumulate G @ V.
+                        with air.herd(
+                            [range(1), range(ncs)],
+                            name="herd_1",
+                            shape=(1, ncs),
+                            link_with=KERNEL,
+                        ) as h_soft:
+
+                            @h_soft.body
+                            def _(tx, ty):
+                                u = air.alloc([tq, 1], bf16, scope=h_soft.private())
+                                s = air.alloc([tq, 1], bf16, scope=h_soft.private())
+                                r = air.alloc([tq, 1], bf16, scope=h_soft.private())
+                                g = air.alloc([tq * lkp], bf16, scope=h_soft.private())
+
+                                g_to_softmax.get(g, indices=[tx, ty])
+                                max_g(g, u)
+                                maximum_up_u(up, u)
+                                exp_g_minus_u(u, g)
+                                exp_up_minus_u(up, u, r)
+                                mul_r_gp(r, Gp)
+
+                                g_copy = air.alloc(
+                                    [tq * lkp], bf16, scope=h_soft.private()
+                                )
+                                copy_g(0, g, g_copy)
+                                g_to_matmul.put(
+                                    g_copy.reshape(tq, lkp // mmul_k, mmul_k).transpose(
+                                        1, 0, 2
                                     ),
-                                ),
-                            ],
-                            [False, False, False, False],
-                        )
+                                    indices=[tx, ty],
+                                )
+                                air.dealloc(g_copy)
 
-                        affine_if_middle = affine.AffineIfOp(
-                            affine_set_middle,
-                            cond_operands=[arg22, arg23],
-                            has_else=True,
-                        )
-                        with InsertionPoint(affine_if_middle.then_block):
-                            # Middle cascade stages: receive from previous, process, and send to next
-                            Gp_cascade = AllocOp(memref_lqp_dv_l1, [], [])
-                            up_cascade = AllocOp(memref_lqp_l1, [], [])
-                            sp_cascade = AllocOp(memref_lqp_l1, [], [])
-                            ChannelGet(
-                                "cascade", Gp_cascade.result, indices=[arg22, arg23]
-                            )
-                            ChannelGet(
-                                "cascade", up_cascade.result, indices=[arg22, arg23]
-                            )
-                            ChannelGet(
-                                "cascade", sp_cascade.result, indices=[arg22, arg23]
-                            )
+                                gv = air.alloc([tq, dk], bf16, scope=h_soft.private())
+                                gv_back.get(gv, indices=[tx, ty])
+                                accum_gp(gv, Gp)
+                                air.dealloc(gv)
 
-                            # Save local max before maximum overwrites arg27
-                            up_B_saved = AllocOp(memref_lqp_l1, [], [])
-                            c0_i32_m = ConstantOp(i32, 0)
-                            CallOp(
-                                [],
-                                "vector_copy_32elems",
-                                [c0_i32_m, arg27, up_B_saved.result],
-                            )
+                                sum_g(g, s)
+                                accum_sp_r_s(sp, r, s)
+                                copy_row(0, s, sp)
+                                copy_row(0, u, up)
+                                air.dealloc(u)
+                                air.dealloc(s)
+                                air.dealloc(r)
+                                air.dealloc(g)
 
-                            # arg27 = max(up_cascade, arg27) = new_max
-                            CallOp([], "maximum_up_u_bf16", [up_cascade.result, arg27])
+                        # G @ V, on its own core so it overlaps the softmax.
+                        with air.herd(
+                            [range(1), range(ncs)],
+                            name="herd_2",
+                            shape=(1, ncs),
+                            link_with=KERNEL,
+                        ) as h_gv:
 
-                            # r_A = exp(up_cascade - new_max)
-                            CallOp(
-                                [],
-                                "exp_up_minus_u",
-                                [up_cascade.result, arg27, r_l1.result],
-                            )
-                            # r_B = exp(up_B_saved - new_max)
-                            r_B = AllocOp(memref_lqp_l1, [], [])
-                            CallOp(
-                                [],
-                                "exp_up_minus_u",
-                                [up_B_saved.result, arg27, r_B.result],
-                            )
+                            @h_gv.body
+                            def _(tx, ty):
+                                v_l1 = air.alloc([dk, lkp], bf16, scope=h_gv.private())
+                                g = air.alloc([tq * lkp], bf16, scope=h_gv.private())
+                                acc = air.alloc([tq, dk], bf16, scope=h_gv.private())
+                                zero_gp(acc)
+                                g_to_matmul.get(g, indices=[tx, ty])
+                                l2_v.get(v_l1, indices=[tx, ty])
+                                matmul_g_b(g, v_l1, acc)
+                                gv_back.put(
+                                    acc.reshape(dv // mmul_n, tq, mmul_n).transpose(
+                                        1, 0, 2
+                                    ),
+                                    indices=[tx, ty],
+                                )
+                                air.dealloc(v_l1)
+                                air.dealloc(g)
+                                air.dealloc(acc)
 
-                            # Rescale both sides
-                            CallOp([], "mul_r_gp", [r_l1.result, Gp_cascade.result])
-                            CallOp([], "mul_r_gp", [r_B.result, arg29])
+                    # Merge the columns down the cascade.
+                    with air.herd(
+                        [range(1), range(ncs)],
+                        name="herd_1",
+                        shape=(1, ncs),
+                        link_with=KERNEL,
+                    ) as h_merge:
 
-                            # Merge Gp
-                            CallOp([], "add_gp_g", [arg29, Gp_cascade.result])
+                        @h_merge.body
+                        def _(tx, ty):
+                            r = air.alloc([tq, 1], bf16, scope=h_merge.private())
 
-                            # sp merge: sp_A * r_A + sp_B * r_B
-                            sp_temp = AllocOp(memref_lqp_l1, [], [])
-                            CallOp([], "zero_fill_sp_bf16", [sp_temp.result])
-                            CallOp(
-                                [],
-                                "accum_sp_r_s",
-                                [sp_cascade.result, r_l1.result, sp_temp.result],
-                            )
-                            CallOp(
-                                [],
-                                "accum_sp_r_s",
-                                [arg28, r_B.result, sp_temp.result],
-                            )
-                            CallOp(
-                                [],
-                                "vector_copy_32elems",
-                                [c0_i32_m, sp_temp.result, sp_cascade.result],
-                            )
+                            def merge():
+                                """Fold the column above into this one.
 
-                            subi = arith.SubIOp(arg23, c1)
-                            ChannelPut(
-                                "cascade", Gp_cascade.result, indices=[arg22, subi]
-                            )
-                            ChannelPut("cascade", arg27, indices=[arg22, subi])
-                            ChannelPut(
-                                "cascade", sp_cascade.result, indices=[arg22, subi]
-                            )
-                            DeallocOp(up_B_saved)
-                            DeallocOp(r_B)
-                            DeallocOp(sp_temp)
-                            affine.AffineYieldOp([])
+                                A Python function, so each call emits its own
+                                copy of the body -- which is what is wanted
+                                here: the two arms below are separate regions
+                                and only one of them runs on any given core.
+                                """
+                                gp_in = air.alloc(
+                                    [tq, dk], bf16, scope=h_merge.private()
+                                )
+                                up_in = air.alloc(
+                                    [tq, 1], bf16, scope=h_merge.private()
+                                )
+                                sp_in = air.alloc(
+                                    [tq, 1], bf16, scope=h_merge.private()
+                                )
+                                cascade.get(gp_in, indices=[tx, ty])
+                                cascade.get(up_in, indices=[tx, ty])
+                                cascade.get(sp_in, indices=[tx, ty])
 
-                        with InsertionPoint(affine_if_middle.else_block):
-                            # First cascade stage (index 0): receive from previous, process, and output result
-                            Gp_cascade = AllocOp(memref_lqp_dv_l1, [], [])
-                            up_cascade = AllocOp(memref_lqp_l1, [], [])
-                            sp_cascade = AllocOp(memref_lqp_l1, [], [])
-                            ChannelGet(
-                                "cascade", Gp_cascade.result, indices=[arg22, arg23]
-                            )
-                            ChannelGet(
-                                "cascade", up_cascade.result, indices=[arg22, arg23]
-                            )
-                            ChannelGet(
-                                "cascade", sp_cascade.result, indices=[arg22, arg23]
-                            )
+                                # maximum_up_u overwrites up, so keep the local
+                                # maximum before merging it away.
+                                up_mine = air.alloc(
+                                    [tq, 1], bf16, scope=h_merge.private()
+                                )
+                                copy_row(0, up, up_mine)
+                                maximum_up_u(up_in, up)
 
-                            # Save local max before maximum overwrites arg27
-                            up_B_saved = AllocOp(memref_lqp_l1, [], [])
-                            c0_i32_f = ConstantOp(i32, 0)
-                            CallOp(
-                                [],
-                                "vector_copy_32elems",
-                                [c0_i32_f, arg27, up_B_saved.result],
-                            )
+                                r_b = air.alloc([tq, 1], bf16, scope=h_merge.private())
+                                exp_up_minus_u(up_in, up, r)
+                                exp_up_minus_u(up_mine, up, r_b)
+                                mul_r_gp(r, gp_in)
+                                mul_r_gp(r_b, Gp)
+                                add_gp_g(Gp, gp_in)
 
-                            # arg27 = max(up_cascade, arg27) = new_max
-                            CallOp([], "maximum_up_u_bf16", [up_cascade.result, arg27])
+                                sp_merged = air.alloc(
+                                    [tq, 1], bf16, scope=h_merge.private()
+                                )
+                                zero_sp(sp_merged)
+                                accum_sp_r_s(sp_in, r, sp_merged)
+                                accum_sp_r_s(sp, r_b, sp_merged)
+                                copy_row(0, sp_merged, sp_in)
+                                air.dealloc(up_mine)
+                                air.dealloc(r_b)
+                                air.dealloc(sp_merged)
+                                return gp_in, sp_in
 
-                            # r_A = exp(up_cascade - new_max)
-                            CallOp(
-                                [],
-                                "exp_up_minus_u",
-                                [up_cascade.result, arg27, r_l1.result],
-                            )
-                            # r_B = exp(up_B_saved - new_max)
-                            r_B = AllocOp(memref_lqp_l1, [], [])
-                            CallOp(
-                                [],
-                                "exp_up_minus_u",
-                                [up_B_saved.result, arg27, r_B.result],
-                            )
+                            with air.ops.branch(ty == ncs - 1) as last:
+                                # The tail has nobody above it: hand its state
+                                # down and stop.
+                                cascade.put(Gp, indices=[tx, ty - 1])
+                                cascade.put(up, indices=[tx, ty - 1])
+                                cascade.put(sp, indices=[tx, ty - 1])
 
-                            # Rescale both sides
-                            CallOp([], "mul_r_gp", [r_l1.result, Gp_cascade.result])
-                            CallOp([], "mul_r_gp", [r_B.result, arg29])
+                            with last.otherwise():
+                                # ty is not the tail here, so the predecessor's
+                                # 1 <= ty <= ncs-2 is just ty >= 1.
+                                with air.ops.branch(ty >= 1) as middle:
+                                    gp_in, sp_in = merge()
+                                    cascade.put(gp_in, indices=[tx, ty - 1])
+                                    cascade.put(up, indices=[tx, ty - 1])
+                                    cascade.put(sp_in, indices=[tx, ty - 1])
+                                with middle.otherwise():
+                                    # Column 0 owns the answer.
+                                    gp_in, sp_in = merge()
+                                    div_gp_sp(sp_in, gp_in)
+                                    out_l2.put(gp_in)
 
-                            # Merge Gp
-                            CallOp([], "add_gp_g", [arg29, Gp_cascade.result])
+                    out_l2.get(result_l2[0:tq, 0:dv])
+                    out_l3.put(result_l2)
 
-                            # sp merge: sp_A * r_A + sp_B * r_B
-                            sp_temp = AllocOp(memref_lqp_l1, [], [])
-                            CallOp([], "zero_fill_sp_bf16", [sp_temp.result])
-                            CallOp(
-                                [],
-                                "accum_sp_r_s",
-                                [sp_cascade.result, r_l1.result, sp_temp.result],
-                            )
-                            CallOp(
-                                [],
-                                "accum_sp_r_s",
-                                [arg28, r_B.result, sp_temp.result],
-                            )
-                            CallOp(
-                                [],
-                                "vector_copy_32elems",
-                                [c0_i32_f, sp_temp.result, sp_cascade.result],
-                            )
+            out_l3.get(OUT)
 
-                            # Final normalization
-                            CallOp(
-                                [], "div_gp_sp", [sp_cascade.result, Gp_cascade.result]
-                            )
-                            DeallocOp(up_B_saved)
-                            DeallocOp(r_B)
-                            DeallocOp(sp_temp)
+    return launch.build()
 
-                            ChannelPut(
-                                "L1ToL2Chan1", Gp_cascade.result, indices=[arg22, 0]
-                            )
-                            affine.AffineYieldOp([])
-                        affine.AffineYieldOp([])
 
-                # Parallel gather results from L1 to L2
-                ChannelGet(
-                    "L1ToL2Chan1",
-                    alloc_5.result,
-                    indices=[],
-                    offsets=[0, 0],
-                    sizes=[tile_size_q, dv],
-                    strides=[dv, 1],
-                )
-
-                # L2 to L3 transfer
-                ChannelPut("L2ToL3Chan1", alloc_5.result, indices=[])
-
-            # Get from L2 to L3
-            ChannelGet("L2ToL3Chan1", arg13, indices=[])
+def _reference(q, k, v, m, lq, lkp, lk, dv):
+    """Online softmax in fp32, rounded to bf16 the way the kernel accumulates."""
+    Gp = np.zeros((lq, dv), dtype=bfloat16)
+    up = np.full((lq, 1), -np.inf, dtype=bfloat16)
+    sp = np.zeros((lq, 1), dtype=bfloat16)
+    for j in range(lk // lkp):
+        G = (q @ k[:, j * lkp : (j + 1) * lkp] + m[:, j * lkp : (j + 1) * lkp]).astype(
+            bfloat16
+        )
+        u = np.maximum(np.max(G, axis=-1, keepdims=True).astype(bfloat16), up)
+        G = np.exp(G - u).astype(bfloat16)
+        r = np.exp(up - u).astype(bfloat16)
+        Gp = (G @ v[j * lkp : (j + 1) * lkp, :] + Gp * r).astype(bfloat16)
+        s = np.sum(G, axis=-1, keepdims=True).astype(bfloat16) + sp * r
+        sp, up = s, u
+    return (Gp / sp).astype(bfloat16)
 
 
 if __name__ == "__main__":
@@ -733,86 +474,42 @@ if __name__ == "__main__":
         default="aie2",
         help="Target architecture (default: aie2)",
     )
-
     args = parser.parse_args()
 
     lk, lkp, lq, dk, dv = args.lk, args.lkp, args.lq, args.dk, args.dv
 
-    mlir_module = build_module(
-        lk=lk,
-        lkp=lkp,
-        lq=lq,
-        dk=dk,
-        dv=dv,
-        num_q_tiles=4,
-        num_cascade_stages=4,
-        arch=args.arch,
+    module = build_module(
+        lk=lk, lkp=lkp, lq=lq, dk=dk, dv=dv, num_cascade_stages=4, arch=args.arch
     )
-
     if args.print_module_only:
-        print(mlir_module)
+        print(module)
         exit(0)
 
-    # Import XRT dependencies only when running tests
-    from air.backend.xrt_runner import XRTRunner, type_mapper
-    from air.backend.xrt import XRTBackend
-    from air.extras import types as extrasT
-    from ml_dtypes import bfloat16
+    from air.backend.xrt_runner import XRTRunner
 
-    INPUT_DATATYPE = VM_ACC_DATATYPE = OUTPUT_DATATYPE = bfloat16
+    input_q = np.arange(0, lq * dk, dtype=bfloat16).reshape(lq, dk) / (lq * dk) * 2
+    input_k = np.arange(0, dk * lk, dtype=bfloat16).reshape(dk, lk) / (dk * lk) * 2
+    input_v = np.arange(0, lk * dv, dtype=bfloat16).reshape(lk, dv) / (lk * dv) * 2
+    input_m = np.zeros((lq, lk), dtype=bfloat16)
+    input_q = (input_q.astype(bfloat16) / sqrt(dk)).astype(bfloat16)
+    input_k = input_k.astype(bfloat16)
+    input_v = input_v.astype(bfloat16)
 
-    input_q = (
-        np.arange(0, lq * dk, dtype=INPUT_DATATYPE).reshape(lq, dk) / (lq * dk) * 2
-    )
-    input_q = input_q.astype(INPUT_DATATYPE)
-    input_k = (
-        np.arange(0, dk * lk, dtype=INPUT_DATATYPE).reshape(dk, lk) / (dk * lk) * 2
-    )
-    input_k = input_k.astype(INPUT_DATATYPE)
-    input_m = np.zeros((lq, lk), dtype=INPUT_DATATYPE)
-    input_v = (
-        np.arange(0, lk * dv, dtype=INPUT_DATATYPE).reshape(lk, dv) / (lk * dv) * 2
-    )
-    input_v = input_v.astype(INPUT_DATATYPE)
-
-    input_q_scaled = (input_q / sqrt(dk)).astype(INPUT_DATATYPE)
-    A = input_q_scaled
-    Gp = np.zeros((lq, dv), dtype=VM_ACC_DATATYPE)
-    up = np.full((lq, 1), -np.inf, dtype=VM_ACC_DATATYPE)
-    sp = np.zeros((lq, 1), dtype=VM_ACC_DATATYPE)
-    for j in range(0, lk // lkp):
-        G = input_m[:, j * lkp : (j + 1) * lkp]
-        B = input_k[:, j * lkp : (j + 1) * lkp]
-        G = A @ B + G
-        G = G.astype(VM_ACC_DATATYPE)
-        u = np.max(G, axis=-1, keepdims=True).astype(VM_ACC_DATATYPE)
-        u = np.maximum(u, up)
-        G = np.exp(G - u)
-        G = G.astype(VM_ACC_DATATYPE)
-        B = input_v[j * lkp : (j + 1) * lkp, :]
-        r = np.exp(up - u).astype(VM_ACC_DATATYPE)
-        Gp = Gp * r
-        Gp = G @ B + Gp
-        Gp = Gp.astype(VM_ACC_DATATYPE)
-        s = np.sum(G, axis=-1, keepdims=True).astype(VM_ACC_DATATYPE)
-        s += sp * r
-        sp, up = s, u
-
-    lazy_attn_output = (Gp / sp).astype(OUTPUT_DATATYPE)
+    expected = _reference(input_q, input_k, input_v, input_m, lq, lkp, lk, dv)
 
     runner = XRTRunner(
         omit_while_true_loop=False,
         omit_pingpong=True,
-        verbose=False,
+        verbose=args.verbose,
         runtime_loop_tiling_sizes=[1, 1],
         output_format=args.output_format,
         instance_name="attention_bf16",
     )
     exit(
         runner.run_test(
-            mlir_module,
-            inputs=[input_q_scaled, input_k, input_v, input_m],
-            expected_outputs=[lazy_attn_output],
+            module,
+            inputs=[input_q, input_k, input_v, input_m],
+            expected_outputs=[expected],
             rtol=1e-1,
         )
     )

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -28,11 +28,9 @@ from ._index import IndexExpr
 __all__ = [
     "sequential",
     "parallel",
-    "loop_depth",
     "aborted_regions",
     "enter_region",
     "exit_region",
-    "branch_depth",
 ]
 
 # Names of the regions whose body exited early (break / return / an exception
@@ -46,54 +44,13 @@ __all__ = [
 # problem at all. A single counter reported both as "left a loop early".
 _ABORTED = []
 
-# How many nested bodies -- loop or branch -- are currently open.
-_DEPTH = 0
-
-# Of those, how many are ops.branch arms. An allocation inside a loop is fine:
-# free_buffers anchors each dealloc in the block its alloc lives in, so both
-# land inside the loop body, which is what the hand-written kernels write and
-# what lets the pipeline rotate the buffer between trips. A branch arm is the
-# case that is still refused -- see air.alloc.
-_BRANCH_DEPTH = 0
-
-
-def loop_depth():
-    return _DEPTH
-
-
-def branch_depth():
-    return _BRANCH_DEPTH
-
-
-def enter_body():
-    """Start a fresh loop-depth frame, returning the one to restore.
-
-    Depth exists to catch an ``air.alloc`` nested inside a loop *in the same
-    body*, where the dealloc would be emitted after the loop and so would not be
-    dominated by its alloc. A loop further out is a different matter entirely: a
-    herd inside a segment-scope reduction is re-entered once per trip, and its
-    body's allocs and deallocs are both inside that trip. Counting the outer loop
-    would reject the shape every staged matmul in the tree uses.
-    """
-    global _DEPTH
-    previous, _DEPTH = _DEPTH, 0
-    return previous
-
-
-def exit_body(previous):
-    global _DEPTH
-    _DEPTH = previous
-
 
 def aborted_regions():
     return tuple(_ABORTED)
 
 
 def enter_region():
-    """Count one more open ``ops.branch`` arm."""
-    global _DEPTH, _BRANCH_DEPTH
-    _DEPTH += 1
-    _BRANCH_DEPTH += 1
+    """Open one ``ops.branch`` arm, for early-exit bookkeeping."""
 
 
 def exit_region(aborted, what):
@@ -105,9 +62,6 @@ def exit_region(aborted, what):
     that forgot to say which one it was would silently mislabel the diagnostic,
     which is the failure this pair was split up to prevent.
     """
-    global _DEPTH, _BRANCH_DEPTH
-    _DEPTH -= 1
-    _BRANCH_DEPTH -= 1
     if aborted:
         _ABORTED.append(what)
 
@@ -118,7 +72,7 @@ def sequential(start, stop=None, step=None, name=None):
     Yields the induction variable as an :class:`IndexExpr`, so it composes with
     tile coordinates and tensor slices exactly like a herd coordinate does.
     """
-    global _ABORTED, _DEPTH
+    global _ABORTED
 
     if stop is None:
         start, stop = 0, start
@@ -145,13 +99,11 @@ def sequential(start, stop=None, step=None, name=None):
     from air.dialects.scf import for_ as scf_for, yield_
 
     for iv in scf_for(lo, hi, st):
-        _DEPTH += 1
         completed = False
         try:
             yield IndexExpr.leaf(iv, name or "k")
             completed = True
         finally:
-            _DEPTH -= 1
             if not completed:
                 _ABORTED.append("air.sequential")
             # Terminate the region either way: leaving a block without a
@@ -182,7 +134,7 @@ def parallel(start, stop=None, step=None, name=None):
     Emitted as ``scf.forall``; the pipeline's ``scf-forall-to-parallel`` turns
     it into the ``scf.parallel`` that the hand-written examples spell directly.
     """
-    global _ABORTED, _DEPTH
+    global _ABORTED
 
     if stop is None:
         start, stop = 0, start
@@ -211,7 +163,6 @@ def parallel(start, stop=None, step=None, name=None):
     from air.dialects.scf import ForallOp, InParallelOp
 
     op = ForallOp(lower_bounds=[lo], upper_bounds=[hi], steps=[st])
-    _DEPTH += 1
     completed = False
     try:
         with InsertionPoint(op.body):
@@ -220,7 +171,6 @@ def parallel(start, stop=None, step=None, name=None):
             # scf.forall's terminator, emitted inside the body region.
             InParallelOp()
     finally:
-        _DEPTH -= 1
         if not completed:
             _ABORTED.append("air.parallel")
             with InsertionPoint(op.body):

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -873,6 +873,28 @@ class SegmentContext:
         """
         return Scope("shared", self)
 
+    def per_core(self):
+        """L1 allocated here, and every core gets its own copy of the whole thing.
+
+        The sibling of :meth:`shared`, and the distinction is what the cores
+        see. A ``shared()`` buffer is one allocation that the cores divide
+        between them -- it carries a leading dimension per herd axis and each
+        core addresses its own slab. A ``per_core()`` buffer is not divided:
+        every core gets the shape as written, privately, and no core can see
+        another's.
+
+        What the two have in common is the lifetime, which is the reason to
+        allocate at segment scope at all. A buffer in a herd body dies when that
+        body ends, so state that has to survive from one herd to the next cannot
+        live there. flash_attention/dataflow_based carries a running maximum, a
+        running sum and a running output across three separate herds this way.
+
+        Nothing is sliced, so nothing is subscripted by tile coordinate, and the
+        buffer reaches a kernel whole. It is charged against the 64 KB core
+        budget at full size, because that is what each core spends on it.
+        """
+        return Scope("per_core", self)
+
     def register_buffer(self, buf):
         self._buffers.append(buf)
 
@@ -1427,9 +1449,14 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
             "air.alloc requires scope=<herd>.private() (L1) or "
             "scope=<segment>.private() (L2)"
         )
-    if not isinstance(scope, Scope) or scope.kind not in ("private", "shared"):
+    if not isinstance(scope, Scope) or scope.kind not in (
+        "private",
+        "shared",
+        "per_core",
+    ):
         raise NotImplementedError(
-            f"air.api can only allocate in a private or shared scope, got {scope!r}"
+            f"air.api can only allocate in a private, shared or per_core scope, "
+            f"got {scope!r}"
         )
 
     owner = scope.owner
@@ -1444,7 +1471,7 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
         holder = current_herd()
     elif isinstance(owner, SegmentContext):
         # private() is the memtile; shared() is core L1 with segment lifetime.
-        if scope.kind == "shared":
+        if scope.kind in ("shared", "per_core"):
             space, memory_space, capacity = "L1", MemorySpace.L1, L1_BYTES
         else:
             space, memory_space, capacity = (
@@ -1511,7 +1538,7 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     for extent in shape:
         nbytes *= int(extent)
     nbytes *= dtype.itemsize
-    if scope.kind == "shared":
+    if scope.kind in ("shared", "per_core"):
         # A herd-shared buffer is declared once with one leading dimension per
         # herd axis, and each core addresses exactly one slab of it. Charging
         # the whole thing against one core's 64 KB would reject configurations
@@ -1519,6 +1546,10 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
         # and 16 KB per core. How many leading dimensions are the herd is the
         # herd's business, and no herd has been entered yet: this is segment
         # scope. So the charge is deferred to the herd -- see _charge_shared_l1.
+        #
+        # A per_core buffer has no such ambiguity -- every core spends the whole
+        # of it -- but it is deferred alongside, because the two kinds compete
+        # for the same 64 KB and only a combined total means anything.
         pass
     else:
         # A segment holds L2 memtile buffers and herd-shared L1 buffers at once,
@@ -1535,11 +1566,16 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
             enclosing = current_segment(required=False)
             if enclosing is not None:
                 nlead = len(owner.grid)
-                live += sum(
-                    _buffer_bytes(b, nlead)
-                    for b in enclosing._buffers
-                    if b.space == "L1" and getattr(b.scope, "kind", None) == "shared"
-                )
+                # A shared buffer is charged by the slab this core owns; a
+                # per_core buffer by the whole of it, since every core has one.
+                for b in enclosing._buffers:
+                    if b.space != "L1":
+                        continue
+                    kind = getattr(b.scope, "kind", None)
+                    if kind == "shared":
+                        live += _buffer_bytes(b, nlead)
+                    elif kind == "per_core":
+                        live += _buffer_bytes(b)
         if space == "L1":
             unit, verb = "a compute tile", "has"
         else:
@@ -1568,7 +1604,7 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
         space=space,
     )
     holder.register_buffer(buf)
-    if space == "L1" and scope.kind != "shared":
+    if space == "L1" and scope.kind not in ("shared", "per_core"):
         trace = active_trace()
         trace.l1_peak = max(trace.l1_peak, live)
     return buf
@@ -1593,15 +1629,21 @@ def _charge_shared_l1(segment, nlead, herd_name):
     herd is what says, so the check waits until one is entered. Deferring it is
     not a loosening: a shared buffer is unusable without a herd, so every one
     of them reaches this.
+
+    ``per_core()`` buffers are counted here too. Their own charge needs no herd
+    -- a core spends the whole of one -- but they share the 64 KB with the
+    shared slabs, so only the combined figure is worth checking.
     """
     if segment is None:
         return
-    shared = [
-        b
-        for b in segment._buffers
-        if b.space == "L1" and getattr(b.scope, "kind", None) == "shared"
-    ]
-    if not shared:
+    kinds = {}
+    for b in segment._buffers:
+        kind = getattr(b.scope, "kind", None)
+        if b.space == "L1" and kind in ("shared", "per_core"):
+            kinds.setdefault(kind, []).append(b)
+    shared = kinds.get("shared", [])
+    per_core = kinds.get("per_core", [])
+    if not shared and not per_core:
         return
     for b in shared:
         if len(b.shape) <= nlead:
@@ -1612,12 +1654,15 @@ def _charge_shared_l1(segment, nlead, herd_name):
                 "itself. Give it one leading dimension per herd axis and at "
                 "least one more."
             )
-    live = sum(_buffer_bytes(b, nlead) for b in shared)
+    live = sum(_buffer_bytes(b, nlead) for b in shared) + sum(
+        _buffer_bytes(b) for b in per_core
+    )
     if live > L1_BYTES:
         detail = ", ".join(
-            f"{list(b.shape)} {b.dtype} ({_buffer_bytes(b, nlead) / 1024:.1f} KB "
+            f"{list(b.shape)} {b.dtype} ({_buffer_bytes(b, lead) / 1024:.1f} KB "
             "per core)"
-            for b in shared
+            for group, lead in ((shared, nlead), (per_core, 0))
+            for b in group
         )
         raise ValueError(
             f"L1 budget exceeded: the buffers shared across herd {herd_name!r} "

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1227,7 +1227,7 @@ class HerdContext:
         from air.dialects.air import herd as herd_region
         from air.dialects.scf import for_ as range_, yield_
 
-        from ._loop import aborted_regions, enter_body, exit_body
+        from ._loop import aborted_regions
 
         aborted_before = len(aborted_regions())
 
@@ -1324,14 +1324,12 @@ class HerdContext:
                 free_buffers(herd_self._buffers)
                 herd_self._buffers.clear()
 
-            outer_depth = enter_body()
             try:
                 run_strip_mined(run, herd_self.repeats, range_, yield_)
                 # After the strip nest, not inside it: one alloc above the loop
                 # needs one dealloc below it.
                 herd_self._free_scratch()
             finally:
-                exit_body(outer_depth)
                 herd_self._buffers.clear()
                 herd_self._scratch.clear()
                 for t, v in zip(tensors, saved):
@@ -1424,8 +1422,6 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     from air.dialects.memref import AllocOp
     from air.extras import types as T
 
-    from ._loop import branch_depth
-
     if scope is None:
         raise ValueError(
             "air.alloc requires scope=<herd>.private() (L1) or "
@@ -1483,20 +1479,17 @@ def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     # gives the pipeline one buffer to rotate instead of a fresh one per trip,
     # which is the ping-pong the kernel is built around.
     #
-    # A branch arm is still refused. Both arms of an ops.branch write to the
-    # same enclosing scope, so which alloc a later use refers to is a question
-    # the tracer cannot answer, and the failure would be a silently wrong
-    # buffer rather than a verifier error.
-    if space == "L1" and branch_depth() and not _hoisted:
-        raise NotImplementedError(
-            "air.alloc inside an ops.branch body is not supported: the arm is a "
-            "region the buffer cannot outlive, so a use after the branch would "
-            "not be dominated by its alloc. Hoist the allocation above the "
-            "branch -- both arms then name the same buffer, which is what a "
-            "branch that fills a tile two different ways means. Allocating "
-            "inside an air.sequential is fine: the buffer is freed inside that "
-            "loop."
-        )
+    # A branch arm allocates on the same terms. The arm is a region like the
+    # loop body is, and placement treats it the same way: the dealloc lands in
+    # the arm beside its alloc, so a tile that only one kind of core needs is
+    # written where it is needed rather than hoisted above the branch and paid
+    # for by every core. flash_attention/dataflow_based does this twelve times,
+    # once per scratch tile in each arm of its cascade-stage select.
+    #
+    # What used to make this unsafe was not the allocation but the diagnosis: a
+    # buffer read *after* the arm closed walked off the top of the IR and
+    # aborted the process. _last_use_anchor now reports that as an error naming
+    # the region, so the bad case is caught and the good case is allowed.
     # 0 is meaningful -- it selects the scalar path. Negative is not, and it
     # would otherwise pass a caller's own `tile % width` guard unnoticed, since
     # Python's modulo is 0 for any divisor of the tile regardless of sign.

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1114,6 +1114,15 @@ def _staged_in_scope(segment):
     # to the segment body. The walk stops there rather than running to the
     # module, because `block.owner.operation.block` on the top-level block
     # aborts the process instead of returning None.
+    # Ancestry, not dominance -- and those are only the same thing because the
+    # tracer appends. A buffer is in segment._buffers here only if its alloc has
+    # already been emitted, and a herd is created at the end of its block or
+    # ahead of the terminator, so anything sitting in an ancestor block also
+    # precedes this point. Checked against an exact dominance test over all 72
+    # converted examples: they agree on every buffer. A construct that stepped
+    # back into a closed region to allocate would break that, and this check
+    # would have to compare positions (Operation.is_before_in_block) rather than
+    # just block membership.
     visible, block = set(), InsertionPoint.current.block
     while True:
         visible.add(block)

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -681,6 +681,81 @@ def _region_name(block):
     return owner.name if owner is not None else "region"
 
 
+def prune_unused_operands(op):
+    """Drop the kernel operands ``op``'s body turned out not to touch.
+
+    ``air.segment`` and ``air.herd`` are IsolatedFromAbove, so anything the
+    body reaches has to arrive as an operand -- and the operand list is fixed
+    when the op is created, which is *before* the body runs. The tracer
+    therefore cannot know what the body will touch at the one moment it has to
+    decide, and over-approximates: every tensor, every enclosing coordinate,
+    every L2 buffer still in scope. This is the same bind any builder of these
+    ops is in, which is why ``canonicalizeHierarchyOpArgs`` exists in
+    AIRDialect.cpp to clean up after it.
+
+    Leaving the cleanup to that canonicalization is too late. It runs at PASS
+    014, and ``air-dependency`` runs at 008 -- so the dead operands have
+    already been read as data dependencies by the time they are removed, and
+    the async edges they produced outlive them. In
+    ``flash_attention/dataflow_based`` that serialises three herds the
+    predecessor leaves independent; a loop body with three impure ops instead
+    of one fails ``hasNImpureOps(body, 1)`` in
+    ``HoistAIRHerdsToSharedRegionPattern``, so the herds never hoist out of
+    the loop, never merge, and their L1 accumulators are still herd operands
+    when ``air-verify-hierarchy-locality`` rejects them at 043.
+
+    So the over-approximation is undone here, while the body is fresh and its
+    uses are visible, rather than left for a pass that runs after the damage.
+    The op is rebuilt because an operand list is not resizable in place; the
+    traced block moves across unchanged.
+
+    ``air.launch`` is deliberately not pruned: its operands are the kernel
+    interface, and ``LaunchState.reentry`` holds its block arguments so a
+    later segment can step back into the region.
+    """
+    from air.ir import DenseI32ArrayAttr, InsertionPoint, Operation
+
+    op = op.operation if hasattr(op, "operation") else op
+    segments = op.attributes["operandSegmentSizes"]
+    n_async, n_sizes = segments[0], segments[1]
+    # Block arguments are ids + sizes + operands, so the operands start after
+    # twice the number of size operands.
+    ctrl = 2 * n_sizes
+    block = op.regions[0].blocks[0]
+    dead = [
+        i
+        for i in range(ctrl, len(block.arguments))
+        if not list(block.arguments[i].uses)
+    ]
+    if not dead:
+        return op
+
+    kept = [j for j in range(len(block.arguments) - ctrl) if j + ctrl not in dead]
+    base = n_async + n_sizes
+    operands = list(op.operands[:base]) + [op.operands[base + j] for j in kept]
+    attributes = {name: op.attributes[name] for name in op.attributes}
+    attributes["operandSegmentSizes"] = DenseI32ArrayAttr.get(
+        [n_async, n_sizes, len(kept)]
+    )
+    new = Operation.create(
+        op.name,
+        results=[r.type for r in op.results],
+        operands=operands,
+        attributes=attributes,
+        regions=1,
+        ip=InsertionPoint(op),
+        loc=op.location,
+    )
+    # Highest index first: erasing shifts everything after it down.
+    for i in reversed(dead):
+        block.erase_argument(i)
+    block.append_to(new.regions[0])
+    for old_result, new_result in zip(op.results, new.results):
+        old_result.replace_all_uses_with(new_result)
+    op.erase()
+    return new
+
+
 def free_buffers(buffers):
     """End the life of every buffer that ``air.dealloc`` did not already end.
 
@@ -985,6 +1060,11 @@ class SegmentContext:
                     leaf.value = v
                 _CURRENT_SEGMENT = previous
 
+        # The body has run, so what it touched is finally knowable. Herds
+        # nested inside pruned themselves as they closed, which is what makes
+        # an operand only they had a candidate here too.
+        prune_unused_operands(segment_body)
+
 
 def segment(grid=None, name=None):
     """A device segment with L2 scope; nest herds inside its body."""
@@ -1006,7 +1086,8 @@ def _staged_in_scope(segment):
 
     ``air.herd`` is IsolatedFromAbove, so an L2 buffer the body reaches has to
     be passed in as an operand, and the tracer cannot know which ones the body
-    touches until it has run it -- so it passes every one it can.
+    touches until it has run it -- so it passes every one it can, and drops the
+    unused ones afterwards (``prune_unused_operands``).
 
     "Can" is the point. A buffer allocated inside an ``air.sequential`` at
     segment scope dies with that loop: by the time a *later* herd is emitted,
@@ -1278,10 +1359,11 @@ class HerdContext:
         #
         # Every live one is passed, referenced or not, which is the policy
         # already applied to tensors and to L2 buffers: the tracer cannot know
-        # what the body will touch until it has run it. That is not free -- an
-        # unused herd operand survives air-dependency as an async edge -- but a
-        # coordinate is one index, and correctness for the kernels that need it
-        # is worth the edge for the kernels that do not.
+        # what the body will touch until it has run it. The ones it turns out
+        # not to touch are dropped once it has -- see prune_unused_operands,
+        # and note that leaving them in place is not merely untidy: they reach
+        # air-dependency as data dependencies and serialise herds that have
+        # nothing to do with each other.
         outer = list(current_launch().leaves)
         outer += list(enclosing.leaves) if enclosing is not None else []
         operands = (
@@ -1369,6 +1451,10 @@ class HerdContext:
             herd_body.attributes["link_with"] = StringAttr.get(
                 next(iter(herd_self._objects))
             )
+
+        # After link_with, because pruning rebuilds the op and carries its
+        # attributes across.
+        prune_unused_operands(herd_body)
 
         aborted = aborted_regions()[aborted_before:]
         if aborted:

--- a/python/test/api/errors.py
+++ b/python/test/api/errors.py
@@ -2105,17 +2105,19 @@ def _():
     _trace(body)
 
 
-# CHECK-LABEL: TEST: alloc_inside_a_branch
-# The buffer cannot outlive the arm, so a use after the branch would not be
-# dominated by the alloc. It is also the wrong instinct: L1 is charged per core
-# whether or not that core's branch runs. A loop body, by contrast, is allowed:
-# its dealloc lands inside the loop beside the alloc.
-# CHECK: NotImplementedError: air.alloc inside an ops.branch body
-@expect(NotImplementedError, "alloc_inside_a_branch")
+# CHECK-LABEL: TEST: buffer_read_after_its_branch_closed
+# Allocating inside a branch arm is allowed -- see api/lifetime.py -- but the
+# buffer does not reach past the arm, and this is the shape that used to abort
+# the process instead of saying so.
+# CHECK: RuntimeError: a buffer is used outside the region it was allocated in
+@expect(RuntimeError, "buffer_read_after_its_branch_closed")
 def _():
     def body(h, tx, ty, A, B, C):
+        escaped = None
         with ops.branch(tx == 0):
-            air.alloc([64], bf16, scope=h.private())
+            escaped = air.alloc([64], bf16, scope=h.private())
+            escaped[:] = 1.0
+        escaped[:] = escaped[:] + 1.0
 
     _trace(body)
 

--- a/python/test/api/lifetime.py
+++ b/python/test/api/lifetime.py
@@ -201,3 +201,43 @@ def an_l2_buffer_in_a_loop_is_not_a_herd_operand():
                                 air.ops.store(l1, B[0:1, 0:N])
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: allocated_in_a_branch_is_freed_in_that_arm
+# A branch arm allocates on the same terms as a loop body: the dealloc lands in
+# the arm beside its alloc. That matters for a herd whose cores are not
+# interchangeable -- a scratch tile only one kind of core needs is written where
+# it is needed, rather than hoisted above the branch and charged to every core's
+# L1. flash_attention/dataflow_based does this twelve times.
+# Each arm carries its own alloc/dealloc pair, and neither escapes.
+# CHECK: scf.if
+# CHECK: memref.alloc
+# CHECK: memref.dealloc
+# CHECK: } else {
+# CHECK: memref.alloc
+# CHECK: memref.dealloc
+@run
+def allocated_in_a_branch_is_freed_in_that_arm():
+    A = air.tensor([N, N], i32)
+    B = air.tensor([N, N], i32)
+
+    with air.launch(name="armed") as launch:
+
+        @launch.body
+        def _():
+            with air.herd([range(2)], name="h", shape=(2,)) as h:
+
+                @h.body
+                def _(tx):
+                    out = air.alloc([N], i32, scope=h.private(), vector=0)
+                    with air.ops.branch(tx == 0) as first:
+                        scratch = air.alloc([N], i32, scope=h.private(), vector=0)
+                        air.ops.load(scratch, A[0:1, 0:N])
+                        out[:] = scratch[:] + 1
+                    with first.otherwise():
+                        other = air.alloc([N], i32, scope=h.private(), vector=0)
+                        air.ops.load(other, A[1:2, 0:N])
+                        out[:] = other[:] + 2
+                    air.ops.store(out, B[0:1, 0:N])
+
+    print(launch.mlir())

--- a/python/test/api/lifetime.py
+++ b/python/test/api/lifetime.py
@@ -160,13 +160,15 @@ def allocated_in_a_loop_is_freed_in_that_loop():
 # free_buffers, rather than raise.
 #
 # The staging buffer is allocated and freed inside the loop, and the herd's
-# operand list names the two L3 tensors and nothing else -- in particular not
-# the memory-space-1 buffer the loop above it just finished with.
+# operand list names the one L3 tensor it stores to and nothing else -- in
+# particular not the memory-space-1 buffer the loop above it just finished
+# with. `A` is absent for the milder reason that this body never reads it, and
+# an operand no op in the body touches is dropped once the body has run.
 # CHECK: air.segment
 # CHECK: scf.for
 # CHECK: memref.alloc() : memref<8xi32, 1
 # CHECK: memref.dealloc
-# CHECK: air.herd{{.*}}args({{[^)]*}}) : memref<8x8xi32>, memref<8x8xi32> {
+# CHECK: air.herd{{.*}}args({{[^)]*}}) : memref<8x8xi32> {
 @run
 def an_l2_buffer_in_a_loop_is_not_a_herd_operand():
     A = air.tensor([N, N], i32)

--- a/python/test/api/segment.py
+++ b/python/test/api/segment.py
@@ -92,10 +92,15 @@ def run(f):
 # core, not once per core.
 # CHECK: air.dma_memcpy_nd (%{{.*}}[] [] [], %[[SA]][0, 0] [4, 64] [64, 1]) : (memref<4x64xi32, 1 : i32>, memref<4x64xi32>)
 #
-# The herd is nested inside, and carries the L2 buffers as operands after the
-# tensors -- it is IsolatedFromAbove too, so a memtile buffer cannot simply be
-# referenced from within it.
-# CHECK: air.herd @herd_0 tile (%[[TX:.*]], %{{.*}}) in ({{.*}}) args({{.*}}) : memref<4x64xi32>, memref<4x64xi32>, memref<4x64xi32, 1 : i32>, memref<4x64xi32, 1 : i32>
+# The herd is nested inside, and carries the L2 buffers as operands -- it is
+# IsolatedFromAbove too, so a memtile buffer cannot simply be referenced from
+# within it. It carries *only* those: this body never touches the two L3
+# tensors, and an operand it does not touch is not free. The tracer has to
+# name every candidate when it creates the op, because that is before the body
+# has run, but it drops the ones the body turned out not to use once it has --
+# air-dependency reads a dead operand as a data dependency and would serialise
+# this herd against every other one staged from the same segment.
+# CHECK: air.herd @herd_0 tile (%[[TX:.*]], %{{.*}}) in ({{.*}}) args({{.*}}) : memref<4x64xi32, 1 : i32>, memref<4x64xi32, 1 : i32>
 # CHECK: memref.alloc() : memref<64xi32, 2 : i32>
 #
 # L2 -> L1, one window per core: the tile coordinate becomes the offset, and

--- a/python/test/api/segment.py
+++ b/python/test/api/segment.py
@@ -130,3 +130,54 @@ def staged_passthrough():
 @run
 def staged_f32():
     print(build(dtype=f32).mlir())
+
+
+# CHECK-LABEL: TEST: per_core_reaches_each_herd_whole
+# <segment>.shared() and <segment>.per_core() differ in what the cores see. A
+# shared buffer is one allocation the cores divide between them: it carries a
+# leading dimension per herd axis, and a kernel reached through air.extern is
+# handed a memref.subview of this core's slab. A per_core buffer is not
+# divided -- every core gets its own copy of the whole shape, and the kernel
+# receives it entire.
+#
+# The shape below is flash_attention/dataflow_based's: a [lq, 1] running
+# maximum carried across two separate herds of a 2-D herd grid. shared() cannot
+# express it at all -- both its dimensions would be cores, leaving nothing for
+# the tile -- which is the case checked in api/errors.py.
+# CHECK: %[[UP:.*]] = memref.alloc() : memref<64x1xbf16, 2 : i32>
+# CHECK: air.herd @h {{.*}}%[[A0:.*]]=%[[UP]]{{.*}} memref<64x1xbf16, 2 : i32>
+# CHECK: func.call @zero_fill_sp_bf16(%[[A0]]) : (memref<64x1xbf16, 2 : i32>)
+# CHECK: air.herd @h {{.*}}%[[A1:.*]]=%[[UP]]{{.*}} memref<64x1xbf16, 2 : i32>
+# CHECK: func.call @zero_fill_sp_bf16(%[[A1]]) : (memref<64x1xbf16, 2 : i32>)
+# CHECK-NOT: memref.subview
+@run
+def per_core_reaches_each_herd_whole():
+    from air.api.types import bf16
+
+    B = air.tensor([64, 1], bf16)
+    fill = air.extern("zero_fill_sp_bf16", link_with="attn.o")
+
+    with air.launch(name="carried") as launch:
+
+        @launch.body
+        def _():
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    up = air.alloc([64, 1], bf16, scope=seg.per_core())
+
+                    with air.herd([range(1), range(4)], name="h", shape=(1, 4)) as h0:
+
+                        @h0.body
+                        def _(tx, ty):
+                            fill(up)
+
+                    with air.herd([range(1), range(4)], name="h", shape=(1, 4)) as h1:
+
+                        @h1.body
+                        def _(tx, ty):
+                            fill(up)
+                            air.ops.store(up, B)
+
+    print(launch.mlir())

--- a/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
+++ b/test/airrunner/matmul_bf16_vectorized/run_makefile_airrunner.lit
@@ -30,4 +30,11 @@
 // nothing left to match. See @func8 in
 // mlir/test/Transform/AIRDependencyScheduleOpt/fuse_alloc_dealloc.mlir.
 
-// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 774.592us
+// 774.592us until air.api stopped handing a herd the operands its body never
+// touches. air-dependency reads an unknown op's memref accesses off its operand
+// list alone, taking every operand as both read and written, so two herds that
+// shared a dead operand got an async edge between them. Removing the operands
+// removes the edge, the simulator is free to overlap what the edge had ordered,
+// and the estimate drops by 16ns. Measured on one box with only that commit
+// reverted: 774.592us before, 774.576us after.
+// CHECK: Latency (single-iteration mode, estimated for 16 iterations): 774.576us


### PR DESCRIPTION
Converts `programming_examples/flash_attention/dataflow_based` onto `air.api`,
replacing the raw-bindings `attn.py`. Six herds across three stages -- Q@K, the
online softmax, G@V -- feeding a four-stage cascade that merges the column
results and divides by the running denominator.

### Gating

`air.insts.bin` is **byte-identical** to the predecessor's, so every DMA and
buffer descriptor the host issues is unchanged. `cdo_enable.bin` matches too.
`cdo_elfs.bin` differs, from the two departures below. `cdo_init.bin` is
excluded because it is nondeterministic in this flow -- the same input compiled
twice gives two different hashes.

`PASS!` on npu1 at the lit config, predecessor and conversion run back to back
in one session. The npu2 lit is UNSUPPORTED on the box I have, as it is for the
predecessor.

### The three features it needs

Each lands here with this example as its first consumer.

**Allocation inside a branch arm.** The cascade's arms each need scratch only
their own cores use; hoisting it above the branch would charge every core's L1
for it. This is the second half of a removal whose first half was #1932.

**`<segment>.per_core()`.** `up`/`sp`/`Gp` are L1 but outlive the herd that
writes them -- three separate herds touch them. Unlike `shared()` they are not
divided between cores; each core keeps its own whole copy.

**Dropping the hierarchy operands a body turns out not to touch.** In `air.api`
the user never writes an operand list, so the tracer infers it -- and it has to
create the op before it can run the body that would tell it the answer. It
guessed "everything in scope": 24 operands where 3 were used.

That is not cosmetic. `air-dependency` (PASS 008) classifies an unknown op's
memref accesses from its operand list alone, taking every operand as both read
and written, so herds that share an operand get an async edge. The predecessor's
three in-loop herds have disjoint operand sets and come out independent; ours
had identical 24-buffer lists and came out totally ordered. `canonicalize`
removes the dead operands at PASS 014, but the edges they produced outlive them.
A loop body with three impure ops instead of one then fails
`hasNImpureOps(body, 1)` in `HoistAIRHerdsToSharedRegionPattern`, so the herds
never hoist out of the loop, never merge, and their L1 accumulators are still
herd operands when `air-verify-hierarchy-locality` rejects them at PASS 043.

So the inference now runs after the body has, where the answer is visible. The
op is rebuilt because MLIR will not resize an operand list in place; the traced
block moves across unchanged, minus the arguments nothing used. `air.launch` is
left alone -- its operands are the kernel interface, and `LaunchState.reentry`
holds its block arguments so a later segment can step back into the region.

Swept across all 72 converted examples: 28 change, 21 of them byte-identical
once canonicalized. The other 7 move an L2 `memref.dealloc` earlier, because a
buffer whose only surviving use was an unused herd operand now dies at its real
last use instead of after a herd that never read it. All 7 pass on npu1, with
the rest of the changed set: 32 pass, 2 XFAIL, and one pre-existing
environmental failure that fails identically on the baseline.

### Two deliberate departures from the predecessor's IR

* The cascade select is nested `ops.branch` on the column coordinate, where the
  predecessor writes one `affine.if` over a two-constraint `IntegerSet`.
  `air-to-aie` specialises both away once the herd is unrolled and the
  coordinate is a literal -- `SpecializeScfIfPattern` sits beside
  `SpecializeAffineIfPattern` at three call sites in `AIRToAIEPass.cpp`.
* 26 more `memref.dealloc`, because `air.api` ends a buffer's life at its last
  use and the predecessor lets its cascade-arm scratch leak.

The rest of the diff is the DSL's usual `affine.apply` where the predecessor
uses a raw block argument, and two channels the predecessor declares and never
uses.

### One thing worth reading twice

The three L1->L1 transfers are the subtle part. G leaves each stage in block
order, not row order: the consumer reads one micro-block down every row before
moving to the next block. Reaching that is a reshape with the block axis
outermost followed by a swap with the row axis -- a view, so nothing moves -- and
getting it wrong is silent. Reading the same buffer contiguously compiles, runs,
and returns a plausible smooth ramp that is wrong by a factor of ~15.

🤖 Generated with [Claude Code](https://claude.com/claude-code)