### PR TITLE
[air-opt] Let the prefill engines build at padded length 4096

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1653,6 +1653,161 @@ const std::vector<int> AIE2_WRAP_UPPER_BOUNDS = {64, 1024, 1024, 1024};
 const int AIE2_STRIDE_UPPER_BOUND = 1048576;
 const int AIE2_DIM_COUNT = 4;
 
+// Largest divisor of `n` that is at most `limit` (0 if none, i.e. limit < 1).
+static int64_t largestDivisorUpTo(int64_t n, int64_t limit) {
+  for (int64_t d = std::min(n, limit); d >= 1; d--)
+    if (n % d == 0)
+      return d;
+  return 0;
+}
+
+// Re-partition the outermost run of dims so that fewer shim BDs get unrolled
+// out of it.
+//
+// tileIllegalWrapDim splits an over-long dim into exactly two factors, then
+// hands everything past AIE2_DIM_COUNT to the affine.for unroller below, which
+// costs one shim BD per iteration. Splitting a single dim can leave a partition
+// that is legal but needlessly fine-grained, because it never reconsiders the
+// dims NEXT to the one it split. gelu_and_mul at 4096x10240 (Gemma-3-4B's GeGLU
+// at padded prefill 4096) is the case that motivated this: the airrt descriptor
+// [512, 2, 8, 640] x [81920, 40960, 640, 1] becomes [16, 32, 2, 8, 640], i.e.
+// sixteen BDs each covering only 32*2 = 64 of a 1024-step outer walk. Sixteen
+// is a shim tile's entire budget, so the design fails to compile.
+//
+// Adjacent dims where strides[j] == strides[j+1] * wraps[j+1] describe ONE
+// logical extent walked at the run's innermost stride, so the run can be
+// re-partitioned freely without changing which addresses are touched. Picking
+// the pair that MAXIMIZES the per-BD volume -- subject to the position-0 wrap
+// bound, the position-1 wrap bound, and the stride ceiling on the dim built out
+// of it -- turns the example into [2, 32, 16, 8, 640]: the same transfer in two
+// BDs instead of sixteen.
+//
+// Only ever applied when the list is already over AIE2_DIM_COUNT (so BDs were
+// going to be unrolled regardless) and only when it strictly reduces the unroll
+// count without lengthening the list, so it cannot make a working design worse.
+static void minimizeUnrolledBdCount(SmallVector<OpFoldResult> &offsets,
+                                    SmallVector<OpFoldResult> &wraps,
+                                    SmallVector<OpFoldResult> &strides,
+                                    OpBuilder &builder) {
+  if (wraps.size() <= (size_t)AIE2_DIM_COUNT)
+    return;
+  SmallVector<int64_t> w, s;
+  for (auto [wrap, stride] : llvm::zip_equal(wraps, strides)) {
+    auto cw = getConstantIntValue(wrap);
+    auto cs = getConstantIntValue(stride);
+    if (!cw || !cs)
+      return;
+    w.push_back(*cw);
+    s.push_back(*cs);
+  }
+  // Maximal run of mergeable dims starting at the outermost.
+  unsigned runEnd = 0;
+  while (runEnd + 1 < w.size() && s[runEnd] == s[runEnd + 1] * w[runEnd + 1])
+    runEnd++;
+  unsigned runLen = runEnd + 1;
+  if (runLen < 2)
+    return;
+  // Every dim the run swallows must sit at a known offset 0; re-partitioning
+  // one that does not would move the base address. Offsets past the run are
+  // carried over untouched and so may be anything.
+  for (unsigned j = 0; j <= runEnd; j++) {
+    auto off = getConstantIntValue(offsets[j]);
+    if (!off || *off != 0)
+      return;
+  }
+
+  int64_t runStride = s[runEnd];
+  // A run reaching the contiguous innermost dim would need the shim's inner
+  // element-alignment rule applied to the re-split; leave those alone.
+  if (runStride <= 1)
+    return;
+  int64_t runExtent = 1;
+  for (unsigned j = 0; j <= runEnd; j++)
+    runExtent *= w[j];
+
+  // wraps[0] of the emitted BD must fit the position-0 bound; the dim built on
+  // top of the innermost factor must keep its stride under the ceiling.
+  const int64_t maxOuter = AIE2_WRAP_UPPER_BOUNDS[0] - 1;
+  const int64_t maxInner =
+      std::min<int64_t>(AIE2_WRAP_UPPER_BOUNDS[1] - 1,
+                        (int64_t)AIE2_STRIDE_UPPER_BOUND / runStride);
+  int64_t bestOuter = 0, bestInner = 0, bestVolume = 0;
+  for (int64_t inner = std::min(runExtent, maxInner); inner >= 1; inner--) {
+    if (inner * maxOuter <= bestVolume)
+      break; // cannot beat the incumbent from here down
+    if (runExtent % inner)
+      continue;
+    int64_t outer = largestDivisorUpTo(runExtent / inner, maxOuter);
+    if (outer * inner > bestVolume) {
+      bestVolume = outer * inner;
+      bestOuter = outer;
+      bestInner = inner;
+    }
+  }
+  if (!bestVolume)
+    return;
+
+  int64_t unrollCount = runExtent / bestVolume;
+
+  // Candidate leading dims: the unroll counter (dropped when it is 1) plus the
+  // pair, followed by whatever the run did not cover.
+  SmallVector<int64_t> newW, newS;
+  if (unrollCount > 1) {
+    newW.push_back(unrollCount);
+    newS.push_back(runStride * bestVolume);
+  }
+  newW.push_back(bestOuter);
+  newS.push_back(runStride * bestInner);
+  newW.push_back(bestInner);
+  newS.push_back(runStride);
+  for (unsigned j = runLen; j < w.size(); j++) {
+    newW.push_back(w[j]);
+    newS.push_back(s[j]);
+  }
+
+  // Validate the descriptor the unroller will actually emit. It peels leading
+  // dims until AIE2_DIM_COUNT remain, so the positional wrap bounds and the
+  // stride ceiling apply to the TAIL of the list -- the dim that ends up at BD
+  // position 0 is not necessarily the outer factor chosen above (with an unroll
+  // count of 1 the pair shifts left by one and the inner factor lands there).
+  auto bdStartOf = [](size_t n) -> unsigned {
+    return n > (size_t)AIE2_DIM_COUNT ? n - AIE2_DIM_COUNT : 0;
+  };
+  auto bdCount = [&](ArrayRef<int64_t> ws) {
+    int64_t bds = 1;
+    for (unsigned j = 0, e = bdStartOf(ws.size()); j < e; j++)
+      bds *= ws[j];
+    return bds;
+  };
+  auto isLegalBd = [&](ArrayRef<int64_t> ws, ArrayRef<int64_t> ss) {
+    unsigned bdStart = bdStartOf(ws.size());
+    for (unsigned j = bdStart; j < ws.size(); j++)
+      if (ws[j] >= AIE2_WRAP_UPPER_BOUNDS[j - bdStart] ||
+          ss[j] > AIE2_STRIDE_UPPER_BOUND)
+        return false;
+    return true;
+  };
+  if (!isLegalBd(newW, newS))
+    return; // candidate is not a legal descriptor
+  if (bdCount(newW) >= bdCount(w))
+    return; // no improvement over what the split already produced
+
+  // The run's own dims were all at offset 0 (checked above); the dims past it
+  // keep the offsets they had.
+  SmallVector<OpFoldResult> tailOffsets(offsets.begin() + runLen,
+                                        offsets.end());
+  unsigned newLeading = newW.size() - (w.size() - runLen);
+  wraps.clear();
+  strides.clear();
+  offsets.clear();
+  for (unsigned j = 0; j < newW.size(); j++) {
+    wraps.push_back(builder.getI64IntegerAttr(newW[j]));
+    strides.push_back(builder.getI64IntegerAttr(newS[j]));
+    offsets.push_back(j < newLeading ? builder.getI64IntegerAttr(0)
+                                     : tailOffsets[j - newLeading]);
+  }
+}
+
 bool violatesAIE2WrapLimit(airrt::DmaMemcpyNdOp dma) {
   // Linear shim BDs (contiguous row-major + optional outer dummies/repeat)
   // use the wide buffer_length register and bypass the per-dim 10-bit limit.
@@ -1743,6 +1898,10 @@ LogicalResult tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
       i++;
     }
   }
