### PR TITLE
[air.api] conv2d_14x14 and bf16_cascade, and the reduction bug they found

### DIFF
--- a/programming_examples/conv2d_14x14/conv2d_14x14.py
+++ b/programming_examples/conv2d_14x14/conv2d_14x14.py
@@ -10,246 +10,115 @@ to keep total work identical at 72 oc-groups across CO=1152.
 Both paths execute 14x14 stride-14 conv on 896x896 input, 4 in-channels,
 1152 out-channels, uint8 act / int8 wts / int8 out.
 
-Design highlights:
-  * L2 act buffer holds a full 14-row image-band per memtile (50176 B each,
-    4 memtiles); producer L3->L2 uses a 4D scatter wrap matching upstream's
-    [<14,56>,<64,784>,<56,1>], and consumer L2->L1 gathers via the same
-    [<2,6272>,<98,8>,<8,784>,<8,1>] window the kernel expects.
-  * L1 weights are streamed direct L3->L1 with a 4D shim BD per col. The
-    per-col weight slab is num_g * 12544 bytes (=112896 for npu2, =225792
-    for npu1).
-  * L2->L3 output drain is a flat 65536-B/col S2MM per g iter; host
-    reorders the kernel's [oc=2,nt=2,nt8=8,oc8=8] byte order into
-    upstream-host-major [nt=2,nt8=8,oc=2,oc8=8] before comparing.
+Every transfer here is a *view*, not a copy: the buffer keeps its declared
+shape and the reshape/transpose describes the order the hardware walks it.
+The three that are not simply contiguous:
+
+* **L3 -> L2 activations.** The input is declared ``[4, 802816]`` and read as
+  ``[4, 14, 64, 56]`` over strides ``[802816, 3584, 56, 1]`` -- a band of 14
+  rows per memtile. ``I[:, y0:y0+50176].reshape(4, 14, 64, 56)`` is that,
+  and it is the case ``python/test/api/tensor_views.py`` pins.
+* **The L2 side of the same transfer** wants ``[50176, 56, 784, 1]``, whose
+  middle two strides are swapped relative to row-major. Splitting the memtile
+  band the other way round and permuting gets there:
+  ``reshape(4, 64, 14, 56).transpose(0, 2, 1, 3)``.
+* **L2 -> L1 activations** is the 6-D gather the kernel expects,
+  ``[1, 1, 2, 98, 8, 8]`` over ``[50176, 12544, 6272, 8, 784, 1]``. Same idiom
+  one rank up: ``reshape(4, 4, 2, 8, 98, 8).transpose(0, 1, 2, 4, 3, 5)``,
+  then subscript the two leading axes. An integer subscript keeps its axis in
+  the transfer's sizes, which is where the two leading 1s come from.
+
+All compute is in ``conv2dk14.o``; this file moves data and calls it.
 """
 
 import argparse
 import numpy as np
 import torch
 
-from air.ir import (
-    AffineConstantExpr,
-    AffineExpr,
-    AffineMap,
-    AffineSymbolExpr,
-    IntegerAttr,
-    MemRefType,
-    StringAttr,
-    UnitAttr,
-)
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import (
-    MemorySpace,
-    T,
-    dma_memcpy_nd,
-    herd,
-    launch,
-    module_builder,
-    segment,
-)
-from air.dialects.arith import ConstantOp
-from air.dialects.func import CallOp, FuncOp
-from air.dialects.memref import AllocOp, DeallocOp
-from air.dialects.scf import for_, yield_
+from air import api as air
+from air.api import ops
+from air.api.types import i8, i32
 from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
+KERNEL = "conv2dk14.o"
 
 
-def _mul_const_map(c):
-    """affine_map<(s0) -> (s0 * c)> for affine_apply of `iv * c`."""
-    return AffineMap.get(
-        0,
-        1,
-        [AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(c))],
-    )
+def build_launch(n_cols=8, num_g=9):
+    """An n_cols x 4 herd processing num_g oc-groups per column.
 