+
+  // The split above factors one dim at a time, which can leave more BDs to
+  // unroll below than the shim's descriptor limits actually require.
+  minimizeUnrolledBdCount(offsets, wraps, strides, builder);
 
   // Unroll highest dimensions of wrap and stride, if the new dimension count
   // goes beyond 4.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2623,8 +2623,8 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
       auto o0 = getConstantIntValue(offsets[0]);
       auto o1 = getConstantIntValue(offsets[1]);
       bool zeroOuterOffsets = o0 && o1 && *o0 == 0 && *o1 == 0;
-      if (w0 && w1 && s0 && s1 && zeroOuterOffsets &&
-          *w0 > kOutermostWrapMax && *s1 != 0 && *s0 == *s1 * *w1) {
+      if (w0 && w1 && s0 && s1 && zeroOuterOffsets && *w0 > kOutermostWrapMax &&
+          *s1 != 0 && *s0 == *s1 * *w1) {
         int64_t total = *w0 * *w1;
         for (int64_t a = kOutermostWrapMax; a >= 1; a--) {
           if (total % a)

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2583,6 +2583,55 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
       if (postFoldActiveDims > maxNumDims)
         return failure();
     }
+
+    // Outermost-dimension rebalance (shim only).
+    //
+    // canonicalizeWrapAndStrideList splits an oversized extent against a
+    // single `maxSize` (1023) for every dimension, but the outermost shim BD
+    // dimension is narrower than the rest -- a 6-bit count, so 64 on AIE2.
+    // A fold that lands 1024 iterations as [512, 2, ...] is therefore legal by
+    // maxSize and illegal in the slot it occupies, and airrt-to-npu has to
+    // split it again. The descriptor is already at the 4-dim limit by then, so
+    // that second split overflows to 5 dims and gets unrolled into a chain of
+    // one BD per outer iteration: 16 BDs for llama's SwiGLU drain at seq_len
+    // 4096, which alone exhausts a shim tile's 16 BD slots and fails the
+    // build.
+    //
+    // Whenever strides[0] == strides[1] * wraps[1] the two outermost dims
+    // describe one contiguous iteration space, so the same extent can be
+    // re-split as any factor pair. Pick the largest outer factor that fits the
+    // outermost bound while keeping strides[0] under the stride cap: [512, 2]
+    // becomes [32, 32], legal in place, and the descriptor stays a single BD.
+    // Only rebalances descriptors that would otherwise be split downstream, so
+    // anything already legal is emitted byte-for-byte as before.
+    if (!skipZeroStride && wraps.size() >= 2) {
+      // AIE2 shim BD limits, mirrored from AIE2_WRAP_UPPER_BOUNDS /
+      // AIE2_STRIDE_UPPER_BOUND in AIRRtToNpuPass.cpp.
+      constexpr int64_t kOutermostWrapMax = 63;
+      constexpr int64_t kStrideMax = 1048576;
+      auto w0 = getConstantIntValue(wraps[0]);
+      auto w1 = getConstantIntValue(wraps[1]);
+      auto s0 = getConstantIntValue(strides[0]);
+      auto s1 = getConstantIntValue(strides[1]);
+      if (w0 && w1 && s0 && s1 && *w0 > kOutermostWrapMax && *s1 != 0 &&
+          *s0 == *s1 * *w1) {
+        int64_t total = *w0 * *w1;
+        for (int64_t a = kOutermostWrapMax; a >= 1; a--) {
+          if (total % a)
+            continue;
+          int64_t b = total / a;
+          if (b > maxSize)
+            continue;
+          int64_t newS0 = *s1 * b;
+          if (newS0 > kStrideMax)
+            continue;
+          wraps[0] = arith::ConstantIndexOp::create(rewriter, loc, a);
+          wraps[1] = arith::ConstantIndexOp::create(rewriter, loc, b);
+          strides[0] = arith::ConstantIndexOp::create(rewriter, loc, newS0);
+          break;
+        }
+      }
+    }
     // Whether repeat (i.e. stride = 0) is supported at highest dimension.
     if (enableRepeatAtHighestDim && !wraps.empty()) {
       // Force bump up number of dims to maxNumDims.

--- a/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
+++ b/mlir/lib/Transform/AIRDependencyScheduleOpt.cpp
@@ -2613,8 +2613,18 @@ struct AIRSpecializeChannelWrapAndStrideInScfFor
       auto w1 = getConstantIntValue(wraps[1]);
       auto s0 = getConstantIntValue(strides[0]);
       auto s1 = getConstantIntValue(strides[1]);
-      if (w0 && w1 && s0 && s1 && *w0 > kOutermostWrapMax && *s1 != 0 &&
-          *s0 == *s1 * *w1) {
+      // Re-splitting is only address-preserving from the START of the run.
+      // The addresses covered are s1 * [(o0+k0)*w1 + (o1+k1)], so the first is
+      // s1 * (o0*w1 + o1); after the re-split it is s1 * (o0*b + o1). Those
+      // agree only when o0 == 0 -- with a non-zero outer offset, rewriting
+      // strides[0] silently moves the base of the DMA region. o1 is required
+      // zero too: it indexes within the outer dim's span, and that span
+      // changes from w1 to b.
+      auto o0 = getConstantIntValue(offsets[0]);
+      auto o1 = getConstantIntValue(offsets[1]);
+      bool zeroOuterOffsets = o0 && o1 && *o0 == 0 && *o1 == 0;
+      if (w0 && w1 && s0 && s1 && zeroOuterOffsets &&
+          *w0 > kOutermostWrapMax && *s1 != 0 && *s0 == *s1 * *w1) {
         int64_t total = *w0 * *w1;
         for (int64_t a = kOutermostWrapMax; a >= 1; a--) {
           if (total % a)

--- a/mlir/test/Conversion/AIRRtToNpu/minimize_unrolled_bd_count.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/minimize_unrolled_bd_count.mlir
@@ -1,0 +1,102 @@
+//===- minimize_unrolled_bd_count.mlir ------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu -split-input-file %s | FileCheck %s
+
+// tileIllegalWrapDim splits ONE oversized dim into two factors and hands
+// everything past the 4-dim shim limit to the affine.for unroller, which costs
+// one BD per iteration. Because the split never reconsiders the dims NEXT to
+// the one it cut, it can leave a partition that is legal but needlessly fine.
+//
+// This is Gemma-3-4B's GeGLU at padded prefill 4096 (4096x10240 bf16, 8-wide
+// herd). The airrt descriptor is [512, 2, 8, 640] x [81920, 40960, 640, 1].
+// Splitting dim 0 alone gives [16, 32, 2, 8, 640], i.e. SIXTEEN BDs each
+// covering only 32*2 = 64 of the 1024-step outer walk -- a shim tile's entire
+// 16-BD budget on one channel, so the design failed to compile.
+//
+// Dims 0 and 1 are adjacent in the iteration space (81920 == 40960 * 2), so
+// they describe one 1024-step extent walked at stride 40960 and can be
+// re-partitioned freely. The pair that maximizes per-BD volume is 32 x 16:
+// 16 is the largest inner factor keeping the outer stride under the 1 MiB
+// ceiling (40960 * 16 = 655360, where 40960 * 32 would overflow it), and 32 is
+// the largest outer factor inside the 6-bit position-0 wrap bound. That covers
+// 512 of the 1024 steps, so TWO BDs replace sixteen.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<4096x10240xbf16> offset = 0 len = 81920 sizes = [32, 16, 8, 640] strides = [655360, 40960, 640, 1])
+// CHECK: aie.dma_bd(%arg0 : memref<4096x10240xbf16> offset = 20971520 len = 81920 sizes = [32, 16, 8, 640] strides = [655360, 40960, 640, 1])
+// CHECK-NOT: aie.dma_bd
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<4096x10240xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i64 = arith.constant 2 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c640_i64 = arith.constant 640 : i64
+    %c40960_i64 = arith.constant 40960 : i64
+    %c81920_i64 = arith.constant 81920 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    affine.for %arg1 = 0 to 1 {
+      %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c512_i64, %c2_i64, %c8_i64, %c640_i64], [%c81920_i64, %c40960_i64, %c640_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<4096x10240xbf16>) : !airrt.event
+    }
+    return
+  }
+}
+
+// -----
+
+// Non-mergeable neighbour: dim 0 stride 4096 != dim 1 stride 64 * wrap 8, so
+// there is no run to re-partition and the plain one-dim split stands. 128
+// splits into 4 x 32 and the four BDs are emitted unchanged. This is the
+// dma_memcpy_split.mlir shape, pinned here so the re-partition cannot start
+// firing on it.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<128x8x8x64xbf16> offset = 0 len = 1024 sizes = [32, 8, 8, 16] strides = [4096, 64, 512, 1])
+// CHECK: aie.dma_bd(%arg0 : memref<128x8x8x64xbf16> offset = 131072
+// CHECK: aie.dma_bd(%arg0 : memref<128x8x8x64xbf16> offset = 262144
+// CHECK: aie.dma_bd(%arg0 : memref<128x8x8x64xbf16> offset = 393216
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<128x8x8x64xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c8_i64 = arith.constant 8 : i64
+    %c16_i64 = arith.constant 16 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %c128_i64 = arith.constant 128 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    affine.for %arg1 = 0 to 1 {
+      %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c128_i64, %c8_i64, %c8_i64, %c16_i64], [%c4096_i64, %c64_i64, %c512_i64, %c1_i64]) {metadata = @airMemcpyId4} : (i32, i64, i64, memref<128x8x8x64xbf16>) : !airrt.event
+    }
+    return
+  }
+}

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -397,7 +397,8 @@ def build_module(
     if _row_split_out and NB not in (3, 4):
         raise NotImplementedError(
             f"the row-split output placement past 4 rounds is only mapped for "
-            f"NB in (3, 4) (num_heads / num_kv_heads); got NB={NB} from "
+            f"the GQA ratio NB = num_heads / num_kv_heads to be 3 or 4; "
+            f"got NB={NB} from "
             f"num_heads={num_heads}, num_kv_heads={num_kv_heads}. Either keep "
             f"lq <= 4 * lqp (= {4 * lqp}) so the four-tile gathers are used, "
             f"or extend _out_col with a verified column budget for this NB."

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -388,16 +388,16 @@ def build_module(
     # Splitting each block's halves by row instead gives twelve 2-tile gathers,
     # which do fit the five remaining columns; see _out_col for the assignment.
     _row_split_out = q_tiles_per_core == 1 and (lq // lqp) > 4
-    # _out_col's table below is a hand-checked column budget for NB == 3 (the
-    # GQA 3:1 shape, e.g. Llama-3.2-3B). At NB == 4 (GQA 4:1 at head_dim 128,
-    # e.g. Llama-3-8B) the herd spans all 8 columns, so the twelve gathers
-    # become sixteen over seven non-K/V columns and the assignment does not
-    # carry over. Fail here with the reason rather than letting _out_col raise
-    # KeyError halfway through building the module.
-    if _row_split_out and NB != 3:
+    # _out_col's table below is a hand-checked column budget for NB == 3 (GQA
+    # 3:1, e.g. Llama-3.2-3B) and NB == 4 (GQA 4:1, e.g. Llama-3.2-1B), where
+    # the herd spans all 8 columns and sixteen gathers share seven non-K/V
+    # columns. Smaller NB leaves the herd narrower than the table assumes, so
+    # fail here with the reason rather than letting _out_col raise KeyError
+    # halfway through building the module.
+    if _row_split_out and NB not in (3, 4):
         raise NotImplementedError(
             f"the row-split output placement past 4 rounds is only mapped for "
-            f"NB == 3 (num_heads / num_kv_heads == 3); got NB={NB} from "
+            f"NB in (3, 4) (num_heads / num_kv_heads); got NB={NB} from "
             f"num_heads={num_heads}, num_kv_heads={num_kv_heads}. Either keep "
             f"lq <= 4 * lqp (= {4 * lqp}) so the four-tile gathers are used, "
             f"or extend _out_col with a verified column budget for this NB."
@@ -929,13 +929,37 @@ def build_module(
                 # channel is the one with no BD-ID headroom.
                 def _out_col(b, i):
                     if _row_split_out:
-                        # Twelve 2-flow gathers over the five non-K/V columns.
-                        # Every column stays inside both its six S2MM ports and
-                        # its six MM2S channels (cols 0/2/4 spend four of those
-                        # on the Q broadcast), and each block's spill lands on a
-                        # column adjacent to its own pair so the gather still
-                        # routes: block 1 reaches col 1 and col 4, both one hop
-                        # from its tiles in cols 2 and 3.
+                        if NB == 4:
+                            # Sixteen 2-flow gathers, and the herd spans all 8
+                            # columns, so every block keeps its own pair and
+                            # splits its four slices 2/2. Two per column stays
+                            # inside both budgets: four of the six S2MM ports,
+                            # and one MM2S each against the two the Q broadcast
+                            # leaves free on cols 0/2/4/6.
+                            #
+                            # Sixteen gathers need eight memtiles, so col 3
+                            # carries two even though it is the K/V column --
+                            # which is what makes this FIT rather than what
+                            # breaks it. A shim logical tile is grouped by
+                            # source memtile and holds two S2MM, so col 3's
+                            # gathers land on the SAME shim logical tile that
+                            # already carries KIn/VIn on its two MM2S, for
+                            # eight shim logical tiles total. Spilling off col 3
+                            # instead leaves some column with three gathers,
+                            # whose odd one needs a second shim tile: ten
+                            # logical tiles against the eight physical ones
+                            # merge-logical-tiles=false allows, which fails
+                            # placement outright.
+                            return 2 * b + (i // 2)
+                        # NB == 3: twelve 2-flow gathers over the FIVE non-K/V
+                        # columns (the herd is only six wide, so there is no
+                        # eighth memtile to absorb col 3's share and it stays
+                        # private). Every column stays inside both its six S2MM
+                        # ports and its six MM2S channels (cols 0/2/4 spend four
+                        # of those on the Q broadcast), and each block's spill
+                        # lands on a column adjacent to its own pair so the
+                        # gather still routes: block 1 reaches col 1 and col 4,
+                        # both one hop from its tiles in cols 2 and 3.
                         return {
                             0: [0, 0, 1, 1],
                             1: [2, 2, 1, 4],


### PR DESCRIPTION
Three changes that together let the prefill engines build at padded length
4096. They fix unrelated things and are reviewable separately; the FA one is
example Python, the other two are compiler passes.

Needed by #1910's 4096 column: without these, models that get a registry config
(now on main via #1933) still fail to compile at 4096.

## 1. Rebalance the outermost shim BD dim — `AIRDependencyScheduleOpt.cpp`

`canonicalizeWrapAndStrideList` splits an oversized extent against one
`maxSize` (1023) for **every** dimension, but the outermost shim BD dimension is
narrower: a 6-bit count, so 64 on AIE2. A fold that lands 1024 iterations as
`[512, 2, ...]` is therefore legal by `maxSize` and illegal in the slot it
occupies, and `airrt-to-npu` has to split it again. The descriptor is already at
the 4-dim limit by then, so that second split overflows to 5 dims and is
unrolled into one BD per outer iteration -- **16 BDs for llama's SwiGLU drain at
seq_len 4096, which alone exhausts a shim tile's 16 slots and fails the build.**

Whenever `strides[0] == strides[1] * wraps[1]` the two outermost dims describe
one contiguous iteration space, so the extent can be re-split as any factor
pair. Pick the largest outer factor inside the 63 bound that keeps `strides[0]`
under the 1 MiB stride cap: `[512, 2]` becomes `[32, 32]`, legal in place, and
the descriptor stays a single BD.

## 2. FlashAttention `_out_col` for NB == 4 — example Python

`_out_col` is a hand-checked column budget that only covered NB == 3 (GQA 3:1);
NB == 4 hit an explicit `raise`. At NB == 4 the herd spans all 8 columns and
sixteen gathers share seven non-K/V columns, so the NB == 3 assignment does not
carry over. New mapping is `2*b + (i // 2)` -- each block keeps its own column
pair and splits its four slices 2/2.

The counter-intuitive part, which cost a build to learn: **col 3, the K/V
column, must carry two gathers, and that is what makes it fit.** A shim logical
tile is grouped by source memtile and holds 2 S2MM, so col 3's gathers land on
the same logical tile already carrying KIn/VIn on its 2 MM2S -- eight shim
logical tiles. Spilling off col 3 leaves some column with three gathers, whose
odd one needs a second shim tile: ten logical tiles against the eight physical
ones `merge-logical-tiles=false` allows, which fails placement outright.

## 3. Minimize the BDs unrolled out of an over-long wrap — `AIRRtToNpuPass.cpp`

gemma3_4b's `gelu_mul` at 4096 emits `sizes=[32,2,8,640]
strides=[81920,40960,640,1]`, outer extent 1024, 16 tasks per channel. Change 1
provably **cannot** fire there: it needs `b <= 1048576/40960 = 25` and
`a = 1024/b <= 63`, but 1024 is a power of two so `b <= 16` forces `a >= 64` --
no factorization exists. `tileIllegalWrapDim` splits one dim and never
reconsiders its neighbours, so this re-partitions adjacent dims instead: dims 0
and 1 are adjacent in the iteration space (81920 == 40960*2), giving
`[32,16,8,640]` and two BDs.

Comes with a lit test (`minimize_unrolled_bd_count.mlir`). The trap it encodes:
the unroller peels LEADING dims until 4 remain, so the positional wrap bounds
apply to the TAIL of the list -- an earlier version got this wrong and broke
`airrt_to_npu.mlir` and `dma_memcpy_split.mlir`.

## Regression surface, and one gap I want to flag

Changes 1 and 3 are in passes that run for **every** AIR design, not just LLMs.
Both are guarded to fire only on descriptors that were already going to be
re-split downstream (change 1 needs outermost wrap > 63 plus the contiguity
relation; change 3 only runs inside `tileIllegalWrapDim`), so anything legal
today is emitted byte-for-byte as before -- the 2048 IR is byte-identical.

Evidence:

- `check-air-mlir` 521 passed, 0 failures.
- All 8 LLM models sweep 512/1024/2048 through the real harness, 24/24, every
  first-token gate passing.
- A/B at 2048: gemma3_4b 4203 ms with vs 4262 ms without; llama32_1b (control,
  transform never fires) 978 vs 984.
- At 4096, all 8 models build and pass their first-token gate.

*** Gap: change 1 has no lit test. *** I tried to write one and could not
produce a reduced reproducer: every synthetic input I built either merged to a
single contiguous dim, or split with the small factor outermost (`[2, 512, 8]`),
which is already legal and does not trigger the rebalance. So its only coverage
is end-to-end -- llama32_1b at 4096 fails to build without it and builds with it.
I would rather say that than add a test that passes trivially. Happy to keep
digging for a reproducer if a reviewer wants one before this lands.

The `test/xrt/*` device examples were also not run; they are unrunnable in my
build tree and the fold is a shared path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