-
-def _add_mul_map(c):
-    """affine_map<(s0, s1) -> (s0 * c + s1)> for `iv0 * c + iv1`."""
-    return AffineMap.get(
-        0,
-        2,
-        [
-            AffineExpr.get_add(
-                AffineExpr.get_mul(AffineSymbolExpr.get(0), AffineConstantExpr.get(c)),
-                AffineSymbolExpr.get(1),
-            )
-        ],
-    )
-
-
-@module_builder
-def build_module(n_cols=8, num_g=9):
-    """Build the AIR module for an n_cols x 4 herd processing num_g oc-groups
-    per column. n_cols * num_g must equal 72 (total oc-groups across CO=1152
-    with 16 OC per group). For NPU2 use (8, 9); for NPU1 use (4, 18)."""
+    n_cols * num_g == 72, the total oc-groups across CO=1152.
+    """
     assert (
         n_cols * num_g == 72
     ), f"Expected n_cols * num_g == 72, got {n_cols} * {num_g} = {n_cols * num_g}"
     wts_per_col = num_g * 12544  # bytes per col in the L3 weight slab
     out_per_col = num_g * 65536  # bytes per col in the L3 output slab
 
-    i8 = T.i8()
-    i32 = T.i32()
-    l2_attr = IntegerAttr.get(i32, MemorySpace.L2)
-    l1_attr = IntegerAttr.get(i32, MemorySpace.L1)
+    I = air.tensor([4, 802816], i8)
+    W = air.tensor([n_cols, wts_per_col], i8)
+    O = air.tensor([n_cols, out_per_col], i8)
 
-    # L3 (host) memref types
-    memrefTyI = MemRefType.get([4, 802816], i8)
-    memrefTyW = MemRefType.get([n_cols, wts_per_col], i8)
-    memrefTyO = MemRefType.get([n_cols, out_per_col], i8)
+    conv = air.extern("conv2dk14_i8", link_with=KERNEL, scalars=[i32] * 5)
 
-    # L2 (memtile)
-    l2ActTy = MemRefType.get([4, 14, 3584], i8, memory_space=l2_attr)
-    l2OutTy = MemRefType.get([n_cols, 4, 64, 256], i8, memory_space=l2_attr)
+    with air.launch(name="conv2dk14_test") as launch:
 
-    # L1 (compute tile)
-    l1InTy = MemRefType.get([12544], i8, memory_space=l1_attr)
-    l1WtsTy = MemRefType.get([12544], i8, memory_space=l1_attr)
-    l1OutTy = MemRefType.get([256], i8, memory_space=l1_attr)
+        @launch.body
+        def _():
+            with air.segment(name="conv2dk14_seg") as seg:
 
-    # External kernel
-    conv_func = FuncOp(
-        "conv2dk14_i8",
-        ([l1InTy, l1WtsTy, l1OutTy, i32, i32, i32, i32, i32], []),
-        visibility="private",
-    )
-    conv_func.attributes["link_with"] = StringAttr.get("conv2dk14.o")
-    conv_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+                @seg.body
+                def _():
+                    # One full 14-row image band per memtile, and the output
+                    # staging slab the herd drains into.
+                    l2_act = air.alloc([4, 14, 3584], i8, scope=seg.private())
+                    l2_out = air.alloc([n_cols, 4, 64, 256], i8, scope=seg.private())
 
-    @FuncOp.from_py_func(memrefTyI, memrefTyW, memrefTyO)
-    def conv2dk14_test(I, W, O):
-        @launch(operands=[I, W, O])
-        def launch_body(l3_I, l3_W, l3_O):
-            @segment(name="conv2dk14_seg", operands=[l3_I, l3_W, l3_O])
-            def segment_body(l3_I_s, l3_W_s, l3_O_s):
-                l2_act = AllocOp(l2ActTy, [], [])
-                l2_out = AllocOp(l2OutTy, [], [])
+                    # L3 -> L2: scatter the band. The destination walk swaps
+                    # the two middle axes relative to row-major, hence the
+                    # transpose on the L2 side.
+                    for _gp in air.sequential(num_g):
+                        for yp in air.sequential(16):
+                            y14 = yp * 14
+                            ops.load(
+                                l2_act.reshape(4, 64, 14, 56).transpose(0, 2, 1, 3),
+                                I.reshape(4, 224, 64, 56)[:, y14 : y14 + 14, :, :],
+                            )
 
-                # L3->L2 act fill (num_g oc-groups x 16 y-rows of the 4D
-                # scatter wrap matching upstream's [<14,56>,<64,784>,<56,1>]).
-                mul14 = _mul_const_map(14)
-                for _gp in range_(0, num_g):
-                    for yp in range_(0, 16):
-                        y_off = affine_apply(mul14, [yp])
-                        dma_memcpy_nd(
-                            l2_act,
-                            l3_I_s,
-                            src_offsets=[0, y_off, 0, 0],
-                            src_sizes=[4, 14, 64, 56],
-                            src_strides=[802816, 3584, 56, 1],
-                            dst_offsets=[0, 0, 0, 0],
-                            dst_sizes=[4, 14, 64, 56],
-                            dst_strides=[50176, 56, 784, 1],
-                        )
-                        yield_([])
-                    yield_([])
+                    with air.herd(
+                        [range(n_cols), range(4)],
+                        name="conv2dk14_herd",
+                        shape=(n_cols, 4),
+                        link_with=KERNEL,
+                    ) as h:
 
-                @herd(
-                    name="conv2dk14_herd",
-                    sizes=[n_cols, 4],
-                    operands=[l3_W_s, l2_act, l2_out],
-                )
-                def herd_body(tx, ty, _sx, _sy, _l3_W, _l2_act, _l2_out):
-                    l1_in = AllocOp(l1InTy, [], [])
-                    l1_wts = AllocOp(l1WtsTy, [], [])
-                    l1_out = AllocOp(l1OutTy, [], [])
+                        @h.body
+                        def _(tx, ty):
+                            l1_in = air.alloc([12544], i8, scope=h.private())
+                            l1_wts = air.alloc([12544], i8, scope=h.private())
+                            l1_out = air.alloc([256], i8, scope=h.private())
 
-                    c224 = ConstantOp(IntegerAttr.get(i32, 224), None)
-                    c4_i32 = ConstantOp(IntegerAttr.get(i32, 4), None)
-                    c16_i32 = ConstantOp(IntegerAttr.get(i32, 16), None)
-                    c14_i32 = ConstantOp(IntegerAttr.get(i32, 14), None)
+                            # The 6-D gather, subscripted at (memtile, quarter).
+                            act = l2_act.reshape(4, 4, 2, 8, 98, 8).transpose(
+                                0, 1, 2, 4, 3, 5
+                            )
 
-                    mul12544 = _mul_const_map(12544)
-                    y4_plus_xb = _add_mul_map(4)
+                            for g in air.sequential(num_g):
+                                w0 = g * 12544
+                                ops.load(l1_wts, W[tx, w0 : w0 + 12544])
+                                for y in air.sequential(16):
+                                    for xb in air.sequential(4):
+                                        ops.load(l1_in, act[ty, xb, :, :, :, :])
+                                        conv(l1_in, l1_wts, l1_out, 224, 4, 16, 14, 14)
+                                        ops.store(
+                                            l1_out, l2_out[tx, ty, y * 4 + xb, 0:256]
+                                        )
 
-                    for g in range_(0, num_g):
-                        g_off = affine_apply(mul12544, [g])
+                    # L2 -> L3: one flat 65536-B/col drain per g iteration.
+                    for gg in air.sequential(num_g):
+                        g0 = gg * 65536
+                        ops.store(l2_out.reshape(n_cols, 65536), O[:, g0 : g0 + 65536])
 
-                        # L3->L1 wts (per oc-group, per col=tx).
-                        dma_memcpy_nd(
-                            l1_wts,
-                            _l3_W,
-                            src_offsets=[tx, g_off],
-                            src_sizes=[1, 12544],
-                            src_strides=[wts_per_col, 1],
-                        )
-
-                        for y in range_(0, 16):
-                            for xb in range_(0, 4):
-                                # L2->L1 act gather (4D inner wrap
-                                # [<2,6272>,<98,8>,<8,784>,<8,1>] selected
-                                # per (tx_row=ty, xb_col=xb) image block).
-                                dma_memcpy_nd(
-                                    l1_in,
-                                    _l2_act,
-                                    src_offsets=[ty, xb, 0, 0, 0, 0],
-                                    src_sizes=[1, 1, 2, 98, 8, 8],
-                                    src_strides=[
-                                        50176,
-                                        12544,
-                                        6272,
-                                        8,
-                                        784,
-                                        1,
-                                    ],
-                                )
-
-                                CallOp(
-                                    conv_func,
-                                    [
-                                        l1_in,
-                                        l1_wts,
-                                        l1_out,
-                                        c224,
-                                        c4_i32,
-                                        c16_i32,
-                                        c14_i32,
-                                        c14_i32,
-                                    ],
-                                )
-
-                                # L1->L2 out: drop the 256-B kernel result
-                                # at (col=tx, row=ty, y_xb_slot=i_yx).
-                                i_yx = affine_apply(y4_plus_xb, [y, xb])
-                                dma_memcpy_nd(
-                                    _l2_out,
-                                    l1_out,
-                                    dst_offsets=[tx, ty, i_yx, 0],
-                                    dst_sizes=[1, 1, 1, 256],
-                                    dst_strides=[65536, 16384, 256, 1],
-                                )
-                                yield_([])
-                            yield_([])
-                        yield_([])
-
-                    DeallocOp(l1_in)
-                    DeallocOp(l1_wts)
-                    DeallocOp(l1_out)
-
-                herd_body.attributes["link_with"] = StringAttr.get("conv2dk14.o")
-
-                # L2->L3 out drain (flat 65536 B per (col, g iter)). Host
-                # reorders the per-call [oc, nt, nt8, oc8] byte order into
-                # spatial [nt, nt8, oc, oc8] before comparing.
-                mul65536 = _mul_const_map(65536)
-                for g in range_(0, num_g):
-                    gg_off = affine_apply(mul65536, [g])
-                    dma_memcpy_nd(
-                        l3_O_s,
-                        l2_out,
-                        dst_offsets=[0, gg_off],
-                        dst_sizes=[n_cols, 65536],
-                        dst_strides=[out_per_col, 1],
-                        src_offsets=[0, 0, 0, 0],
-                        src_sizes=[n_cols, 4, 64, 256],
-                        src_strides=[65536, 16384, 256, 1],
-                    )
-                    yield_([])
-
-                DeallocOp(l2_act)
-                DeallocOp(l2_out)
+    return launch
 
 
 # Problem dims (fixed to match the IR string)
@@ -381,9 +250,9 @@ if __name__ == "__main__":
 
     n_cols, num_g = DEVICE_LAYOUTS[args.target_device]
 
-    mlir_module = build_module(n_cols=n_cols, num_g=num_g)
+    launch = build_launch(n_cols=n_cols, num_g=num_g)
     if args.print_module_only:
-        print(mlir_module)
+        print(launch.mlir())
         exit(0)
 
     in1, in2, expected_out = build_inputs_and_golden(n_cols, num_g)
@@ -398,7 +267,7 @@ if __name__ == "__main__":
     )
     exit(
         runner.run_test(
-            mlir_module,
+            launch.build(target=args.target_device),
             inputs=[in1, in2],
             expected_outputs=[expected_out],
         )

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade.py
@@ -1,107 +1,65 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-#
-# Cascade-based matrix-vector multiplication (GEMV): C[M] = A[M,K] @ B[K]
-# BF16 input/output, accfloat accumulation in the kernel.
-#
-# Uses cascade channels to split K-reduction across `n_cascade` tiles in each
-# column.  Each column handles `tile_m` independent output rows.  `herd_cols`
-# columns run in parallel.
-#
-# Cascade flows north-to-south within each column:
-#   ty == n_cascade-1 (first/northernmost): compute partial dot → cascade put
-#   ty == 1..n_cascade-2 (middle): cascade get → add own partial → cascade put
-#   ty == 0 (last/southernmost): cascade get → add own partial → write result
-#
-# L2 (MemTile) staging for A and C; B goes L3→L1 directly (broadcast).
-#
-# The cascade data transfer is compiler-managed: air.channel.put/get on cascade
-# channels are lowered to aie.put_cascade/aie.get_cascade by the compiler.
-# The kernels do NOT call put_mcd/get_scd directly.
+"""Cascade matrix-vector multiplication (GEMV) on air.api: C[M] = A[M,K] @ B[K].
+
+bf16 in and out, accumulated in f32.
+
+The K reduction is split across ``n_cascade`` cores stacked in one column, and
+``herd_cols`` such columns run side by side, each owning ``tile_m`` output rows.
+Every core dots its own K chunk; the partial sums travel *down* the column over
+a cascade channel, which is a direct core-to-core link rather than a DMA
+stream::
+
+    ty == n_cascade-1  (northernmost)   dot            -> put
+    ty == 1..n_cascade-2  (middle)      get -> dot, += -> put
+    ty == 0            (southernmost)   get -> dot, += -> L1 -> L2 -> L3
+
+A and C stage through L2; B goes L3 -> L1 directly, since each core reads a
+different slice of it.
+
+Three things about this port are worth knowing.
+
+**The three cascade stages are one traced body, not three.** A herd body is
+traced once for every core, so the stage a core plays has to be an ``scf.if``
+on its coordinate -- ``ops.branch(ty == ...)`` -- and not a Python ``if``,
+which would pick one stage for all of them. That is the same shape
+``programming_examples/cascade_reduction`` uses, one level deeper.
+
+**The dot product is written out, not called.** ``ops.dot`` accumulates through
+a loop-carried vector, which does not legalize on AIE2; the predecessor
+therefore hand-rolled a bf16 -> f32 widening FMA over a 16-lane f32
+accumulator, and so does this. ``ops.fma`` and ``ops.cast`` emit exactly the
+``vector.fma`` and ``arith.extf`` it emitted, and ``ops.reduce_add`` the closing
+``vector.reduction <add>``.
+
+**The partial sum goes through ``scratch`` instead of an SSA value.** A
+reduction is the whole right-hand side of a statement -- it is the one op whose
+result shape differs from its operand's -- so it cannot be added to the value
+arriving from the north in the same expression. It lands in ``scratch`` first
+and is folded in on the next line, which the middle stage wanted anyway (that
+is the buffer it forwards) and which costs the last stage one store and one
+load per row. That is the only departure from the predecessor's IR.
+"""
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith, scf
-from air.dialects.memref import (
-    AllocOp,
-    DeallocOp,
-    subview,
-    load as memref_load,
-    store as memref_store,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    reduction as vector_reduction,
-    fma,
-)
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
-
-
-def compute_partial_dot(
-    row,
-    _l1_a,
-    _l1_b,
-    l1_acc_tmp,
-    c0,
-    k_chunk,
-    f32_vec_size,
-    vecTy_bf16,
-    vecTy_f32,
-    identity_map,
-    read_map_2d,
-    cst0_bf16,
-    cst0_f32,
-    f32_type,
-):
-    """Emit IR to compute a single-row bf16 dot product into an f32 accumulator.
-
-    Zero-initialises l1_acc_tmp, then accumulates A[row, :] * B[:] in f32
-    via bf16->f32 extension + vector.fma.  Returns the scalar f32 horizontal
-    sum of the accumulator.  Must be called within the correct InsertionPoint.
-    """
-    zero_vec_f32 = BroadcastOp(vecTy_f32, cst0_f32)
-    transfer_write(None, zero_vec_f32, l1_acc_tmp, [c0], identity_map, [True])
-
-    # Vectorized dot product: bf16 inputs extended to f32 for accfloat precision
-    for j_k in range_(0, k_chunk, f32_vec_size):
-        sub_a = subview(_l1_a, [row, j_k], [1, f32_vec_size], [1, 1])
-        sub_b = subview(_l1_b, [j_k], [f32_vec_size], [1])
-        v_a_bf16 = transfer_read(
-            vecTy_bf16, sub_a, [c0, c0], read_map_2d, cst0_bf16, [True]
-        )
-        v_b_bf16 = transfer_read(
-            vecTy_bf16, sub_b, [c0], identity_map, cst0_bf16, [True]
-        )
-        v_a_f32 = arith.extf(vecTy_f32, v_a_bf16)
-        v_b_f32 = arith.extf(vecTy_f32, v_b_bf16)
-        v_acc = transfer_read(
-            vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True]
-        )
-        v_result = fma(v_a_f32, v_b_f32, v_acc)
-        transfer_write(None, v_result, l1_acc_tmp, [c0], identity_map, [True])
-        yield_([])
-
-    # Horizontal reduction of f32 accumulator to scalar f32
-    v_final = transfer_read(vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True])
-    return vector_reduction(f32_type, "add", v_final)
+# f32 lanes per FMA: 16 x 32 bits is the full 512-bit SIMD width.
+VEC = 16
+# The AIE2P cascade bus is 512 bits wide, so a cascade payload is a whole
+# multiple of 16 floats however few rows a column actually carries.
+CASCADE_WIDTH = 16
 
 
-@module_builder
-def build_module(
-    m, k, tile_m, m_input, herd_cols, n_cascade, np_dtype_in, np_dtype_out
-):
+def build_module(m, k, tile_m, m_input, herd_cols, n_cascade):
     assert (
         n_cascade >= 2
     ), f"n_cascade ({n_cascade}) must be >= 2 for a cascade pipeline"
@@ -118,10 +76,8 @@ def build_module(
     ), f"k_chunk ({k_chunk}) must be divisible by 64 (vector width)"
 
     # L2 capacity guard.
-    bytes_per_elem_in = np.dtype(np_dtype_in).itemsize
-    bytes_per_elem_out = np.dtype(np_dtype_out).itemsize
-    a_l2_bytes = herd_cols * tile_m * k * bytes_per_elem_in
-    c_l2_bytes = herd_cols * tile_m * bytes_per_elem_out
+    a_l2_bytes = herd_cols * tile_m * k * 2
+    c_l2_bytes = herd_cols * tile_m * 2
     L2_CAPACITY = 512 * 1024
     assert a_l2_bytes + c_l2_bytes <= L2_CAPACITY, (
         f"L2 capacity exceeded: A={a_l2_bytes}B + C={c_l2_bytes}B = "
@@ -129,411 +85,169 @@ def build_module(
         f"Reduce herd_cols ({herd_cols}), tile_m ({tile_m}), or k ({k})."
     )
 
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
-    f32_type = F32Type.get()
-
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get([m, k], xrt_dtype_in)
-    memrefTyB = MemRefType.get([k], xrt_dtype_in)
-    memrefTyC = MemRefType.get([m], xrt_dtype_out)
-
-    # L2 MemRefTypes — A staged as [herd_cols, tile_m, k]
-    l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-    l2MemrefTyA = MemRefType.get(
-        shape=[herd_cols, tile_m, k],
-        element_type=xrt_dtype_in,
-        memory_space=l2_mem_space,
-    )
-    l2MemrefTyC = MemRefType.get(
-        shape=[herd_cols, tile_m],
-        element_type=xrt_dtype_out,
-        memory_space=l2_mem_space,
-    )
-
-    # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    # Each tile sees m_input rows x k_chunk columns of A.
-    l1MemrefTyA = MemRefType.get(
-        shape=[m_input, k_chunk],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    # Full B vector slice for this tile's k_chunk.
-    l1MemrefTyB = MemRefType.get(
-        shape=[k_chunk],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    # Output buffer (only used by last tile ty==0).
-    l1MemrefTyC = MemRefType.get(
-        shape=[tile_m],
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    # Cascade bus width on AIE2P is 512 bits = 16 floats.
-    # The cascade buffer must be padded to this width.
-    CASCADE_WIDTH = 16  # 512 bits / 32 bits per float
-    cascade_buf_len = max(tile_m, CASCADE_WIDTH)
-    # Round up to multiple of CASCADE_WIDTH for multi-beat transfers.
-    cascade_buf_len = (
-        (cascade_buf_len + CASCADE_WIDTH - 1) // CASCADE_WIDTH
+    cascade_len = (
+        (max(tile_m, CASCADE_WIDTH) + CASCADE_WIDTH - 1) // CASCADE_WIDTH
     ) * CASCADE_WIDTH
 
-    # Float partial sum buffers (used for cascade data transfer and kernel I/O).
-    # scratch: kernel output for first/middle tiles; cascade put source
-    # recv: cascade get destination; kernel input for middle/last tiles
-    # Sized to cascade_buf_len (padded to 512-bit cascade width).
-    l1MemrefTyScratch = MemRefType.get(
-        shape=[cascade_buf_len],
-        element_type=f32_type,
-        memory_space=l1_mem_space,
+    A = air.tensor([m, k], bf16)
+    B = air.tensor([k], bf16)
+    C = air.tensor([m], bf16)
+
+    # One link per adjacent pair in each column, so n_cascade-1 per column.
+    cascade = air.channel(
+        "chan_cascade", size=[herd_cols, n_cascade - 1], channel_type="npu_cascade"
     )
 
-    # Cascade channel: per-column cascade links.
-    # n_cascade tiles per column → n_cascade-1 links per column.
-    channel("chan_cascade", size=[herd_cols, n_cascade - 1], channel_type="npu_cascade")
+    # One launch iteration per band of herd_cols * tile_m output rows.
+    with air.launch(
+        [range(m // tile_m // herd_cols), range(1)], name="matvec_cascade_bf16"
+    ) as launch:
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyC)
-    def matvec_cascade_bf16(arg0, arg1, arg2):
+        @launch.body
+        def _(li, lj):
 
-        # Each launch handles herd_cols * tile_m output rows.
-        launch_size = [m // tile_m // herd_cols, 1]
+            with air.segment(name="matvec_cascade_0") as seg:
 
-        @launch(operands=[arg0, arg1, arg2], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_c_data,
-        ):
+                @seg.body
+                def _():
+                    l2_a = air.alloc([herd_cols, tile_m, k], bf16, scope=seg.private())
+                    l2_c = air.alloc([herd_cols, tile_m], bf16, scope=seg.private())
 
-            @segment(
-                name="matvec_cascade_0",
-                operands=[launch_ivx, l3_a_data, l3_b_data, l3_c_data],
-            )
-            def segment_body(
-                launch_ivx_s,
-                l3_a_data_s,
-                l3_b_data_s,
-                l3_c_data_s,
-            ):
-                # Row offset = launch_ivx * tile_m * herd_cols
-                launch_ivx_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_m * herd_cols),
-                        )
-                    ],
-                )
-                launch_offset_m = affine_apply(launch_ivx_map, [launch_ivx_s])
-
-                # Alloc L2 buffers
-                l2_a_data = AllocOp(l2MemrefTyA, [], [])
-                l2_c_data = AllocOp(l2MemrefTyC, [], [])
-
-                # L3→L2: A (all herd_cols * tile_m rows, full K)
-                dma_memcpy_nd(
-                    l2_a_data,
-                    l3_a_data_s,
-                    src_offsets=[0, launch_offset_m, 0],
-                    src_sizes=[herd_cols, tile_m, k],
-                    src_strides=[tile_m * k, k, 1],
-                )
-
-                # Alloc L1 buffers
-                l1_a_data = AllocOp(l1MemrefTyA, [], [])
-                l1_b_data = AllocOp(l1MemrefTyB, [], [])
-                l1_c_data = AllocOp(l1MemrefTyC, [], [])
-                l1_scratch = AllocOp(l1MemrefTyScratch, [], [])
-                l1_recv = AllocOp(l1MemrefTyScratch, [], [])
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_cols, n_cascade],
-                    operands=[
-                        l1_a_data,
-                        l1_b_data,
-                        l1_c_data,
-                        l1_scratch,
-                        l1_recv,
-                        l2_a_data,
-                        l3_b_data_s,
-                        l2_c_data,
-                    ],
-                )
-                def herd_body(
-                    tx,
-                    ty,
-                    sx,
-                    sy,
-                    _l1_a,
-                    _l1_b,
-                    _l1_c,
-                    _l1_scratch,
-                    _l1_recv,
-                    _l2_a,
-                    _l3_b,
-                    _l2_c,
-                ):
-                    c0 = arith.ConstantOp.create_index(0)
-                    c1_idx = arith.ConstantOp.create_index(1)
-                    last_ty = arith.ConstantOp.create_index(n_cascade - 1)
-
-                    # k_offset = ty * k_chunk
-                    ty_k_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(k_chunk),
-                            )
-                        ],
-                    )
-                    k_offset = affine_apply(ty_k_map, [ty])
-
-                    # L3→L1: B[k_offset:k_offset+k_chunk] directly
-                    dma_memcpy_nd(
-                        _l1_b,
-                        _l3_b,
-                        src_offsets=[k_offset],
-                        src_sizes=[k_chunk],
-                        src_strides=[1],
-                    )
-
-                    # === Cascade pipeline logic setup (inline vector implementation) ===
-                    # f32 accumulation: 16 f32 = 512 bits (full SIMD width).
-                    # A and B are read as bf16 (16 elements) and extended to f32 before
-                    # FMA to match the precision of accfloat accumulation in the
-                    # external kernel reference.
-                    f32_vec_size = 16
-                    vecTy_bf16 = VectorType.get([f32_vec_size], xrt_dtype_in)
-                    vecTy_f32 = VectorType.get([f32_vec_size], f32_type)
-                    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-                    # (d0, d1) -> (d1): project 2D subview offset to the k dimension
-                    read_map_2d = AffineMapAttr.get(
-                        AffineMap.get(2, 0, [AffineExpr.get_dim(1)])
-                    )
-                    cst0_bf16 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    cst0_f32 = arith.ConstantOp(f32_type, 0.0)
-                    # Affine map for last-tile output index: s0 + s1 (j_m_offset + row)
-                    row_out_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineSymbolExpr.get(1),
-                            )
+                    # A's rows split into bands of tile_m, so the band index is
+                    # the outer axis of the reshape and this launch iteration
+                    # takes herd_cols consecutive bands.
+                    ops.load(
+                        l2_a,
+                        A.reshape(m // tile_m, tile_m, k)[
+                            li * herd_cols : li * herd_cols + herd_cols, :, :
                         ],
                     )
 
-                    # Allocate temp buffer for f32 vector accumulator (reused across all rows)
-                    l1MemrefTyAccTmp = MemRefType.get(
-                        shape=[f32_vec_size],
-                        element_type=f32_type,
-                        memory_space=l1_mem_space,
-                    )
-                    l1_acc_tmp = AllocOp(l1MemrefTyAccTmp, [], [])
+                    # L1, but allocated here: a core's stage buffers are read
+                    # and written across the whole herd, and per_core gives each
+                    # core its own whole copy rather than a slab of one.
+                    l1_a = air.alloc([m_input, k_chunk], bf16, scope=seg.per_core())
+                    l1_b = air.alloc([k_chunk], bf16, scope=seg.per_core())
+                    l1_c = air.alloc([tile_m], bf16, scope=seg.per_core())
+                    scratch = air.alloc([cascade_len], f32, scope=seg.per_core())
+                    recv = air.alloc([cascade_len], f32, scope=seg.per_core())
 
-                    # Shared args tuple for compute_partial_dot calls
-                    dot_args = (
-                        _l1_a,
-                        _l1_b,
-                        l1_acc_tmp,
-                        c0,
-                        k_chunk,
-                        f32_vec_size,
-                        vecTy_bf16,
-                        vecTy_f32,
-                        identity_map,
-                        read_map_2d,
-                        cst0_bf16,
-                        cst0_f32,
-                        f32_type,
-                    )
+                    with air.herd(
+                        [range(herd_cols), range(n_cascade)],
+                        name="herd_0",
+                        shape=(herd_cols, n_cascade),
+                    ) as h:
 
-                    # Loop over m_input rows at a time
-                    for j_m in range_(0, tile_m // m_input):
-                        j_m_map = AffineMap.get(
-                            0,
-                            1,
-                            [
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(0),
-                                    AffineConstantExpr.get(m_input),
-                                )
-                            ],
-                        )
-                        j_m_offset = affine_apply(j_m_map, [j_m])
+                        @h.body
+                        def _(tx, ty):
+                            k0 = ty * k_chunk
+                            ops.load(l1_b, B[k0 : k0 + k_chunk])
 
-                        # L2→L1: A[tx, j_m_offset:j_m_offset+m_input, k_offset:k_offset+k_chunk]
-                        dma_memcpy_nd(
-                            _l1_a,
-                            _l2_a,
-                            src_offsets=[tx, j_m_offset, k_offset],
-                            src_sizes=[1, m_input, k_chunk],
-                            src_strides=[tile_m * k, k, 1],
-                        )
+                            acc = air.alloc([VEC], f32, scope=h.private())
 
-                        # First tile (ty == n_cascade-1): compute → cascade put
-                        cmp_first = arith.CmpIOp(arith.CmpIPredicate.eq, ty, last_ty)
-                        if_first = scf.IfOp(cmp_first, has_else=True)
-                        with InsertionPoint(if_first.then_block):
-                            for row in range_(0, m_input):
-                                partial_sum = compute_partial_dot(row, *dot_args)
-                                sub_scratch = subview(_l1_scratch, [row], [1], [1])
-                                memref_store(partial_sum, sub_scratch, [c0])
-                                yield_([])
-
-                            prev_ty = arith.SubIOp(ty, c1_idx)
-                            ChannelPut(
-                                "chan_cascade", _l1_scratch, indices=[tx, prev_ty]
-                            )
-                            yield_([])
-
-                        with InsertionPoint(if_first.else_block):
-                            # Last tile (ty == 0): cascade get → compute → write to output
-                            cmp_last = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
-                            if_last = scf.IfOp(cmp_last, has_else=True)
-                            with InsertionPoint(if_last.then_block):
-                                ChannelGet("chan_cascade", _l1_recv, indices=[tx, ty])
-
-                                for row in range_(0, m_input):
-                                    partial_sum = compute_partial_dot(row, *dot_args)
-                                    sub_recv = subview(_l1_recv, [row], [1], [1])
-                                    recv_val = memref_load(sub_recv, [c0])
-                                    total = arith.addf(recv_val, partial_sum)
-                                    total_bf16 = arith.truncf(xrt_dtype_out, total)
-                                    out_idx = affine_apply(
-                                        row_out_map, [j_m_offset, row]
+                            def dot_into_scratch(row):
+                                """scratch[row] = A[row, :] . B[:], in f32."""
+                                acc[:] = 0.0
+                                for jk in air.sequential(0, k_chunk, VEC):
+                                    acc[:] = ops.fma(
+                                        ops.cast(l1_a[row, jk : jk + VEC], f32),
+                                        ops.cast(l1_b[jk : jk + VEC], f32),
+                                        acc[:],
                                     )
-                                    sub_c_out = subview(_l1_c, [out_idx], [1], [1])
-                                    memref_store(total_bf16, sub_c_out, [c0])
-                                    yield_([])
+                                scratch[row : row + 1] = ops.reduce_add(acc[:])
 
-                                yield_([])
-
-                            with InsertionPoint(if_last.else_block):
-                                # Middle tiles: cascade get → compute → cascade put
-                                ChannelGet("chan_cascade", _l1_recv, indices=[tx, ty])
-
-                                for row in range_(0, m_input):
-                                    partial_sum = compute_partial_dot(row, *dot_args)
-                                    sub_recv = subview(_l1_recv, [row], [1], [1])
-                                    recv_val = memref_load(sub_recv, [c0])
-                                    total = arith.addf(recv_val, partial_sum)
-                                    sub_scratch = subview(_l1_scratch, [row], [1], [1])
-                                    memref_store(total, sub_scratch, [c0])
-                                    yield_([])
-
-                                prev_ty_mid = arith.SubIOp(ty, c1_idx)
-                                ChannelPut(
-                                    "chan_cascade",
-                                    _l1_scratch,
-                                    indices=[tx, prev_ty_mid],
+                            for jm in air.sequential(0, tile_m // m_input):
+                                j0 = jm * m_input
+                                ops.load(
+                                    l1_a,
+                                    l2_a[tx, j0 : j0 + m_input, k0 : k0 + k_chunk],
                                 )
-                                yield_([])
 
-                            yield_([])
+                                with ops.branch(ty == n_cascade - 1) as head:
+                                    # Northernmost: nothing to add in.
+                                    for row in air.sequential(0, m_input):
+                                        dot_into_scratch(row)
+                                    cascade.put(scratch, indices=[tx, ty - 1])
 
-                        yield_([])
+                                with head.otherwise():
+                                    with ops.branch(ty == 0) as tail:
+                                        # Southernmost: fold in and narrow.
+                                        cascade.get(recv, indices=[tx, ty])
+                                        for row in air.sequential(0, m_input):
+                                            dot_into_scratch(row)
+                                            o = j0 + row
+                                            l1_c[o : o + 1] = ops.cast(
+                                                recv[row : row + 1]
+                                                + scratch[row : row + 1],
+                                                bf16,
+                                            )
 
-                    # Only ty==0 tiles write results back: L1→L2
-                    cmp_writer = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
-                    if_writer = scf.IfOp(cmp_writer)
-                    with InsertionPoint(if_writer.then_block):
-                        dma_memcpy_nd(
-                            _l2_c,
-                            _l1_c,
-                            dst_offsets=[tx, 0],
-                            dst_sizes=[1, tile_m],
-                            dst_strides=[tile_m, 1],
-                            src_offsets=[],
-                            src_sizes=[tile_m],
-                            src_strides=[1],
-                        )
-                        yield_([])
+                                    with tail.otherwise():
+                                        # Middle: fold in and forward south.
+                                        cascade.get(recv, indices=[tx, ty])
+                                        for row in air.sequential(0, m_input):
+                                            dot_into_scratch(row)
+                                            scratch[row : row + 1] = (
+                                                recv[row : row + 1]
+                                                + scratch[row : row + 1]
+                                            )
+                                        cascade.put(scratch, indices=[tx, ty - 1])
 
-                    # Deallocate temp accumulator buffer
-                    DeallocOp(l1_acc_tmp)
+                            # Only the southernmost core of each column holds a
+                            # finished result.
+                            with ops.branch(ty == 0):
+                                ops.store(l1_c, l2_c[tx, :])
 
-                # L2→L3: C
-                dma_memcpy_nd(
-                    l3_c_data_s,
-                    l2_c_data,
-                    dst_offsets=[launch_offset_m],
-                    dst_sizes=[herd_cols * tile_m],
-                    dst_strides=[1],
-                    src_offsets=[0, 0],
-                    src_sizes=[herd_cols, tile_m],
-                    src_strides=[tile_m, 1],
-                )
+                    band = li * herd_cols * tile_m
+                    ops.store(
+                        l2_c.reshape(herd_cols * tile_m),
+                        C[band : band + herd_cols * tile_m],
+                    )
 
-                DeallocOp(l2_a_data)
-                DeallocOp(l2_c_data)
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_c_data)
-                DeallocOp(l1_scratch)
-                DeallocOp(l1_recv)
+    return launch
 
 
-if __name__ == "__main__":
-    # Default values for NPU2 8-column x 4-row cascade
-    # tile_m=2 with 8 cols and K=8192: A_L2 = 8*2*8192*2 = 256KB < 512KB ✓
-    M = 2048
-    K = 8192
-    TILE_M = 2
-    M_INPUT = 1
-    HERD_COLS = 8
-    N_CASCADE = 4
-    INPUT_DATATYPE = bfloat16
-    OUTPUT_DATATYPE = bfloat16
-
+def parse_args():
     parser = argparse.ArgumentParser(
         prog="matvec_cascade.py",
-        description="Builds, runs, and tests the cascade bf16 matrix-vector multiplication (GEMV) example",
+        description="Builds, runs, and tests the cascade bf16 matrix-vector "
+        "multiplication (GEMV) example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
     parser.add_argument(
-        "--m", type=int, default=M, help="M dimension (matrix rows / output size)"
+        "--m", type=int, default=2048, help="M dimension (matrix rows / output size)"
     )
     parser.add_argument(
-        "--k", type=int, default=K, help="K dimension (matrix columns / vector length)"
+        "--k",
+        type=int,
+        default=8192,
+        help="K dimension (matrix columns / vector length)",
     )
     parser.add_argument(
         "--tile-m",
         type=int,
-        default=TILE_M,
+        default=2,
         dest="tile_m",
         help="Number of output rows per tile per column",
     )
     parser.add_argument(
         "--m-input",
         type=int,
-        default=M_INPUT,
-        help="Number of matrix rows per kernel call",
+        default=1,
+        help="Number of matrix rows per inner loop iteration",
     )
     parser.add_argument(
         "--herd-cols",
         type=int,
-        default=HERD_COLS,
+        default=8,
         dest="herd_cols",
         help="Number of AIE columns (parallel compute tiles along M dimension)",
     )
     parser.add_argument(
         "--n-cascade",
         type=int,
-        default=N_CASCADE,
+        default=4,
         dest="n_cascade",
         help="Number of cascade tiles per column (K-reduction depth)",
     )
@@ -551,7 +265,15 @@ if __name__ == "__main__":
         choices=["compile-and-run", "compile-and-xclbin"],
         dest="compile_mode",
         default="compile-and-run",
-        help="compile-and-run (default): compile and validate; compile-and-xclbin: generate xclbin only",
+        help="compile-and-run (default): compile and validate; "
+        "compile-and-xclbin: generate xclbin only",
+    )
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
     parser.add_argument(
         "--debug-ir",
@@ -559,56 +281,57 @@ if __name__ == "__main__":
         dest="debug_ir",
         help="Emit IR after each pass into debug_ir/ directory",
     )
+    return parser.parse_args()
 
-    args = parser.parse_args()
 
-    mlir_module = build_module(
-        args.m,
-        args.k,
-        args.tile_m,
-        args.m_input,
-        args.herd_cols,
-        args.n_cascade,
-        INPUT_DATATYPE,
-        OUTPUT_DATATYPE,
+def main():
+    args = parse_args()
+
+    launch = build_module(
+        args.m, args.k, args.tile_m, args.m_input, args.herd_cols, args.n_cascade
     )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
-    if args.compile_mode == "compile-and-run":
-        np.random.seed(42)
-        input_a = (np.random.randn(args.m, args.k) * 4).astype(INPUT_DATATYPE)
-        input_b = (np.random.randn(args.k) * 4).astype(INPUT_DATATYPE)
-        output_c = np.dot(
-            input_a.astype(np.float32), input_b.astype(np.float32)
-        ).astype(OUTPUT_DATATYPE)
-
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            runtime_loop_tiling_sizes=[4, 4],
-            output_format=args.output_format,
-            instance_name="matvec_cascade_bf16",
-            debug_ir=args.debug_ir,
-            use_lock_race_condition_fix=True,
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_a, input_b],
-                expected_outputs=[output_c],
-                rtol=0.04,
-                atol=1e-3,
-            )
-        )
-
-    elif args.compile_mode == "compile-and-xclbin":
+    if args.compile_mode == "compile-and-xclbin":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[4, 4],
             use_lock_race_condition_fix=True,
+            target_device=launch.target,
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    np.random.seed(42)
+    input_a = (np.random.randn(args.m, args.k) * 4).astype(bfloat16)
+    input_b = (np.random.randn(args.k) * 4).astype(bfloat16)
+    output_c = np.dot(input_a.astype(np.float32), input_b.astype(np.float32)).astype(
+        bfloat16
+    )
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        runtime_loop_tiling_sizes=[4, 4],
+        output_format=args.output_format,
+        instance_name="matvec_cascade_bf16",
+        debug_ir=args.debug_ir,
+        use_lock_race_condition_fix=True,
+        target_device=launch.target,
+    )
+    return runner.run_test(
+        mlir_module,
+        inputs=[input_a, input_b],
+        expected_outputs=[output_c],
+        rtol=0.04,
+        atol=1e-3,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
+++ b/programming_examples/matrix_vector_multiplication/bf16_cascade/matvec_cascade_add.py
@@ -1,95 +1,49 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
-#
-# Cascade-based GEMV with fused residual add: D[M] = A[M,K] @ B[K] + R[M]
-# BF16 input/output, accfloat accumulation.
-#
-# R is added at the cascade HEAD as the initial accumulator; the cascade
-# carries R + Σpartials south to the TAIL which writes D.
-#
-# A and R share the ar_L3toL2 / ar_L2toL1 channels (per-(col, cascade_row)
-# bundle slot), each fill targeting its own L2 buffer to avoid shared-
-# buffer write/read races between independent lock pairs.
+"""Cascade GEMV with a fused residual add, on air.api: D[M] = A[M,K] @ B[K] + R[M].
+
+The cascade is ``matvec_cascade.py``'s -- ``n_cascade`` cores down a column,
+each dotting its own K chunk and passing the running sum south -- with one
+change: the residual is added at the *head* rather than the tail. R therefore
+seeds the accumulator that travels the cascade instead of being folded into the
+result at the end, which costs nothing: the head has to write the payload
+buffer anyway, and the tail's work is unchanged.
+
+A and R share one L3 -> L2 channel per column, ``ar_L3toL2``, and one
+L2 -> L1 channel per (column, cascade row), ``ar_L2toL1``. They share the
+channel but not the buffer -- each fill targets its own L2 allocation -- so the
+two transfers never contend for the same lock pair. On the L2 -> L1 side R goes
+only to the head's slot while A is sliced by K, one put per cascade row.
+
+Two departures from the predecessor's IR.
+
+``ops.branch`` emits ``arith.cmpi`` plus ``scf.if`` where the predecessor hand-
+built an ``IntegerSet`` and an ``affine.if`` for the head-only R receive. The
+condition is the same one; the DSL has a single spelling for "this core only",
+and it is the one the rest of the cascade already used.
+
+The partial sum goes through ``scratch`` rather than an SSA value, for the
+reason ``matvec_cascade.py`` documents: a reduction is the whole right-hand side
+of a statement, so what it produces cannot be added to R -- or to the value
+arriving from the north -- in the same expression.
+"""
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects import affine
-from air.dialects.air import *
-from air.dialects.air import channel as channel_decl
-from air.dialects import arith, scf
-from air.dialects.memref import (
-    AllocOp,
-    DeallocOp,
-    subview,
-    load as memref_load,
-    store as memref_store,
-)
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    reduction as vector_reduction,
-    fma,
-)
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, f32
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
-
-
-def compute_partial_dot(
-    row,
-    _l1_a,
-    _l1_b,
-    l1_acc_tmp,
-    c0,
-    k_chunk,
-    f32_vec_size,
-    vecTy_bf16,
-    vecTy_f32,
-    identity_map,
-    read_map_2d,
-    cst0_bf16,
-    cst0_f32,
-    f32_type,
-):
-    """Single-row bf16 dot product into f32 accumulator (verbatim from
-    matvec_cascade.py). Returns the f32 horizontal sum."""
-    zero_vec_f32 = BroadcastOp(vecTy_f32, cst0_f32)
-    transfer_write(None, zero_vec_f32, l1_acc_tmp, [c0], identity_map, [True])
-
-    for j_k in range_(0, k_chunk, f32_vec_size):
-        sub_a = subview(_l1_a, [row, j_k], [1, f32_vec_size], [1, 1])
-        sub_b = subview(_l1_b, [j_k], [f32_vec_size], [1])
-        v_a_bf16 = transfer_read(
-            vecTy_bf16, sub_a, [c0, c0], read_map_2d, cst0_bf16, [True]
-        )
-        v_b_bf16 = transfer_read(
-            vecTy_bf16, sub_b, [c0], identity_map, cst0_bf16, [True]
-        )
-        v_a_f32 = arith.extf(vecTy_f32, v_a_bf16)
-        v_b_f32 = arith.extf(vecTy_f32, v_b_bf16)
-        v_acc = transfer_read(
-            vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True]
-        )
-        v_result = fma(v_a_f32, v_b_f32, v_acc)
-        transfer_write(None, v_result, l1_acc_tmp, [c0], identity_map, [True])
-        yield_([])
-
-    v_final = transfer_read(vecTy_f32, l1_acc_tmp, [c0], identity_map, cst0_f32, [True])
-    return vector_reduction(f32_type, "add", v_final)
+VEC = 16
+CASCADE_WIDTH = 16
 
 
-@module_builder
-def build_module(
-    m, k, tile_m, m_input, herd_cols, n_cascade, np_dtype_in, np_dtype_out
-):
+def build_module(m, k, tile_m, m_input, herd_cols, n_cascade):
     assert (
         n_cascade >= 2
     ), f"n_cascade ({n_cascade}) must be >= 2 for a cascade pipeline"
@@ -104,565 +58,174 @@ def build_module(
     assert (
         k_chunk % 64 == 0
     ), f"k_chunk ({k_chunk}) must be divisible by 64 (vector width)"
+    # R reaches L1 as one bulk transfer of tile_m bf16, and an AIE DMA moves
+    # whole 4-byte words.
+    assert (
+        tile_m * 2 >= 4
+    ), f"tile_m ({tile_m}) * sizeof(bf16) must be >= 4 bytes (AIE DMA alignment)"
 
-    bytes_per_elem_in = np.dtype(np_dtype_in).itemsize
-    bytes_per_elem_out = np.dtype(np_dtype_out).itemsize
-    # L2 budget: per col, 1 bulk A buffer (tile_m*k bf16) + 1 R buffer
-    # (tile_m bf16). Plus a single bulk D buffer (herd_cols*tile_m).
-    a_bulk_bytes = tile_m * k * bytes_per_elem_in
-    r_bytes = tile_m * bytes_per_elem_in
-    l2_per_col = a_bulk_bytes + r_bytes
-    d_l2_bytes = herd_cols * tile_m * bytes_per_elem_out
+    # L2 budget: one bulk A buffer and one R buffer per column, plus one bulk D.
+    l2_per_col = tile_m * k * 2 + tile_m * 2
+    d_l2_bytes = herd_cols * tile_m * 2
     L2_CAPACITY = 512 * 1024
     assert herd_cols * l2_per_col + d_l2_bytes <= L2_CAPACITY, (
-        f"L2 capacity exceeded: per-col={l2_per_col}B × {herd_cols} cols "
+        f"L2 capacity exceeded: per-col={l2_per_col}B x {herd_cols} cols "
         f"+ D={d_l2_bytes}B = {herd_cols * l2_per_col + d_l2_bytes}B "
         f"> {L2_CAPACITY}B."
     )
 
-    xrt_dtype_in = type_mapper(np_dtype_in)
-    xrt_dtype_out = type_mapper(np_dtype_out)
-    f32_type = F32Type.get()
-
-    # L3 MemRefTypes
-    memrefTyA = MemRefType.get([m, k], xrt_dtype_in)
-    memrefTyB = MemRefType.get([k], xrt_dtype_in)
-    memrefTyR = MemRefType.get([m], xrt_dtype_in)
-    memrefTyD = MemRefType.get([m], xrt_dtype_out)
-
-    # L2 staging:
-    #   bulk A per col: [tile_m, k] — single L3->L2 fill per launch iter
-    #     (matches matvec_cascade.py reference). Multiple memtile MM2S
-    #     read distinct K-slices.
-    #   R per col: [tile_m] — single L3->L2 fill per launch iter, one
-    #     memtile MM2S to (col, HEAD) only.
-    # 2 BDs total per col on shim ar_L3toL2 (R + A bulk) → tiling=2 fits.
-    l2_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L2)
-    l2MemrefTyAbulk = MemRefType.get(
-        shape=[tile_m, k],
-        element_type=xrt_dtype_in,
-        memory_space=l2_mem_space,
-    )
-    l2MemrefTyR = MemRefType.get(
-        shape=[tile_m],
-        element_type=xrt_dtype_in,
-        memory_space=l2_mem_space,
-    )
-    l2MemrefTyD = MemRefType.get(
-        shape=[herd_cols, tile_m],
-        element_type=xrt_dtype_out,
-        memory_space=l2_mem_space,
-    )
-
-    # L1 MemRefTypes
-    l1_mem_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    # L1 A holds the full tile_m rows for this (col, ty) — single bulk
-    # transfer per launch iter.
-    l1MemrefTyA = MemRefType.get(
-        shape=[tile_m, k_chunk],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyB = MemRefType.get(
-        shape=[k_chunk],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    l1MemrefTyD = MemRefType.get(
-        shape=[tile_m],
-        element_type=xrt_dtype_out,
-        memory_space=l1_mem_space,
-    )
-    # HEAD's L1 R buffer holds the full tile_m R values for this col —
-    # single bulk transfer per launch iter. tile_m*sizeof(bf16) >= 4 bytes
-    # for AIE DMA alignment.
-    assert (
-        tile_m * np.dtype(np_dtype_in).itemsize >= 4
-    ), f"tile_m ({tile_m}) * sizeof({np_dtype_in}) must be >= 4 bytes (AIE DMA alignment)"
-    l1MemrefTyR = MemRefType.get(
-        shape=[tile_m],
-        element_type=xrt_dtype_in,
-        memory_space=l1_mem_space,
-    )
-    CASCADE_WIDTH = 16
-    cascade_buf_len = max(tile_m, CASCADE_WIDTH)
-    cascade_buf_len = (
-        (cascade_buf_len + CASCADE_WIDTH - 1) // CASCADE_WIDTH
+    cascade_len = (
+        (max(tile_m, CASCADE_WIDTH) + CASCADE_WIDTH - 1) // CASCADE_WIDTH
     ) * CASCADE_WIDTH
-    l1MemrefTyScratch = MemRefType.get(
-        shape=[cascade_buf_len],
-        element_type=f32_type,
-        memory_space=l1_mem_space,
+    head = n_cascade - 1
+
+    A = air.tensor([m, k], bf16)
+    B = air.tensor([k], bf16)
+    R = air.tensor([m], bf16)
+    D = air.tensor([m], bf16)
+
+    ar_l3_l2 = air.channel("ar_L3toL2", size=[herd_cols])
+    ar_l2_l1 = air.channel("ar_L2toL1", size=[herd_cols, n_cascade])
+    cascade = air.channel(
+        "chan_cascade", size=[herd_cols, n_cascade - 1], channel_type="npu_cascade"
     )
 
-    # ar_L3toL2: per-col channel from L3.
-    # ar_L2toL1: per-(col, cascade_row) memtile MM2S → compute tile.
-    # R goes to slot (col, n_cascade-1) = HEAD; A_r goes to (col, r).
-    channel_decl("ar_L3toL2", size=[herd_cols])
-    channel_decl("ar_L2toL1", size=[herd_cols, n_cascade])
-    channel_decl(
-        "chan_cascade",
-        size=[herd_cols, n_cascade - 1],
-        channel_type="npu_cascade",
-    )
+    with air.launch(
+        [range(m // tile_m // herd_cols), range(1)], name="matvec_cascade_add_bf16"
+    ) as launch:
 
-    @FuncOp.from_py_func(memrefTyA, memrefTyB, memrefTyR, memrefTyD)
-    def matvec_cascade_add_bf16(arg0, arg1, arg2, arg3):
+        @launch.body
+        def _(li, lj):
+            band = li * tile_m * herd_cols
 
-        launch_size = [m // tile_m // herd_cols, 1]
-
-        @launch(operands=[arg0, arg1, arg2, arg3], sizes=launch_size)
-        def launch_body(
-            launch_ivx,
-            launch_ivy,
-            launch_sizex,
-            launch_sizey,
-            l3_a_data,
-            l3_b_data,
-            l3_r_data,
-            l3_d_data,
-        ):
-            # Row offset for this launch iter
-            launch_ivx_map = AffineMap.get(
-                0,
-                1,
-                [
-                    AffineExpr.get_mul(
-                        AffineSymbolExpr.get(0),
-                        AffineConstantExpr.get(tile_m * herd_cols),
-                    )
-                ],
-            )
-            launch_offset_m_l = affine_apply(launch_ivx_map, [launch_ivx])
-
-            # L3-side puts on ar_L3toL2[col]: 1 R + 1 A bulk per launch iter.
-            # Order: R first, then A bulk (segment-side reads in same order).
+            # R first, then A: the segment reads them back in the same order.
             for col in range(herd_cols):
-                c_col_idx_l = arith.ConstantOp.create_index(col)
-                col_off_map = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_add(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(col * tile_m),
-                        )
-                    ],
-                )
-                col_off = affine_apply(col_off_map, [launch_offset_m_l])
-                # R bulk: tile_m elements for this col
-                ChannelPut(
-                    "ar_L3toL2",
-                    l3_r_data,
-                    indices=[c_col_idx_l],
-                    offsets=[col_off],
-                    sizes=[tile_m],
-                    strides=[1],
-                )
-                # A bulk: tile_m × k for this col
-                ChannelPut(
-                    "ar_L3toL2",
-                    l3_a_data,
-                    indices=[c_col_idx_l],
-                    offsets=[col_off, 0],
-                    sizes=[tile_m, k],
-                    strides=[k, 1],
-                )
+                lo = band + col * tile_m
+                ar_l3_l2.put(R[lo : lo + tile_m], indices=[col])
+                ar_l3_l2.put(A[lo : lo + tile_m, :], indices=[col])
 
-            @segment(
-                name="matvec_cascade_add_seg",
-                operands=[launch_ivx, l3_b_data, l3_d_data],
-            )
-            def segment_body(
-                launch_ivx_s,
-                l3_b_data_s,
-                l3_d_data_s,
-            ):
-                # L2: bulk A buffer per col + small R buffer per col + bulk D.
-                # Each buffer has a single L3->L2 writer (no shared-buffer
-                # race possible).
-                a_l2_bufs = [AllocOp(l2MemrefTyAbulk, [], []) for _ in range(herd_cols)]
-                r_l2_bufs = [AllocOp(l2MemrefTyR, [], []) for _ in range(herd_cols)]
-                l2_d_data = AllocOp(l2MemrefTyD, [], [])
+            with air.segment(name="matvec_cascade_add_seg") as seg:
 
-                # Memtile streaming per col: 1 R get + 1 A bulk get from L3,
-                # then per-(col, ty) MM2S puts of A slices and 1 R put to HEAD.
-                c_head_idx = arith.ConstantOp.create_index(n_cascade - 1)
-                for col in range(herd_cols):
-                    c_col_idx = arith.ConstantOp.create_index(col)
-                    r_l2 = r_l2_bufs[col].result
-                    a_l2 = a_l2_bufs[col].result
-                    # R: GET tile_m elements from L3 → r_l2
-                    ChannelGet(
-                        "ar_L3toL2",
-                        r_l2,
-                        indices=[c_col_idx],
-                        offsets=[0],
-                        sizes=[tile_m],
-                        strides=[1],
-                    )
-                    # R: PUT r_l2 → (col, HEAD)
-                    ChannelPut(
-                        "ar_L2toL1",
-                        r_l2,
-                        indices=[c_col_idx, c_head_idx],
-                        offsets=[0],
-                        sizes=[tile_m],
-                        strides=[1],
-                    )
-                    # A bulk: GET tile_m × k from L3 → a_l2
-                    ChannelGet(
-                        "ar_L3toL2",
-                        a_l2,
-                        indices=[c_col_idx],
-                        offsets=[0, 0],
-                        sizes=[tile_m, k],
-                        strides=[k, 1],
-                    )
-                    # A slices: PUT per ty (each MM2S reads its k_chunk slice)
-                    for ty_v in range(n_cascade):
-                        c_ty_idx = arith.ConstantOp.create_index(ty_v)
-                        ChannelPut(
-                            "ar_L2toL1",
-                            a_l2,
-                            indices=[c_col_idx, c_ty_idx],
-                            offsets=[0, ty_v * k_chunk],
-                            sizes=[tile_m, k_chunk],
-                            strides=[k, 1],
-                        )
+                @seg.body
+                def _():
+                    a_l2 = [
+                        air.alloc([tile_m, k], bf16, scope=seg.private())
+                        for _ in range(herd_cols)
+                    ]
+                    r_l2 = [
+                        air.alloc([tile_m], bf16, scope=seg.private())
+                        for _ in range(herd_cols)
+                    ]
+                    l2_d = air.alloc([herd_cols, tile_m], bf16, scope=seg.private())
 
-                # L1 buffers (passed into herd as operands)
-                l1_a_data = AllocOp(l1MemrefTyA, [], [])
-                l1_b_data = AllocOp(l1MemrefTyB, [], [])
-                l1_d_data = AllocOp(l1MemrefTyD, [], [])
-                l1_r_data = AllocOp(l1MemrefTyR, [], [])
-                l1_scratch = AllocOp(l1MemrefTyScratch, [], [])
-                l1_recv = AllocOp(l1MemrefTyScratch, [], [])
-
-                @herd(
-                    name="herd_0",
-                    sizes=[herd_cols, n_cascade],
-                    operands=[
-                        l1_a_data,
-                        l1_b_data,
-                        l1_d_data,
-                        l1_r_data,
-                        l1_scratch,
-                        l1_recv,
-                        l3_b_data_s,
-                        l2_d_data,
-                    ],
-                )
-                def herd_body(
-                    tx,
-                    ty,
-                    sx,
-                    sy,
-                    _l1_a,
-                    _l1_b,
-                    _l1_d,
-                    _l1_r,
-                    _l1_scratch,
-                    _l1_recv,
-                    _l3_b,
-                    _l2_d,
-                ):
-                    c0 = arith.ConstantOp.create_index(0)
-                    c1_idx = arith.ConstantOp.create_index(1)
-                    last_ty = arith.ConstantOp.create_index(n_cascade - 1)
-
-                    # k_offset = ty * k_chunk
-                    ty_k_map = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(k_chunk),
+                    for col in range(herd_cols):
+                        ar_l3_l2.get(r_l2[col], indices=[col])
+                        # R is only wanted by the core that seeds the cascade.
+                        ar_l2_l1.put(r_l2[col], indices=[col, head])
+                        ar_l3_l2.get(a_l2[col], indices=[col])
+                        for row in range(n_cascade):
+                            ar_l2_l1.put(
+                                a_l2[col][:, row * k_chunk : (row + 1) * k_chunk],
+                                indices=[col, row],
                             )
-                        ],
-                    )
-                    k_offset = affine_apply(ty_k_map, [ty])
 
-                    # B (L3->L1) — per-tile k_chunk slice (broadcast within row
-                    # by air-broadcast-detection).
-                    dma_memcpy_nd(
-                        _l1_b,
-                        _l3_b,
-                        src_offsets=[k_offset],
-                        src_sizes=[k_chunk],
-                        src_strides=[1],
-                    )
+                    l1_a = air.alloc([tile_m, k_chunk], bf16, scope=seg.per_core())
+                    l1_b = air.alloc([k_chunk], bf16, scope=seg.per_core())
+                    l1_d = air.alloc([tile_m], bf16, scope=seg.per_core())
+                    l1_r = air.alloc([tile_m], bf16, scope=seg.per_core())
+                    scratch = air.alloc([cascade_len], f32, scope=seg.per_core())
+                    recv = air.alloc([cascade_len], f32, scope=seg.per_core())
 
-                    # head_set fires when cascade_row == n_cascade-1.
-                    head_set = IntegerSet.get(
-                        0,
-                        1,
-                        [
-                            AffineSymbolExpr.get(0)
-                            - AffineConstantExpr.get(n_cascade - 1)
-                        ],
-                        [True],
-                    )
+                    with air.herd(
+                        [range(herd_cols), range(n_cascade)],
+                        name="herd_0",
+                        shape=(herd_cols, n_cascade),
+                    ) as h:
 
-                    # Cascade pipeline setup (vector dot product utilities).
-                    f32_vec_size = 16
-                    vecTy_bf16 = VectorType.get([f32_vec_size], xrt_dtype_in)
-                    vecTy_f32 = VectorType.get([f32_vec_size], f32_type)
-                    identity_map = AffineMapAttr.get(AffineMap.get_identity(1))
-                    read_map_2d = AffineMapAttr.get(
-                        AffineMap.get(2, 0, [AffineExpr.get_dim(1)])
-                    )
-                    cst0_bf16 = arith.ConstantOp(xrt_dtype_in, 0.0)
-                    cst0_f32 = arith.ConstantOp(f32_type, 0.0)
-                    row_out_map = AffineMap.get(
-                        0,
-                        2,
-                        [
-                            AffineExpr.get_add(
-                                AffineSymbolExpr.get(0),
-                                AffineSymbolExpr.get(1),
-                            )
-                        ],
-                    )
+                        @h.body
+                        def _(tx, ty):
+                            k0 = ty * k_chunk
+                            ops.load(l1_b, B[k0 : k0 + k_chunk])
 
-                    l1MemrefTyAccTmp = MemRefType.get(
-                        shape=[f32_vec_size],
-                        element_type=f32_type,
-                        memory_space=l1_mem_space,
-                    )
-                    l1_acc_tmp = AllocOp(l1MemrefTyAccTmp, [], [])
+                            # One bulk receive each per launch iteration,
+                            # outside the row loop that consumes them.
+                            with ops.branch(ty == head):
+                                ar_l2_l1.get(l1_r, indices=[tx, ty])
+                            ar_l2_l1.get(l1_a, indices=[tx, ty])
 
-                    dot_args = (
-                        _l1_a,
-                        _l1_b,
-                        l1_acc_tmp,
-                        c0,
-                        k_chunk,
-                        f32_vec_size,
-                        vecTy_bf16,
-                        vecTy_f32,
-                        identity_map,
-                        read_map_2d,
-                        cst0_bf16,
-                        cst0_f32,
-                        f32_type,
-                    )
+                            acc = air.alloc([VEC], f32, scope=h.private())
 
-                    # Bulk receives outside the j_m loop (one BD each per
-                    # launch iter): HEAD-only R, plus A slice for this
-                    # (col, ty). Both fill their own L1 buffers and are
-                    # consumed across all j_m iters.
-                    if_head_r = affine.AffineIfOp(head_set, cond_operands=[ty])
-                    with InsertionPoint(if_head_r.then_block):
-                        ChannelGet(
-                            "ar_L2toL1",
-                            _l1_r,
-                            indices=[tx, ty],
-                        )
-                        affine.AffineYieldOp([])
-
-                    ChannelGet(
-                        "ar_L2toL1",
-                        _l1_a,
-                        indices=[tx, ty],
-                    )
-
-                    # Hot loop: per j_m iter, compute partial dot from
-                    # rows [j_m*m_input : (j_m+1)*m_input] of _l1_a (which
-                    # holds the full tile_m rows for this (col, ty)).
-                    for j_m in range_(0, tile_m // m_input):
-                        j_m_map = AffineMap.get(
-                            0,
-                            1,
-                            [
-                                AffineExpr.get_mul(
-                                    AffineSymbolExpr.get(0),
-                                    AffineConstantExpr.get(m_input),
-                                )
-                            ],
-                        )
-                        j_m_offset = affine_apply(j_m_map, [j_m])
-                        # Map (j_m_offset, row) → row index in _l1_a (= j_m_offset + row)
-                        abs_row_map = AffineMap.get(
-                            0,
-                            2,
-                            [
-                                AffineExpr.get_add(
-                                    AffineSymbolExpr.get(0),
-                                    AffineSymbolExpr.get(1),
-                                )
-                            ],
-                        )
-
-                        # === Cascade compute ===
-                        # HEAD (ty == n_cascade-1): partial = A·B; init acc
-                        # with R; put cascade.
-                        # MIDDLE: get cascade; partial; sum; put cascade.
-                        # TAIL (ty == 0): get cascade; partial; sum; write D.
-                        cmp_first = arith.CmpIOp(arith.CmpIPredicate.eq, ty, last_ty)
-                        if_first = scf.IfOp(cmp_first, has_else=True)
-                        with InsertionPoint(if_first.then_block):
-                            # HEAD: partial + R → scratch → cascade
-                            for row in range_(0, m_input):
-                                abs_row = affine_apply(abs_row_map, [j_m_offset, row])
-                                partial_sum = compute_partial_dot(abs_row, *dot_args)
-                                sub_r = subview(_l1_r, [abs_row], [1], [1])
-                                r_val_bf16 = memref_load(sub_r, [c0])
-                                r_val_f32 = arith.extf(f32_type, r_val_bf16)
-                                init_acc = arith.addf(partial_sum, r_val_f32)
-                                sub_scratch = subview(_l1_scratch, [row], [1], [1])
-                                memref_store(init_acc, sub_scratch, [c0])
-                                yield_([])
-
-                            prev_ty = arith.SubIOp(ty, c1_idx)
-                            ChannelPut(
-                                "chan_cascade",
-                                _l1_scratch,
-                                indices=[tx, prev_ty],
-                            )
-                            yield_([])
-
-                        with InsertionPoint(if_first.else_block):
-                            # TAIL or MIDDLE
-                            cmp_last = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
-                            if_last = scf.IfOp(cmp_last, has_else=True)
-                            with InsertionPoint(if_last.then_block):
-                                # TAIL: get cascade, add own partial, write D
-                                # (no R add — R was added at HEAD)
-                                ChannelGet(
-                                    "chan_cascade",
-                                    _l1_recv,
-                                    indices=[tx, ty],
-                                )
-
-                                for row in range_(0, m_input):
-                                    abs_row = affine_apply(
-                                        abs_row_map, [j_m_offset, row]
+                            def dot_into_scratch(row, at):
+                                """scratch[row] = A[at, :] . B[:], in f32."""
+                                acc[:] = 0.0
+                                for jk in air.sequential(0, k_chunk, VEC):
+                                    acc[:] = ops.fma(
+                                        ops.cast(l1_a[at, jk : jk + VEC], f32),
+                                        ops.cast(l1_b[jk : jk + VEC], f32),
+                                        acc[:],
                                     )
-                                    partial_sum = compute_partial_dot(
-                                        abs_row, *dot_args
-                                    )
-                                    sub_recv = subview(_l1_recv, [row], [1], [1])
-                                    recv_val = memref_load(sub_recv, [c0])
-                                    total_f32 = arith.addf(recv_val, partial_sum)
-                                    total_bf16 = arith.truncf(xrt_dtype_out, total_f32)
-                                    sub_d_out = subview(_l1_d, [abs_row], [1], [1])
-                                    memref_store(total_bf16, sub_d_out, [c0])
-                                    yield_([])
+                                scratch[row : row + 1] = ops.reduce_add(acc[:])
 
-                                yield_([])
+                            for jm in air.sequential(0, tile_m // m_input):
+                                j0 = jm * m_input
 
-                            with InsertionPoint(if_last.else_block):
-                                # Middle tiles: cascade get → compute → cascade put
-                                ChannelGet(
-                                    "chan_cascade",
-                                    _l1_recv,
-                                    indices=[tx, ty],
-                                )
+                                with ops.branch(ty == head) as top:
+                                    # Seed the cascade with the residual.
+                                    for row in air.sequential(0, m_input):
+                                        at = j0 + row
+                                        dot_into_scratch(row, at)
+                                        scratch[row : row + 1] = scratch[
+                                            row : row + 1
+                                        ] + ops.cast(l1_r[at : at + 1], f32)
+                                    cascade.put(scratch, indices=[tx, ty - 1])
 
-                                for row in range_(0, m_input):
-                                    abs_row = affine_apply(
-                                        abs_row_map, [j_m_offset, row]
-                                    )
-                                    partial_sum = compute_partial_dot(
-                                        abs_row, *dot_args
-                                    )
-                                    sub_recv = subview(_l1_recv, [row], [1], [1])
-                                    recv_val = memref_load(sub_recv, [c0])
-                                    total = arith.addf(recv_val, partial_sum)
-                                    sub_scratch = subview(_l1_scratch, [row], [1], [1])
-                                    memref_store(total, sub_scratch, [c0])
-                                    yield_([])
+                                with top.otherwise():
+                                    with ops.branch(ty == 0) as tail:
+                                        # R was already folded in at the head.
+                                        cascade.get(recv, indices=[tx, ty])
+                                        for row in air.sequential(0, m_input):
+                                            at = j0 + row
+                                            dot_into_scratch(row, at)
+                                            l1_d[at : at + 1] = ops.cast(
+                                                recv[row : row + 1]
+                                                + scratch[row : row + 1],
+                                                bf16,
+                                            )
 
-                                prev_ty_mid = arith.SubIOp(ty, c1_idx)
-                                ChannelPut(
-                                    "chan_cascade",
-                                    _l1_scratch,
-                                    indices=[tx, prev_ty_mid],
-                                )
-                                yield_([])
+                                    with tail.otherwise():
+                                        cascade.get(recv, indices=[tx, ty])
+                                        for row in air.sequential(0, m_input):
+                                            dot_into_scratch(row, j0 + row)
+                                            scratch[row : row + 1] = (
+                                                recv[row : row + 1]
+                                                + scratch[row : row + 1]
+                                            )
+                                        cascade.put(scratch, indices=[tx, ty - 1])
 
-                            yield_([])
+                            with ops.branch(ty == 0):
+                                ops.store(l1_d, l2_d[tx, :])
 
-                        yield_([])
+                    ops.store(
+                        l2_d.reshape(herd_cols * tile_m),
+                        D[band : band + herd_cols * tile_m],
+                    )
 
-                    # ty=0 tiles write D to L2 (same pattern as matvec_cascade.py)
-                    cmp_writer = arith.CmpIOp(arith.CmpIPredicate.eq, ty, c0)
-                    if_writer = scf.IfOp(cmp_writer)
-                    with InsertionPoint(if_writer.then_block):
-                        dma_memcpy_nd(
-                            _l2_d,
-                            _l1_d,
-                            dst_offsets=[tx, 0],
-                            dst_sizes=[1, tile_m],
-                            dst_strides=[tile_m, 1],
-                            src_offsets=[],
-                            src_sizes=[tile_m],
-                            src_strides=[1],
-                        )
-                        yield_([])
-
-                    DeallocOp(l1_acc_tmp)
-
-                # L2 -> L3: D writeback for this launch slice.
-                launch_ivx_map_s = AffineMap.get(
-                    0,
-                    1,
-                    [
-                        AffineExpr.get_mul(
-                            AffineSymbolExpr.get(0),
-                            AffineConstantExpr.get(tile_m * herd_cols),
-                        )
-                    ],
-                )
-                launch_offset_m_d = affine_apply(launch_ivx_map_s, [launch_ivx_s])
-                dma_memcpy_nd(
-                    l3_d_data_s,
-                    l2_d_data,
-                    dst_offsets=[launch_offset_m_d],
-                    dst_sizes=[herd_cols * tile_m],
-                    dst_strides=[1],
-                    src_offsets=[0, 0],
-                    src_sizes=[herd_cols, tile_m],
-                    src_strides=[tile_m, 1],
-                )
-
-                for r_l2 in r_l2_bufs:
-                    DeallocOp(r_l2)
-                for a_l2 in a_l2_bufs:
-                    DeallocOp(a_l2)
-                DeallocOp(l2_d_data)
-                DeallocOp(l1_a_data)
-                DeallocOp(l1_b_data)
-                DeallocOp(l1_d_data)
-                DeallocOp(l1_r_data)
-                DeallocOp(l1_scratch)
-                DeallocOp(l1_recv)
+    return launch
 
 
-if __name__ == "__main__":
-    M = 2048
-    K = 8192
-    TILE_M = 2
-    M_INPUT = 1
-    HERD_COLS = 8
-    N_CASCADE = 4
-    INPUT_DATATYPE = bfloat16
-    OUTPUT_DATATYPE = bfloat16
-
+def parse_args():
     parser = argparse.ArgumentParser(
         prog="matvec_cascade_add.py",
         description="Cascade BF16 GEMV with fused residual add: D = A @ B + R",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--m", type=int, default=M)
-    parser.add_argument("--k", type=int, default=K)
-    parser.add_argument("--tile-m", type=int, default=TILE_M, dest="tile_m")
-    parser.add_argument("--m-input", type=int, default=M_INPUT, dest="m_input")
-    parser.add_argument("--herd-cols", type=int, default=HERD_COLS, dest="herd_cols")
-    parser.add_argument("--n-cascade", type=int, default=N_CASCADE, dest="n_cascade")
+    parser.add_argument("--m", type=int, default=2048)
+    parser.add_argument("--k", type=int, default=8192)
+    parser.add_argument("--tile-m", type=int, default=2, dest="tile_m")
+    parser.add_argument("--m-input", type=int, default=1, dest="m_input")
+    parser.add_argument("--herd-cols", type=int, default=8, dest="herd_cols")
+    parser.add_argument("--n-cascade", type=int, default=4, dest="n_cascade")
     parser.add_argument(
         "--output-format",
         type=str,
@@ -677,62 +240,71 @@ if __name__ == "__main__":
         dest="compile_mode",
         default="compile-and-run",
     )
-    parser.add_argument("--debug-ir", action="store_true", dest="debug_ir")
-
-    args = parser.parse_args()
-
-    mlir_module = build_module(
-        args.m,
-        args.k,
-        args.tile_m,
-        args.m_input,
-        args.herd_cols,
-        args.n_cascade,
-        INPUT_DATATYPE,
-        OUTPUT_DATATYPE,
+    parser.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
     )
+    parser.add_argument("--debug-ir", action="store_true", dest="debug_ir")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+
+    launch = build_module(
+        args.m, args.k, args.tile_m, args.m_input, args.herd_cols, args.n_cascade
+    )
+    mlir_module = launch.build(target=args.target)
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
-    if args.compile_mode == "compile-and-run":
-        np.random.seed(42)
-        input_a = (np.random.randn(args.m, args.k) * 4).astype(INPUT_DATATYPE)
-        input_b = (np.random.randn(args.k) * 4).astype(INPUT_DATATYPE)
-        input_r = (np.random.randn(args.m) * 4).astype(INPUT_DATATYPE)
-        output_d = (
-            np.dot(input_a.astype(np.float32), input_b.astype(np.float32))
-            + input_r.astype(np.float32)
-        ).astype(OUTPUT_DATATYPE)
-
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_while_true_loop=False,
-            # Per-col ar_L3toL2 carries 1 R + 1 A bulk per launch iter.
-            # Shim DMA BD queue limit = 4 → tiling=2 keeps it at 4 BDs.
-            runtime_loop_tiling_sizes=[2, 2],
-            output_format=args.output_format,
-            instance_name="matvec_cascade_add_bf16",
-            debug_ir=args.debug_ir,
-            use_lock_race_condition_fix=True,
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[input_a, input_b, input_r],
-                expected_outputs=[output_d],
-                rtol=0.04,
-                atol=1e-3,
-            )
-        )
-
-    elif args.compile_mode == "compile-and-xclbin":
+    # Each column's ar_L3toL2 carries one R and one A transfer per launch
+    # iteration, and the shim DMA BD queue holds 4, so the runtime loop tiles
+    # by 2.
+    if args.compile_mode == "compile-and-xclbin":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_while_true_loop=False,
             runtime_loop_tiling_sizes=[2, 2],
             output_format=args.output_format,
             use_lock_race_condition_fix=True,
+            target_device=launch.target,
         )
         backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    np.random.seed(42)
+    input_a = (np.random.randn(args.m, args.k) * 4).astype(bfloat16)
+    input_b = (np.random.randn(args.k) * 4).astype(bfloat16)
+    input_r = (np.random.randn(args.m) * 4).astype(bfloat16)
+    output_d = (
+        np.dot(input_a.astype(np.float32), input_b.astype(np.float32))
+        + input_r.astype(np.float32)
+    ).astype(bfloat16)
+
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_while_true_loop=False,
+        runtime_loop_tiling_sizes=[2, 2],
+        output_format=args.output_format,
+        instance_name="matvec_cascade_add_bf16",
+        debug_ir=args.debug_ir,
+        use_lock_race_condition_fix=True,
+        target_device=launch.target,
+    )
+    return runner.run_test(
+        mlir_module,
+        inputs=[input_a, input_b, input_r],
+        expected_outputs=[output_d],
+        rtol=0.04,
+        atol=1e-3,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -655,7 +655,9 @@ def _emit_reduce(dst, expr):
                 operand, ivs + [zero], regions[dtype], regions, True, load, reads
             )
             scalar = _result(reduction(dtype.mlir(), kind, value))
-            memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
+            memref_store(
+                scalar, dst.value, _dst_index(dst, ivs + [zero] if keepdims else ivs)
+            )
 
         _nest(bounds, body)
         return
@@ -700,7 +702,9 @@ def _emit_reduce(dst, expr):
             yield_([])
 
         scalar = _result(reduction(dtype.mlir(), kind, read_acc()))
-        memref_store(scalar, dst.value, ivs + [zero] if keepdims else ivs)
+        memref_store(
+            scalar, dst.value, _dst_index(dst, ivs + [zero] if keepdims else ivs)
+        )
 
     _nest(bounds, body)
 

--- a/python/test/api/reduce.py
+++ b/python/test/api/reduce.py
@@ -351,3 +351,42 @@ def argmax_compares_in_the_cast_type():
                     air.ops.store(o, OUT[0:32])
 
     print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: a_reduction_stores_at_the_destination_region_offset
+# The destination of a reduction is written through the same index arithmetic
+# as every other assignment: the region's own offset, plus the induction
+# variable of whatever nest surrounds it.
+#
+# It was not. The store index was built from the reduction's own collapsed-axis
+# nest alone and dropped the destination's base entirely, so
+# `part[row : row + 1] = reduce_add(...)` inside a loop over `row` wrote every
+# row to `part[0]`. It compiles, it runs, and the earlier rows are silently
+# lost -- which is why this is pinned rather than left to the one example that
+# happens to exercise it (matrix_vector_multiplication/bf16_cascade, whose
+# cascade stage reduces one row at a time into a shared partial-sum buffer).
+# CHECK: scf.for %[[ROW:.*]] =
+# CHECK: vector.reduction <add>
+# CHECK: %[[AT:.*]] = arith.addi %{{.*}}, %[[ROW]]
+# CHECK: memref.store %{{.*}}, %{{.*}}[%[[AT]]]
+@run
+def a_reduction_stores_at_the_destination_region_offset():
+    A = air.tensor([4, 16], bf16)
+    OUT = air.tensor([4], bf16)
+
+    with air.launch(name="rro") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([4, 16], bf16, scope=h.private())
+                    part = air.alloc([4], bf16, scope=h.private())
+                    air.ops.load(a, A[0:4, :])
+                    for row in air.sequential(0, 4):
+                        part[row : row + 1] = air.ops.reduce_add(a[row, :])
+                    air.ops.store(part, OUT[0:4])
+
+    print(launch.mlir())


### PR DESCRIPTION
Three more `programming_examples` move onto the `air.api` DSL, replacing their
raw-bindings predecessors, plus the one DSL bug the port turned up.

### `conv2d_14x14`

All compute is in `conv2dk14.o`, so the whole port is data movement: the two
awkward pieces are the 4-D L3 -> L2 fill and the 6-D L2 -> L1 gather, both
written as a reshape/transpose view of the buffer rather than a hand-built
access pattern.

### `matrix_vector_multiplication/bf16_cascade` -- both files

Cascade GEMV, and the same with a fused residual. The three cascade stages are
one traced body selected by `ops.branch` on the tile coordinate -- the shape
`cascade_reduction` already uses, one level deeper. The dot product is written
out rather than reached through `ops.dot`, because a loop-carried vector
accumulator does not legalize on AIE2: `ops.fma` and `ops.cast` emit the same
widening `vector.fma` over a 16-lane f32 accumulator the predecessors
hand-rolled, and `ops.reduce_add` the closing `vector.reduction <add>`.

### The bug

`ops.reduce_add` built its store index from its own collapsed-axis nest alone
and never added the destination's base, so a reduction into a *region* wrote to
that region's buffer at index zero. Inside a loop, `part[row : row + 1] =
ops.reduce_add(...)` wrote every row to `part[0]`: it compiles, it runs, and
every row but the last is lost.

The elementwise path already had `_dst_index` for exactly this; the reduction
was the one assignment not going through it. Every reduction in the tree today
has a whole-buffer destination, for which `_dst_index` returns the induction
variables unchanged -- confirmed by reading all seven call sites and by a
print-module A/B over them, all byte-identical -- so nothing that exists moves.
The cascade is the first example to reduce into a region, which is why the
regression is pinned in `python/test/api/reduce.py` rather than left to it.

## Gating

`air.insts.bin` is byte-identical to each predecessor's at every lit config,
with a same-input control per flow confirming the artifact is deterministic
before any hash was compared. All 7 npu1 lits PASS, predecessor and conversion
back to back in one session. `check-air-python` green.

After canonicalization the op counts match the predecessors exactly but for
three departures, all documented in the module docstrings:

* no `memref.subview` -- the DSL indexes the buffer directly where the
  predecessors built a one-element view of it;
* one extra store/load pair per row in each folding stage -- the partial sum
  goes through the payload buffer instead of an SSA value, because a reduction
  is the whole right-hand side of a statement and so cannot be added to the
  value arriving from the north in the same expression;
* `matvec_cascade_add` only: `arith.cmpi` plus `scf.if` where it hand-built an
  `IntegerSet` and an `affine.if` for the head-only residual receive.

No executing consumers: the example is imported nowhere, and the only path
references are the README registry entry and two prose comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)