### PR TITLE
[air.api] shared_l1_single_herd and dequant_awq, and the surface they need

### DIFF
--- a/programming_examples/dequant_awq/dequant_awq.py
+++ b/programming_examples/dequant_awq/dequant_awq.py
@@ -1,58 +1,65 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""AWQ-style int4 to bfloat16 dequantization on air.api.
 
-"""AWQ-style int4 to bfloat16 dequantization example.
+    output[i] = (int4_weight[i] - zero_point[group]) * scale[group]
 
-Dequantizes int4 weights packed in uint8 pairs using per-group
-scale (bf16) and zero-point (uint8) parameters:
-  output[i] = (int4_weight[i] - zero_point[group]) * scale[group]
+Q, S and Z are concatenated into one packed L1 buffer per tile -- the layout
+``matrix_vector_multiplication/int4_awq`` and ``matrix_multiplication/int4_awq``
+use in production -- which keeps each compute tile inside its DMA channel budget
+while exposing all three pieces of metadata to one vectorised inner loop. A
+1 x HERD_N herd splits N across tiles.
 
-Q, S, and Z are concatenated into a single packed L1 BO per tile
-(matches the production layout used by matrix_vector_multiplication/int4_awq
-and matrix_multiplication/int4_awq), keeping each compute tile within its
-2 S2MM + 2 MM2S channel budget while exposing all three pieces of metadata
-to a fully vectorized inner loop in dequant.cc.
+Two codegen paths share that layout, the DMAs and the output shape:
 
-Uses a 1xHERD_N AIE herd splitting N across compute tiles.
+* default: the per-tile body is a call into a hand-written kernel
+  (``dequant.cc`` -> ``dequant.o``).
 
-Two codegen paths share the same DMA / packed L1 layout / output shape:
+* ``--direct-codegen`` (AIE2P only): the body is written in the DSL and lowered
+  through mlir-aie's VectorToAIEVec pipeline to the AIE2P
+  ``unpack.I512.I8.I4`` intrinsic, the magic-number sitofp i16->bf16 sequence
+  and a native bf16 multiply. No object file.
 
-  * Default: the inner kernel body is a CallOp to a hand-written C++
-    kernel (dequant.cc, compiled to dequant.o) that the linker resolves.
+The interesting line is the unpack::
 
-  * --direct-codegen (AIE2P only): the inner body is authored as standard
-    arith/vector/memref ops and lowered through mlir-aie's VectorToAIEVec
-    + AIEVecToLLVM pipeline to the AIE2P unpack.I512.I8.I4 intrinsic, the
-    magic-number sitofp i16->bf16 sequence, and native bf16 mul. No
-    external .o is needed. The inner subgroup processes R=64 nibbles per
-    iteration (the natural width of llvm.aie2p.unpack.I512.I8.I4), so
-    group_size must be a multiple of 64 in this mode.
+    ops.cast(ops.bitcast(packed[b : b + R // 2], i4), i8, signed=False)
+
+Both halves of that have to be spelled exactly so. ``ops.bitcast`` reinterprets
+32 bytes as 64 half-bytes -- it preserves the representation where ``ops.cast``
+preserves the value -- and the widening is ``signed=False`` because these are
+quantised magnitudes 0..15, where ``extsi`` would read 0x9 as -7. mlir-aie's
+``LowerExtUIOfBitcastI4ToUnpackPattern`` matches that exact pair and rewrites it
+into a single ``aievec.unpack``; masking and shifting by hand computes the same
+numbers and misses the instruction entirely.
+
+Two departures from the predecessor's IR.
+
+The per-group scale goes through a two-byte L1 buffer. It is assembled from two
+bytes with a shift and an or and is a bf16 only once reinterpreted, and the
+predecessor keeps it in a register the whole way. In the DSL a value broadcast
+across a vector is read at the leaf, so writing the assembly inline would widen
+every step of it to 64 lanes; a one-element destination takes the scalar path
+instead and produces the predecessor's scalar ops, at the cost of one store and
+one load per group.
+
+Offsets are computed in bytes directly -- ``g * (group_size // 2)`` -- rather
+than in elements and then halved, so there is no ``arith.divui``. Both are exact
+because the group size is even.
 """
 
 import argparse
+
 import numpy as np
 from ml_dtypes import bfloat16
 
-from air.ir import *
-from air.dialects.affine import apply as affine_apply
-from air.dialects.air import *
-from air.dialects import arith
-from air.dialects.memref import AllocOp, DeallocOp, load as memref_load
-from air.dialects.vector import (
-    transfer_read,
-    transfer_write,
-    BroadcastOp,
-    bitcast as v_bitcast,
-)
-from air.dialects.func import FuncOp, CallOp
-from air.dialects.scf import for_, yield_
-from air.backend.xrt_runner import XRTRunner, type_mapper
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i4, i8, i16
 from air.backend.xrt import XRTBackend
+from air.backend.xrt_runner import XRTRunner
 
-range_ = for_
-
-# Inner subgroup width (nibbles per iteration) for --direct-codegen.
-# Must match the byte-packed source size of llvm.aie2p.unpack.I512.I8.I4.
+# Nibbles per inner iteration. Fixed by the byte-packed source width of
+# llvm.aie2p.unpack.I512.I8.I4.
 R_SUB = 64
 
 
@@ -62,104 +69,13 @@ def packed_tile_bytes(n_tile, group_size):
     s_bytes = 2 * n_groups_tile
     z_bytes = n_groups_tile
     raw = q_bytes + s_bytes + z_bytes
-    # Pad each tile's L3 row to a 4-byte boundary: aie.dma_bd requires the
-    # transfer length to be a multiple of 4 bytes. The kernel only reads
-    # [0, raw); the pad bytes are unused.
+    # aie.dma_bd needs a transfer length that is a multiple of 4 bytes. The
+    # kernel only reads [0, raw); the pad bytes are unused.
     tile_bytes = (raw + 3) & ~3
     return q_bytes, s_bytes, z_bytes, tile_bytes
 
 
-def _emit_inline_dequant_body(
-    l1_packed, l1_out, n_tile, group_size, q_bytes, s_bytes, ng_tile, nsub_per_group
-):
-    """Per-tile int4 -> bf16 dequant authored as standard MLIR ops.
-
-    Reads Q+S+Z out of l1_packed and writes n_tile bf16 results into l1_out.
-    Lowerings (all in upstream mlir-aie):
-      * vector.transfer_read + vector.bitcast + arith.extui (int4 path)
-        -> aievec.unpack -> llvm.aie2p.unpack.I512.I8.I4
-      * arith.extsi (i8 -> i16) + arith.sitofp (i16 -> bf16) -> magic-number
-        aievec sequence (UPS + acc-add + cast + sub + SRS)
-      * arith.subi (i8) and arith.mulf (bf16, native v32/v64) lower via
-        existing aievec patterns.
-    """
-    i8_type = IntegerType.get_signless(8)
-    i16_ty = IntegerType.get_signless(16)
-    bf16_type = type_mapper(bfloat16)
-
-    vec_i8 = VectorType.get([R_SUB // 2], i8_type)
-    vec_i4 = VectorType.get([R_SUB], IntegerType.get_signless(4))
-    vec_i8_unpacked = VectorType.get([R_SUB], i8_type)
-    vec_bf16 = VectorType.get([R_SUB], bf16_type)
-    id_map = AffineMapAttr.get(AffineMap.get_identity(1))
-    c0_i8 = arith.ConstantOp(i8_type, 0)
-
-    # Unroll the per-group loop in Python so each group's z offset and
-    # scale offset stay constants. Wrapping it in an scf.for triggers loop
-    # strength reduction that rewrites the loop IV in element units and
-    # then reuses the same IV for the z/s offsets, silently corrupting
-    # them.
-    for g_py in range(ng_tile):
-        # Scalar zero point: byte at q_bytes + s_bytes + g_py.
-        z_off = arith.ConstantOp.create_index(q_bytes + s_bytes + g_py)
-        z_byte = memref_load(l1_packed, [z_off])
-        zv = BroadcastOp(vec_i8_unpacked, z_byte)
-
-        # Scalar bf16 scale: 2 bytes at q_bytes + g_py*2, reassembled as
-        # i16 then bitcast to bf16.
-        s_off_lo = arith.ConstantOp.create_index(q_bytes + g_py * 2)
-        s_off_hi = arith.ConstantOp.create_index(q_bytes + g_py * 2 + 1)
-        s_lo_i8 = memref_load(l1_packed, [s_off_lo])
-        s_hi_i8 = memref_load(l1_packed, [s_off_hi])
-        s_lo_i16 = arith.extui(i16_ty, s_lo_i8)
-        s_hi_i16 = arith.extui(i16_ty, s_hi_i8)
-        s_hi_shifted = arith.shli(s_hi_i16, arith.ConstantOp(i16_ty, 8))
-        s_bits = arith.ori(s_lo_i16, s_hi_shifted)
-        sv = arith.bitcast(bf16_type, s_bits)
-        sv_vec = BroadcastOp(vec_bf16, sv)
-
-        # Inner subgroup loop stays as scf.for since its IV only feeds
-        # element offsets (no scalar metadata loads keyed on it).
-        c_rs = arith.ConstantOp.create_index(R_SUB)
-        g_base_elems = arith.ConstantOp.create_index(g_py * group_size)
-        for i in range_(0, nsub_per_group):
-            sub_off_elems = arith.addi(
-                g_base_elems,
-                arith.muli(i, c_rs),
-            )
-            sub_off_bytes = arith.divui(
-                sub_off_elems,
-                arith.ConstantOp.create_index(2),
-            )
-
-            pk_i8 = transfer_read(
-                vec_i8, l1_packed, [sub_off_bytes], id_map, c0_i8, [True]
-            )
-            # Canonical int4 unpack: bitcast to i4 vec then zero-extend to
-            # i8. The mlir-aie LowerExtUIOfBitcastI4ToUnpackPattern rewrites
-            # to aievec.unpack on the byte-packed source.
-            pk_i4 = v_bitcast(vec_i4, pk_i8)
-            w_i8 = arith.extui(vec_i8_unpacked, pk_i4)
-
-            wmz_i8 = arith.subi(w_i8, zv)
-
-            # int8 -> int16 -> bf16. LowerVectorSIToFPI16BF16AIE2pPattern
-            # picks up the i16 -> bf16 sitofp at v16/v32 widths and lowers
-            # via the magic-number trick (UPS + accfloat add/sub + SRS).
-            wmz_i16 = arith.extsi(VectorType.get([R_SUB], i16_ty), wmz_i8)
-            wmz_bf16 = arith.sitofp(vec_bf16, wmz_i16)
-
-            out_bf16 = arith.mulf(wmz_bf16, sv_vec)
-
-            transfer_write(None, out_bf16, l1_out, [sub_off_elems], id_map, [True])
-            yield_([])
-
-
-@module_builder
 def build_module(n, group_size, herd_n, direct_codegen=False):
-    bf16_type = type_mapper(bfloat16)
-    u8_type = IntegerType.get_signless(8)
-
     assert n % herd_n == 0, "n must be divisible by herd_n"
     n_tile = n // herd_n
     assert n_tile % group_size == 0, "n_tile must be divisible by group_size"
@@ -167,93 +83,92 @@ def build_module(n, group_size, herd_n, direct_codegen=False):
         assert (
             group_size % R_SUB == 0
         ), f"--direct-codegen requires group_size multiple of {R_SUB}"
-    q_bytes, s_bytes, z_bytes, tile_bytes = packed_tile_bytes(n_tile, group_size)
+    q_bytes, s_bytes, _z_bytes, tile_bytes = packed_tile_bytes(n_tile, group_size)
     ng_tile = n_tile // group_size
     nsub_per_group = group_size // R_SUB if direct_codegen else 0
 
-    # L3 types: packed weights+scales+zeros laid out per-tile, dequantized output
-    l3_packed_ty = MemRefType.get([herd_n, tile_bytes], u8_type)
-    l3_out_ty = MemRefType.get([n], bf16_type)
+    l3_packed = air.tensor([herd_n, tile_bytes], i8)
+    l3_out = air.tensor([n], bf16)
 
-    # L1 types
-    l1_space = IntegerAttr.get(T.i32(), MemorySpace.L1)
-    l1_packed_ty = MemRefType.get([tile_bytes], u8_type, memory_space=l1_space)
-    l1_out_ty = MemRefType.get([n_tile], bf16_type, memory_space=l1_space)
+    kernel = (
+        None
+        if direct_codegen
+        else air.extern("dequant_int4_bf16", link_with="dequant.o")
+    )
 
-    # External kernel decl (only declared in the extern path; aircc only
-    # links dequant.o when a private @dequant_int4_bf16 FuncOp is present
-    # with `link_with = "dequant.o"`).
-    dequant_func = None
-    if not direct_codegen:
-        dequant_func = FuncOp(
-            "dequant_int4_bf16",
-            ([l1_packed_ty, l1_out_ty], []),
-            visibility="private",
-        )
-        dequant_func.attributes["link_with"] = StringAttr.get("dequant.o")
-        dequant_func.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+    with air.launch(name="dequant") as launch:
 
-    herd_kwargs = {"name": "dequant_herd", "sizes": [1, herd_n]}
-    if not direct_codegen:
-        herd_kwargs["link_with"] = "dequant.o"
+        @launch.body
+        def _():
 
-    @FuncOp.from_py_func(l3_packed_ty, l3_out_ty)
-    def dequant(arg_packed, arg_out):
-        @launch(operands=[arg_packed, arg_out])
-        def launch_body(l_packed, l_out):
-            @segment(name="seg", operands=[l_packed, l_out])
-            def segment_body(s_packed, s_out):
-                @herd(operands=[s_packed, s_out], **herd_kwargs)
-                def herd_body(_tx, _ty, _sx, _sy, h_packed, h_out):
-                    l1_packed = AllocOp(l1_packed_ty, [], [])
-                    l1_out = AllocOp(l1_out_ty, [], [])
+            with air.segment(name="seg") as seg:
 
-                    # Each tile pulls one row [_ty, :] of the packed BO.
-                    dma_memcpy_nd(
-                        l1_packed,
-                        h_packed,
-                        src_offsets=[_ty, 0],
-                        src_sizes=[1, tile_bytes],
-                        src_strides=[tile_bytes, 1],
-                    )
+                @seg.body
+                def _():
 
-                    if direct_codegen:
-                        _emit_inline_dequant_body(
-                            l1_packed,
-                            l1_out,
-                            n_tile,
-                            group_size,
-                            q_bytes,
-                            s_bytes,
-                            ng_tile,
-                            nsub_per_group,
-                        )
-                    else:
-                        CallOp(dequant_func, [l1_packed, l1_out])
+                    with air.herd(
+                        [range(1), range(herd_n)],
+                        name="dequant_herd",
+                        shape=(1, herd_n),
+                    ) as h:
 
-                    # Each tile writes a contiguous output slice
-                    # [_ty * n_tile : (_ty + 1) * n_tile].
-                    ty_to_off = AffineMap.get(
-                        0,
-                        1,
-                        [
-                            AffineExpr.get_mul(
-                                AffineSymbolExpr.get(0),
-                                AffineConstantExpr.get(n_tile),
+                        @h.body
+                        def _(tx, ty):
+                            packed = air.alloc([tile_bytes], i8, scope=h.private())
+                            out = air.alloc(
+                                [n_tile], bf16, scope=h.private(), vector=R_SUB
                             )
-                        ],
-                    )
-                    out_off = affine_apply(ty_to_off, [_ty])
-                    dma_memcpy_nd(
-                        h_out,
-                        l1_out,
-                        dst_offsets=[out_off],
-                        dst_sizes=[n_tile],
-                        dst_strides=[1],
-                    )
 
-                    DeallocOp(l1_packed)
-                    DeallocOp(l1_out)
+                            # Each tile pulls one row of the packed buffer.
+                            ops.load(packed, l3_packed[ty, :])
+
+                            if direct_codegen:
+                                scale = air.alloc([1], bf16, scope=h.private())
+                                # Unrolled in Python so each group's metadata
+                                # offsets stay constants. Inside an scf.for,
+                                # loop strength reduction rewrites the
+                                # induction variable in element units and then
+                                # reuses it for the byte offsets, silently
+                                # corrupting them.
+                                for g in range(ng_tile):
+                                    z = q_bytes + s_bytes + g
+                                    lo, hi = q_bytes + g * 2, q_bytes + g * 2 + 1
+                                    # Two bytes, little end first, reinterpreted
+                                    # as the bf16 they spell.
+                                    scale[0:1] = ops.bitcast(
+                                        ops.cast(packed[lo : lo + 1], i16, signed=False)
+                                        | (
+                                            ops.cast(
+                                                packed[hi : hi + 1], i16, signed=False
+                                            )
+                                            << 8
+                                        ),
+                                        bf16,
+                                    )
+                                    for i in air.sequential(0, nsub_per_group):
+                                        e = g * group_size + i * R_SUB
+                                        b = g * (group_size // 2) + i * (R_SUB // 2)
+                                        nibbles = ops.cast(
+                                            ops.bitcast(packed[b : b + R_SUB // 2], i4),
+                                            i8,
+                                            signed=False,
+                                        )
+                                        out[e : e + R_SUB] = (
+                                            ops.cast(
+                                                ops.cast(
+                                                    nibbles - packed[z : z + 1], i16
+                                                ),
+                                                bf16,
+                                            )
+                                            * scale[0:1]
+                                        )
+                            else:
+                                kernel(packed, out)
+
+                            # Each tile writes a contiguous output slice.
+                            ops.store(out, l3_out[ty * n_tile : ty * n_tile + n_tile])
+
+    return launch
 
 
 def pack_inputs(int4_vals, scales, zeros, n, group_size, herd_n):
@@ -278,25 +193,21 @@ def pack_inputs(int4_vals, scales, zeros, n, group_size, herd_n):
     return packed
 
 
-if __name__ == "__main__":
-    N = 1024
-    GROUP_SIZE = 128
-    HERD_N = 4
-
+def parse_args():
     parser = argparse.ArgumentParser(
         prog="dequant_awq.py",
         description="AWQ-style int4 to bf16 dequantization example",
     )
     parser.add_argument("-v", "--verbose", action="store_true")
     parser.add_argument("-p", "--print-module-only", action="store_true")
-    parser.add_argument("--n", type=int, default=N, help="Number of elements")
+    parser.add_argument("--n", type=int, default=1024, help="Number of elements")
     parser.add_argument(
-        "--group-size", type=int, default=GROUP_SIZE, help="Quantization group size"
+        "--group-size", type=int, default=128, help="Quantization group size"
     )
     parser.add_argument(
         "--herd-n",
         type=int,
-        default=HERD_N,
+        default=4,
         dest="herd_n",
         help="Number of compute tiles to split N across",
     )
@@ -330,10 +241,9 @@ if __name__ == "__main__":
         action="store_true",
         dest="direct_codegen",
         help=(
-            "Emit the per-tile dequant body as inline standard MLIR ops "
-            "(arith/vector/memref) instead of a CallOp to the hand-written "
-            "dequant.o kernel. AIE2P only; requires group_size multiple of "
-            f"{R_SUB}."
+            "Emit the per-tile dequant body in the DSL instead of calling the "
+            f"hand-written dequant.o kernel. AIE2P only; requires group_size "
+            f"multiple of {R_SUB}."
         ),
     )
     args = parser.parse_args()
@@ -356,9 +266,8 @@ if __name__ == "__main__":
             parser.error("--direct-codegen is AIE2P only (no npu1 support)")
     else:
         # The hand-written kernel's inner loop processes 32 nibbles per
-        # iteration (see GROUP_SIZE static_assert in dequant.cc). Catch
-        # the mismatch here with a clear message instead of failing at
-        # C++ compile time.
+        # iteration (see the GROUP_SIZE static_assert in dequant.cc). Catch the
+        # mismatch here instead of at C++ compile time.
         if args.group_size % 32 != 0:
             parser.error(
                 "group_size must be a multiple of 32 (kernel inner vector width)"
@@ -371,13 +280,19 @@ if __name__ == "__main__":
         parser.error("N / herd_n must be divisible by group_size")
     if args.device == "npu1" and args.output_format == "elf":
         parser.error("--output-format=elf is not supported on npu1; use xclbin")
+    return args
 
-    mlir_module = build_module(
+
+def main():
+    args = parse_args()
+
+    launch = build_module(
         args.n, args.group_size, args.herd_n, direct_codegen=args.direct_codegen
     )
+    mlir_module = launch.build(target=args.device or "auto")
     if args.print_module_only:
         print(mlir_module)
-        exit(0)
+        return 0
 
     np.random.seed(0)
     n_groups = args.n // args.group_size
@@ -395,30 +310,33 @@ if __name__ == "__main__":
             (float(int4_vals[i]) - float(zeros[g])) * float(scales[g])
         )
 
-    # ELF kernel resolves as main:<instance_name>; must match @dequant.
-    if args.compile_mode == "compile-and-run":
-        runner = XRTRunner(
-            verbose=args.verbose,
-            omit_pingpong=True,
-            output_format=args.output_format,
-            instance_name="dequant",
-            target_device=args.device,
-        )
-        exit(
-            runner.run_test(
-                mlir_module,
-                inputs=[packed],
-                expected_outputs=[ref_output],
-                rtol=1e-1,
-                atol=5e-2,
-            )
-        )
-    elif args.compile_mode == "compile-only":
+    if args.compile_mode == "compile-only":
         backend = XRTBackend(
             verbose=args.verbose,
             omit_pingpong=True,
             output_format=args.output_format,
-            target_device=args.device,
+            target_device=launch.target,
         )
-        module_function = backend.compile(mlir_module)
+        backend.compile(mlir_module)
         backend.unload()
+        return 0
+
+    # The ELF kernel resolves as main:<instance_name>, which must match @dequant.
+    runner = XRTRunner(
+        verbose=args.verbose,
+        omit_pingpong=True,
+        output_format=args.output_format,
+        instance_name="dequant",
+        target_device=launch.target,
+    )
+    return runner.run_test(
+        mlir_module,
+        inputs=[packed],
+        expected_outputs=[ref_output],
+        rtol=1e-1,
+        atol=5e-2,
+    )
+
+
+if __name__ == "__main__":
+    exit(main())

--- a/programming_examples/shared_l1_single_herd/run.py
+++ b/programming_examples/shared_l1_single_herd/run.py
@@ -1,59 +1,132 @@
 # Copyright (C) 2026, Advanced Micro Devices, Inc.
 # SPDX-License-Identifier: MIT
+"""Shared-L1 communication between cores of a single herd, on air.api.
 
-"""Shared-L1 communication between cores within a single air.herd.
-
-A column of NC cores is expressed as ONE air.herd [1, NC]. Every core runs the
-same body (a herd is a single program replicated across its cores) and learns
-its position from the tile index ty. Data flows DOWN the column entirely through
-shared L1: neighbor cores read/write a common L1 buffer, so there is no DMA --
-and no AIE hardware cascade link -- between the cores. Exercising that shared-L1
-hand-off is the whole point of the example.
+A column of NC cores is one ``air.herd [1, NC]``. Every core runs the same body
+and learns its position from ``ty``. Data flows down the column entirely through
+shared L1 -- there is no DMA and no hardware cascade between the cores::
 
     core 0   : v0 = g(in0)                    -> hop[0]
     core k   : vk = g(ink) + hop[k-1]         -> hop[k]        (1 <= k < NC-1)
     core NC-1: out = g(in_{NC-1}) + hop[NC-2] -> @outY
 
-  * Each hop[k] is an L1 buffer shared between neighbor cores k and k+1: core k
-    writes it, core k+1 reads it (intra-herd neighbor shared L1).
-  * Each core picks its role (first / middle / last) from its tile index ty with
-    a single scf.index_switch.
-  * g() also runs a short loop whose per-iteration constant is chosen by a SECOND
-    scf.index_switch keyed on the loop counter -- so the example shows
-    scf.index_switch used both for tile-index role selection and for loop-index
-    value selection.
+Each ``hop[k]`` is an L1 buffer that neighbouring cores k and k+1 both address:
+k writes it, k+1 reads it. In the DSL that is ``<segment>.per_core()`` -- L1
+allocated at segment scope and handed to the herd whole. The name says what the
+*allocation* is, one buffer per core rather than one slab of a divided one; that
+the cores of a single herd can then hand data along it is the compiler's doing,
+and it is what this example exists to exercise.
 
-The per-core compute here is just a trivial vectorized accumulate (a placeholder
-for whatever real work a core would do); input/output move over simple L3<->L1
-channels so the example runs standalone on NPU1.
+``g()`` adds a per-step constant chosen by ``ops.switch`` on the loop counter --
+a value picked by a runtime index, which is ``scf.index_switch`` in its
+value-returning form.
 
 Result: out = sum(in[0..NC-1]) + NC * sum(STEP_ADDENDS).
+
+One departure from the predecessor's IR. The role dispatch was a second
+``scf.index_switch``, keyed on ``ty`` and run for its effects; here it is a
+chain of ``ops.branch``, which is ``scf.if``. The DSL has one N-way construct
+and it is the value-returning one, on the grounds that the statement form is
+nested branch -- so this is that spelling, not a missing feature. What the
+example demonstrated twice it now demonstrates once, in the half where a switch
+buys something a branch does not.
+
+The chunk width is pinned with ``vector=VEC`` rather than left to the emitter:
+a producer's write to a shared buffer and the consumer's read of it have to
+carry matching per-chunk lock acquire/release counts, so the two must be
+chunked the same way.
 """
 
 import argparse
+
 import numpy as np
+from ml_dtypes import bfloat16
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16
+from air.backend.xrt_runner import XRTRunner
 
 np.random.seed(42)
-
-import air
-from air.ir import *
-from air.dialects.air import *
-from air.dialects import memref, vector, arith, scf
-from air.dialects.func import FuncOp
-from air.dialects.scf import for_, yield_, index_switch
-from air.dialects.arith import ConstantOp
-from air.dialects.memref import AllocOp
-from air.backend.xrt_runner import XRTRunner
-from ml_dtypes import bfloat16
 
 NC = 4  # cores in the column; NC-1 shared-L1 hops
 T = 64  # elements per core tile
 VEC = 16  # vector width
 
-STEP_ADDENDS = [1.0, 10.0]  # per-step constant selected via scf.index_switch
+STEP_ADDENDS = [1.0, 10.0]  # per-step constant selected by ops.switch
 NSTEP = len(STEP_ADDENDS)
 
-range_ = for_
+
+def build_module():
+    l3_in = air.tensor([NC, T], bf16)
+    l3_out = air.tensor([1, T], bf16)
+
+    in_x = air.channel("inX", size=[NC])  # per-core input feed (L2 -> L1)
+    out_y = air.channel("outY", size=[1])  # last core's result (L1 -> L2)
+
+    with air.launch([range(1), range(1)], name="col_relay") as launch:
+
+        @launch.body
+        def _(lx, ly):
+
+            with air.segment(name="seg") as seg:
+
+                @seg.body
+                def _():
+                    # Input L3 -> L2 in one transfer, then fanned per core.
+                    in_l2 = air.alloc([NC, T], bf16, scope=seg.private())
+                    ops.load(in_l2, l3_in)
+                    for c in range(NC):
+                        in_x.put(in_l2[c, :], indices=[c])
+
+                    # One hop buffer per relay edge: core k writes hop[k],
+                    # core k+1 reads it.
+                    hop = [
+                        air.alloc([T], bf16, scope=seg.per_core(), vector=VEC)
+                        for _ in range(NC - 1)
+                    ]
+
+                    with air.herd(
+                        [range(1), range(NC)], name="col_relay", shape=(1, NC)
+                    ) as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            local = air.alloc([T], bf16, scope=h.private(), vector=VEC)
+                            in_x.get(local, indices=[ty])
+
+                            # Every core runs this: local += the step's addend,
+                            # which ops.switch picks from the loop counter.
+                            for step in air.sequential(0, NSTEP):
+                                local[:] = local[:] + ops.switch(step, STEP_ADDENDS)
+
+                            def role(k):
+                                if k > 0:
+                                    local[:] = local[:] + hop[k - 1][:]
+                                if k < NC - 1:
+                                    hop[k][:] = local[:]
+                                else:
+                                    out_y.put(local)
+
+                            # core 0, then 1, ... with the last core in the
+                            # final else, matching the predecessor's default arm.
+                            def dispatch(k):
+                                if k == NC - 1:
+                                    role(k)
+                                    return
+                                with ops.branch(ty == k) as arm:
+                                    role(k)
+                                with arm.otherwise():
+                                    dispatch(k + 1)
+
+                            dispatch(0)
+
+                    # The last core's result, L1 -> L2 -> L3.
+                    out_l2 = air.alloc([1, T], bf16, scope=seg.private())
+                    out_y.get(out_l2)
+                    ops.store(out_l2, l3_out)
+
+    return launch
 
 
 def parse_args():
@@ -65,175 +138,24 @@ def parse_args():
         default="xclbin",
         dest="output_format",
     )
+    p.add_argument(
+        "--target",
+        type=str,
+        default="auto",
+        help="NPU generation to build for: auto (default, detects the installed "
+        "device), npu1 or npu2",
+    )
     return p.parse_args()
-
-
-@module_builder
-def build_module():
-    itype = IndexType.get()
-    bf16 = air.ir.Type.parse("bf16")
-
-    def idx(v):
-        return ConstantOp(itype, v)
-
-    l1 = Attribute.parse("2")
-    l2 = Attribute.parse("1")
-    l1_t = MemRefType.get([T], bf16, memory_space=l1)
-    l2_in_t = MemRefType.get([NC, T], bf16, memory_space=l2)
-    l2_out_t = MemRefType.get([1, T], bf16, memory_space=l2)
-    l3_in_t = MemRefType.get([NC, T], bf16)
-    l3_out_t = MemRefType.get([1, T], bf16)
-
-    channel("inX", size=[NC])  # per-core input feed (L2 -> L1)
-    channel("outY", size=[1])  # last core's result (L1 -> L2)
-
-    am = AffineMapAttr.get(AffineMap.get_identity(1))
-
-    def _rd(buf, j):
-        cst0 = arith.ConstantOp(bf16, 0.0)
-        return vector.transfer_read(
-            VectorType.get([VEC], bf16),
-            memref.subview(buf, [j], [VEC], [1]),
-            [idx(0)],
-            am,
-            cst0,
-            [True],
-        )
-
-    def _wr(vec, buf, j):
-        vector.transfer_write(
-            None, vec, memref.subview(buf, [j], [VEC], [1]), [idx(0)], am, [True]
-        )
-
-    def emit_axpy(buf, scalar_val):
-        """buf[:] += scalar_val (bf16 SSA value)."""
-        for j in range_(idx(0), idx(T), idx(VEC)):
-            vs = vector.BroadcastOp(VectorType.get([VEC], bf16), scalar_val)
-            _wr(arith.AddFOp(_rd(buf, j), vs), buf, j)
-            yield_([])
-
-    def emit_add_inplace(dst, src):
-        """dst[:] += src[:]. Chunked so a producer's shared-buffer write and this
-        consumer's read carry MATCHING per-chunk lock acquire/release counts."""
-        for j in range_(idx(0), idx(T), idx(VEC)):
-            _wr(arith.AddFOp(_rd(dst, j), _rd(src, j)), dst, j)
-            yield_([])
-
-    def emit_copy(src, dst):
-        """dst[:] = src[:], chunked (same lock-count reasoning as emit_add_inplace)."""
-        for j in range_(idx(0), idx(T), idx(VEC)):
-            _wr(_rd(src, j), dst, j)
-            yield_([])
-
-    @FuncOp.from_py_func(l3_in_t, l3_out_t)
-    def col_relay(l3_in, l3_out):
-        @launch(operands=[l3_in, l3_out], sizes=[1, 1])
-        def launch_body(lx, ly, lsx, lsy, gin, gout):
-            @segment(name="seg", operands=[gin, gout])
-            def segment_body(sin, sout):
-                # Relay input L3 -> L2 (one DMA) -> fan per-core via @inX.
-                in_l2 = AllocOp(l2_in_t, [], [])
-                dma_memcpy_nd(
-                    in_l2.result,
-                    sin,
-                    dst_offsets=[idx(0), idx(0)],
-                    dst_sizes=[idx(NC), idx(T)],
-                    dst_strides=[idx(T), idx(1)],
-                    src_offsets=[idx(0), idx(0)],
-                    src_sizes=[idx(NC), idx(T)],
-                    src_strides=[idx(T), idx(1)],
-                )
-                for c in range(NC):
-                    ChannelPut(
-                        "inX",
-                        in_l2.result,
-                        indices=[idx(c)],
-                        offsets=[idx(c), idx(0)],
-                        sizes=[idx(1), idx(T)],
-                        strides=[idx(T), idx(1)],
-                    )
-
-                # NC-1 shared L1 hop buffers, one per relay edge (core k -> k+1).
-                shbuf = [AllocOp(l1_t, [], []) for _ in range(NC - 1)]
-                shbuf_ops = [b.result for b in shbuf]
-
-                @herd(name="col_relay", sizes=[1, NC], operands=shbuf_ops)
-                def herd_body(tx, ty, sx, sy, *hops):
-                    # ---- input + step loop (all cores run this common body) ----
-                    # local = in + sum over steps of STEP_ADDENDS[step], where
-                    # each step's addend is picked by scf.index_switch(step).
-                    local = AllocOp(l1_t, [], [])
-                    ChannelGet("inX", local.result, indices=[ty])
-                    a_consts = [arith.ConstantOp(bf16, v) for v in STEP_ADDENDS]
-                    for step in range_(idx(0), idx(NSTEP), idx(1)):
-                        addend = index_switch(
-                            [bf16],
-                            step,
-                            list(range(NSTEP - 1)),
-                            case_body_builder=lambda op, i, cv: yield_(
-                                [a_consts[i].result]
-                            ),
-                            default_body_builder=lambda op: yield_(
-                                [a_consts[-1].result]
-                            ),
-                        )
-                        emit_axpy(local.result, addend)
-                        yield_([])
-
-                    # ---- relay role dispatch by ty via scf.index_switch ----
-                    # case k (0..NC-2): if k>0 fold in the incoming hop, then
-                    #                   publish to hop[k].
-                    # default (k=NC-1): fold in the last hop, emit the result.
-                    def emit_role(k):
-                        if k > 0:
-                            emit_add_inplace(local.result, hops[k - 1])
-                        if k < NC - 1:
-                            emit_copy(local.result, hops[k])
-                        else:
-                            ChannelPut("outY", local.result, indices=[idx(0)])
-
-                    index_switch(
-                        [],
-                        ty,
-                        list(range(NC - 1)),
-                        case_body_builder=lambda op, k, cv: (
-                            emit_role(k),
-                            yield_([]),
-                        )[-1],
-                        default_body_builder=lambda op: (
-                            emit_role(NC - 1),
-                            yield_([]),
-                        )[-1],
-                    )
-
-                # Collect the last core's result L1 -> L2 -> L3.
-                out_l2 = AllocOp(l2_out_t, [], [])
-                ChannelGet(
-                    "outY",
-                    out_l2.result,
-                    indices=[idx(0)],
-                    offsets=[idx(0), idx(0)],
-                    sizes=[idx(1), idx(T)],
-                    strides=[idx(T), idx(1)],
-                )
-                dma_memcpy_nd(
-                    sout,
-                    out_l2.result,
-                    dst_offsets=[idx(0), idx(0)],
-                    dst_sizes=[idx(1), idx(T)],
-                    dst_strides=[idx(T), idx(1)],
-                    src_offsets=[idx(0), idx(0)],
-                    src_sizes=[idx(1), idx(T)],
-                    src_strides=[idx(T), idx(1)],
-                )
 
 
 def main():
     args = parse_args()
-    mlir_module = build_module()
+
+    launch = build_module()
+    mlir_module = launch.build(target=args.target)
     if args.print_ir:
-        print(str(mlir_module))
-        return
+        print(mlir_module)
+        return 0
 
     A = np.random.rand(NC, T).astype(bfloat16)
     s = float(sum(STEP_ADDENDS))
@@ -244,10 +166,10 @@ def main():
         verbose=False,
         output_format=args.output_format,
         instance_name="col_relay",
-        debug_ir=True,
+        target_device=launch.target,
     )
-    exit(runner.run_test(mlir_module, inputs=[A], expected_outputs=[C], rtol=3e-2))
+    return runner.run_test(mlir_module, inputs=[A], expected_outputs=[C], rtol=3e-2)
 
 
 if __name__ == "__main__":
-    main()
+    exit(main())

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -127,7 +127,7 @@ from ._trace import (
     wait,
 )
 from ._value import Buffer, BufferSlice, Tensor, TensorSlice, Token
-from .types import DType, bf16, f16, f32, i8, i16, i32, ui8, ui16, ui32
+from .types import DType, bf16, f16, f32, i4, i8, i16, i32, ui8, ui16, ui32
 
 __all__ = [
     # operations
@@ -157,6 +157,7 @@ __all__ = [
     "bf16",
     "f16",
     "f32",
+    "i4",
     "i8",
     "i16",
     "i32",

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -589,6 +589,8 @@ def emit_elementwise(dst, expr):
     width = dst.vector_width
     vectorized = bool(shape) and width > 0 and shape[-1] % width == 0
 
+    _check_repack(expr, dst, shape, width)
+
     if vectorized:
         _emit_vector(dst, expr, width)
     else:
@@ -598,6 +600,51 @@ def emit_elementwise(dst, expr):
 # ---------------------------------------------------------------------------
 # Loop nest construction
 # ---------------------------------------------------------------------------
+
+
+def _has_repack(node):
+    """Is there a lane-count-changing bitcast anywhere in this expression?"""
+    return _is_repack(node) or any(_has_repack(a) for a in node.args)
+
+
+def _check_repack(expr, dst, shape, width):
+    """A repacking bitcast constrains the whole assignment, so say so up front.
+
+    Raised here rather than where the read is built. The operand is indexed from
+    its region's start alone -- there is no induction variable in the right
+    units to advance it, the destination's are in the other type's -- so more
+    than one trip would read the same run of memory every time. Emission has
+    already opened the loop nest by the time the read happens, and raising from
+    inside it leaves a block with no terminator and a trace too broken to print,
+    which buries the real message under an MLIR verifier error.
+    """
+    if not _has_repack(expr):
+        return
+    if not shape or width <= 0 or shape[-1] % width:
+        raise NotImplementedError(
+            "air.api.ops.bitcast that changes the lane count needs the vector "
+            f"path, and this assignment takes the scalar one: its destination "
+            f"{shape} is not a multiple of its vector width {width}. "
+            "Reinterpreting one element at a time is not the same operation -- "
+            "the whole point is that a run of memory holds a different number "
+            "of them"
+        )
+    trips = 1
+    for extent in shape[:-1]:
+        trips *= extent
+    trips *= shape[-1] // width
+    if trips != 1:
+        raise NotImplementedError(
+            f"air.api.ops.bitcast reinterprets a run of memory, so the "
+            f"assignment it appears in has to cover exactly one vector. This "
+            f"destination is {shape} at a width of {width}, which is {trips} "
+            f"trips of the nest, and the reinterpreted operand is indexed from "
+            f"its region's start alone -- it would read the same {width} "
+            f"elements every trip. Write the loop yourself with air.sequential "
+            f"and assign one vector per trip. Every axis counts, not just the "
+            f"innermost: a {(4, width)} destination is four trips even though "
+            f"its innermost extent is exactly one vector"
+        )
 
 
 def _nest(bounds, body):
@@ -992,19 +1039,9 @@ def _emit_vector(dst, expr, width):
             # A repacking bitcast's operand: fewer buffer elements than the
             # destination has, covering the same run of memory. `_leaf_index`
             # sees an extent that does not match the destination's and pins the
-            # axis at the region's own base -- which is the right index only
-            # while the nest makes a single trip, so require that rather than
-            # rely on it.
-            if shape[-1] != width:
-                raise NotImplementedError(
-                    f"air.api.ops.bitcast reinterprets a run of memory, so the "
-                    f"assignment it appears in has to cover exactly one vector: "
-                    f"this destination is {shape[-1]} elements at a width of "
-                    f"{width}, which is {shape[-1] // width} trips, and the "
-                    f"reinterpreted operand would not advance between them. "
-                    f"Write the loop yourself with air.sequential and assign "
-                    f"{width} elements per trip"
-                )
+            # axis at the region's own base, which is the right index only while
+            # the nest makes a single trip -- checked by `_check_repack` before
+            # any of this was emitted.
             return _result(
                 transfer_read(
                     region.vec_ty,

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -429,8 +429,30 @@ def _regions_in(node, dtype, out):
     return out
 
 
+def _resolve_switches(node, dtype):
+    """Emit any ops.switch in the tree, before the loop nest is built.
+
+    A choice does not depend on the nest's induction variables, so its
+    scf.index_switch belongs above the loop -- one switch per assignment rather
+    than one per trip, which is where the hand-written kernels put it. It also
+    cannot be emitted any earlier than this: the element type it yields is the
+    destination's, and ops.switch is written before the destination is known.
+    """
+    from .ops import _Switch
+
+    if node.kind == "scalar" and isinstance(node.scalar, _Switch):
+        node.scalar = node.scalar.materialize(dtype)
+        return
+    if node.kind == "cast":
+        _resolve_switches(node.args[0], node.args[0].element_dtype() or dtype)
+        return
+    for arg in node.args:
+        _resolve_switches(arg, dtype)
+
+
 def emit_elementwise(dst, expr):
     """Emit ``dst[:] = expr`` as a loop nest over ``dst``'s shape."""
+    _resolve_switches(expr, dst.dtype)
     # A reduction is the one right-hand side whose shape is not the
     # destination's, so it is dispatched before the elementwise shape check
     # rather than being taught to it.
@@ -982,6 +1004,12 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
     if node.kind == "scalar":
         value = node.scalar
         from ._index import IndexExpr
+
+        # An already-typed SSA value -- what ops.switch returns, having emitted
+        # its scf.index_switch where it was written rather than inside this
+        # loop. It is the element type already, so it only needs splatting.
+        if not isinstance(value, (int, float, IndexExpr)):
+            return _result(broadcast(vec_ty, value)) if vectorized else value
 
         if isinstance(value, IndexExpr):
             # Materialise first: a constant expression folds back to a Python

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -189,6 +189,34 @@ def _pins_an_axis(shape, dst_shape):
     return any(extent != dst_shape[i + offset] for i, extent in enumerate(shape))
 
 
+def _is_repack(node):
+    """Is this bitcast one that changes the lane count?
+
+    A same-width bitcast is a relabelling and behaves exactly like a cast. A
+    repack -- 32 bytes read as 64 half-bytes -- changes how many elements a run
+    of memory holds, so its operand is read at a different lane count from the
+    rest of the nest and cannot share the per-dtype region table.
+    """
+    if node.kind != "bitcast":
+        return False
+    return node.args[0].element_dtype().bits != node.dtype.bits
+
+
+def _pins_for(node, dst_shape):
+    """Does any leaf under ``node`` need the shared zero index constant?
+
+    Walks the tree rather than ``leaves()`` because a repacking bitcast's
+    operand is not indexed like an ordinary leaf: its extent never matches the
+    destination's, so ``_leaf_index`` always takes the pinned branch, which
+    reaches for the constant whenever the region starts at 0.
+    """
+    if _is_repack(node):
+        return True
+    if node.kind == "buffer":
+        return _pins_an_axis(node.buffer.shape, dst_shape)
+    return any(_pins_for(a, dst_shape) for a in node.args)
+
+
 def _zero_index_if(needed):
     """An index-typed 0 for the pinned axes of a broadcast, or None.
 
@@ -253,6 +281,22 @@ def _leaf_index(leaf, dst_shape, ivs, zero):
         else:
             index.append(_result(arith.AddIOp(iv, _materialize_index(start))))
     return index
+
+
+def _pinned_index(leaf, zero):
+    """Every axis at the region's own start -- no induction variable anywhere.
+
+    What a repacking bitcast's operand needs. It covers the same run of memory
+    as the destination but counts it in different units, so the destination's
+    induction variables are in the wrong units to index it; the emitter requires
+    such an assignment to be a single trip precisely so that the start is the
+    whole answer.
+    """
+    sizes, dropped, base = _axes_of(leaf)
+    return [
+        zero if base is None or _is_zero(base[i]) else _materialize_index(base[i])
+        for i in range(len(sizes))
+    ]
 
 
 def _dst_index(dst, ivs):
@@ -369,10 +413,46 @@ def _check_region(node, dst, dtype, expected=None):
     # with "destination has shape (1, 1) but operand has shape (1, 64)".
     if node.kind == "reduce":
         raise _nested_reduction(node)
-    if node.kind == "cast":
+    if _is_repack(node):
+        # The operand covers the same run of memory as the destination but
+        # counts it in different units, so it is its *reinterpreted* extent that
+        # has to broadcast -- 32 bytes present as 64 half-bytes. Checking the
+        # buffer's own shape would reject every correct use.
+        leaf = node.args[0].buffer
+        ratio = node.args[0].element_dtype().bits // node.dtype.bits
+        presented = tuple(leaf.shape[:-1]) + (leaf.shape[-1] * ratio,)
+        if _broadcast_offset(presented, dst.shape) is None:
+            raise ValueError(
+                f"shape mismatch in elementwise assignment: destination has "
+                f"shape {dst.shape} but the bitcast operand {leaf.shape} of "
+                f"{node.args[0].element_dtype()} reinterprets as {presented} of "
+                f"{node.dtype}, which does not broadcast to it"
+            )
+        if leaf.dtype is not node.args[0].element_dtype():
+            raise ValueError(
+                f"dtype mismatch in elementwise assignment: the bitcast "
+                f"reinterprets from {node.args[0].element_dtype()} but operand "
+                f"is {leaf.dtype}"
+            )
+        if leaf.value is None:
+            raise RuntimeError(
+                "buffer used before allocation; air.alloc() must be called "
+                "inside the herd body that uses it"
+            )
+        return
+
+    if node.kind in ("cast", "bitcast"):
         source = node.args[0].element_dtype()
+        what = "cast" if node.kind == "cast" else "bitcast"
         _check_region(
-            node.args[0], dst, source, expected=f"the cast converts from {source}"
+            node.args[0],
+            dst,
+            source,
+            expected=(
+                f"the {what} reinterprets from {source}"
+                if what == "bitcast"
+                else f"the cast converts from {source}"
+            ),
         )
         return
     if node.kind == "buffer":
@@ -421,8 +501,13 @@ def _regions_in(node, dtype, out):
     """
     if dtype is not None and dtype not in out:
         out.append(dtype)
-    if node.kind == "cast":
+    if node.kind == "cast" or (node.kind == "bitcast" and not _is_repack(node)):
         _regions_in(node.args[0], node.args[0].element_dtype(), out)
+        return out
+    if node.kind == "bitcast":
+        # A repack reads its operand at its own lane count -- 32 bytes where the
+        # destination steps 64 half-bytes -- so its region cannot come from this
+        # table, which holds one lane count for the whole nest. _eval builds it.
         return out
     for arg in node.args:
         _regions_in(arg, dtype, out)
@@ -654,7 +739,15 @@ def _emit_reduce(dst, expr):
     # The same broadcast-aware read the elementwise path uses: a leaf with the
     # reduced axis's full extent is a vector read, and one of extent 1 there is
     # a single element splatted across the vector.
-    def load(buf, at, region):
+    def load(buf, at, region, packed=False):
+        if packed:
+            raise NotImplementedError(
+                "air.api.ops.bitcast that changes the lane count cannot appear "
+                "inside a reduction or an argmax: those walk the reduced axis "
+                "themselves, and a reinterpretation changes how many elements "
+                "that axis has. Assign the reinterpreted values to a buffer "
+                "first, then reduce it"
+            )
         index = _leaf_index(buf, src_shape, at, zero)
         if buf.shape and buf.shape[-1] == src_shape[-1]:
             return _result(
@@ -805,7 +898,15 @@ def _emit_argmax(dst, expr):
     zero = _result(arith.ConstantOp(IndexType.get(), 0))
     bounds = [(0, extent, 1) for extent in src_shape[:-1]]
 
-    def load(buf, ivs, region):
+    def load(buf, ivs, region, packed=False):
+        if packed:
+            raise NotImplementedError(
+                "air.api.ops.bitcast that changes the lane count cannot appear "
+                "inside a reduction or an argmax: those walk the reduced axis "
+                "themselves, and a reinterpretation changes how many elements "
+                "that axis has. Assign the reinterpreted values to a buffer "
+                "first, then reduce it"
+            )
         return _result(memref_load(buf.value, _leaf_index(buf, src_shape, ivs, zero)))
 
     def at(ivs, column):
@@ -884,11 +985,36 @@ def _emit_vector(dst, expr, width):
 
     # Hoisted above the nest, like the padding constants, so a broadcast costs
     # one constant for the whole kernel rather than one per trip.
-    zero = _zero_index_if(
-        any(_pins_an_axis(leaf.shape, shape) for leaf in expr.leaves())
-    )
+    zero = _zero_index_if(_pins_for(expr, shape))
 
-    def load(buf, ivs, region):
+    def load(buf, ivs, region, packed=False):
+        if packed:
+            # A repacking bitcast's operand: fewer buffer elements than the
+            # destination has, covering the same run of memory. `_leaf_index`
+            # sees an extent that does not match the destination's and pins the
+            # axis at the region's own base -- which is the right index only
+            # while the nest makes a single trip, so require that rather than
+            # rely on it.
+            if shape[-1] != width:
+                raise NotImplementedError(
+                    f"air.api.ops.bitcast reinterprets a run of memory, so the "
+                    f"assignment it appears in has to cover exactly one vector: "
+                    f"this destination is {shape[-1]} elements at a width of "
+                    f"{width}, which is {shape[-1] // width} trips, and the "
+                    f"reinterpreted operand would not advance between them. "
+                    f"Write the loop yourself with air.sequential and assign "
+                    f"{width} elements per trip"
+                )
+            return _result(
+                transfer_read(
+                    region.vec_ty,
+                    buf.value,
+                    _pinned_index(buf, zero),
+                    _minor(len(_axes_of(buf)[0])),
+                    region.pad,
+                    [True],
+                )
+            )
         index = _leaf_index(buf, shape, ivs, zero)
         if buf.shape and buf.shape[-1] == shape[-1]:
             # The operand has the destination's innermost extent, so the vector
@@ -924,11 +1050,14 @@ def _emit_scalar(dst, expr):
     regions = {d: _Region(d, 0, False) for d in _regions_in(expr, dst.dtype, [])}
     bounds = [(0, extent, 1) for extent in shape]
 
-    zero = _zero_index_if(
-        any(_pins_an_axis(leaf.shape, shape) for leaf in expr.leaves())
-    )
+    zero = _zero_index_if(_pins_for(expr, shape))
 
-    def load(buf, ivs, region):
+    def load(buf, ivs, region, packed=False):
+        if packed:
+            raise NotImplementedError(
+                "air.api.ops.bitcast that changes the lane count needs the "
+                "vector path; this assignment fell back to a scalar loop"
+            )
         return _result(memref_load(buf.value, _leaf_index(buf, shape, ivs, zero)))
 
     def body(ivs):
@@ -998,8 +1127,49 @@ def _eval(node, ivs, region, regions, vectorized, load, reads=None):
         # again here keeps the rule in one place rather than trusting a flag
         # threaded down from the call site.
         narrowing_ok = _clamped_into(node.args[0], region.dtype)
-        build = _conversion_op(source, region.dtype, narrowing_ok=narrowing_ok)
+        build = _conversion_op(
+            source, region.dtype, narrowing_ok=narrowing_ok, signed=node.signed
+        )
         return _result(build(vec_ty if vectorized else ety, operand))
+
+    if node.kind == "bitcast":
+        from air.dialects.vector import bitcast as vector_bitcast
+
+        source = node.args[0].element_dtype()
+        if not _is_repack(node):
+            # Same width: a relabelling, and the lane count is untouched, so it
+            # rides the ordinary region machinery exactly as a cast does.
+            operand = recur(node.args[0], regions[source])
+            build = vector_bitcast if vectorized else arith.BitcastOp
+            return _result(build(vec_ty if vectorized else ety, operand))
+
+        # A repack. The operand is a buffer region (ops.bitcast enforces that),
+        # read at the lane count its own type gives the same run of memory: 32
+        # i8 where the destination steps 64 i4.
+        if not vectorized:
+            raise NotImplementedError(
+                f"air.api.ops.bitcast from {source} to {node.dtype} needs the "
+                f"vector path, and this assignment fell back to a scalar loop "
+                f"-- its destination tile is not a multiple of its vector "
+                f"width. Reinterpreting one element at a time is not the same "
+                f"operation: the whole point is that a run of memory holds a "
+                f"different number of them"
+            )
+        ratio = source.bits // node.dtype.bits
+        lanes = vec_ty.shape[0]
+        if lanes % ratio:
+            raise ValueError(
+                f"air.api.ops.bitcast from {source} to {node.dtype}: the "
+                f"destination is {lanes} lanes wide, which is not a whole "
+                f"number of {ratio}-element groups, so the reinterpreted run "
+                f"does not line up with a vector"
+            )
+        leaf = node.args[0].buffer
+        src_region = _Region(source, lanes // ratio, True)
+        # Through `load`, not a transfer_read here: the destination shape and
+        # the shared zero constant live in that closure, and so does the check
+        # that the reinterpreted run lines up with a single trip of the nest.
+        return _result(vector_bitcast(vec_ty, load(leaf, ivs, src_region, True)))
 
     if node.kind == "scalar":
         value = node.scalar

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1525,8 +1525,21 @@ def herd(iterable, name=None, shape=None, target=None, link_with=None):
     )
 
 
+def _require_allocatable(dtype, what):
+    """Refuse an element type no buffer can hold. Only i4 is such a type."""
+    if getattr(dtype, "allocatable", True):
+        return
+    raise TypeError(
+        f"{what} cannot have element type {dtype}: a DMA moves whole bytes and "
+        f"the L1 budget is counted in them, so there is no buffer of half-bytes "
+        f"to allocate. {dtype} names what packed *bytes* contain -- read them "
+        f"as a byte buffer and reinterpret with air.api.ops.bitcast"
+    )
+
+
 def tensor(shape, dtype, name=None):
     """Declare a host-visible L3 array; becomes a kernel argument."""
+    _require_allocatable(dtype, "air.tensor")
     t = Tensor(shape, dtype, name=name or infer_name(f"t{len(PENDING_TENSORS)}"))
     PENDING_TENSORS.append(t)
     return t
@@ -1534,6 +1547,7 @@ def tensor(shape, dtype, name=None):
 
 def alloc(shape, dtype, scope=None, vector=None, _hoisted=False):
     """Allocate a tile: L1 in a herd body, or L2 in a segment body."""
+    _require_allocatable(dtype, "air.alloc")
     from air.ir import IntegerAttr, MemRefType
     from air.dialects.air import MemorySpace
     from air.dialects.memref import AllocOp

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -844,10 +844,10 @@ def _check_shift_amount(amount, value, op):
             f"and MLIR would make it poison, which is silent. Shift by a "
             f"non-negative amount, or use the opposite operator"
         )
-    if dtype is not None and count >= dtype.itemsize * 8:
+    if dtype is not None and count >= dtype.bits:
         raise ValueError(
             f"shift count {count} is not less than the width of {dtype} "
-            f"({dtype.itemsize * 8} bits) in '{spelling}': Python would give "
+            f"({dtype.bits} bits) in '{spelling}': Python would give "
             f"{'0 or -1' if op == 'shr' else 'a wider integer'} but MLIR makes "
             f"it poison, which is silent. Shift by less than the width"
         )

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -860,9 +860,18 @@ class BufferExpr:
     once and emits a single vectorised loop.
     """
 
-    __slots__ = ("kind", "op", "args", "buffer", "scalar", "dtype")
+    __slots__ = ("kind", "op", "args", "buffer", "scalar", "dtype", "signed")
 
-    def __init__(self, kind, op=None, args=(), buffer=None, scalar=None, dtype=None):
+    def __init__(
+        self,
+        kind,
+        op=None,
+        args=(),
+        buffer=None,
+        scalar=None,
+        dtype=None,
+        signed=True,
+    ):
         # "buffer" | "scalar" | "unary" | "binary" | "fma" evaluate to the
         # element type; "compare" evaluates to i1 and only ops.select consumes
         # it; "select" takes (compare, value, value) back to the element type;
@@ -886,6 +895,12 @@ class BufferExpr:
         # *to*. Every other node adopts the type of the region it sits in, which
         # is what ``element_dtype`` below reports.
         self.dtype = dtype
+        # Set on a widening "cast" node only: whether the source's top bit is a
+        # sign to replicate (arith.extsi) or a value bit to zero-fill
+        # (arith.extui). Signedness lives on the *operation* rather than on the
+        # type, because MLIR's arith ops take signless integers -- a byte is
+        # just eight bits until something widens it and has to decide.
+        self.signed = signed
 
     @staticmethod
     def leaf(buffer):
@@ -907,7 +922,7 @@ class BufferExpr:
         """
         if self.kind == "buffer":
             return self.buffer.dtype
-        if self.kind == "cast":
+        if self.kind in ("cast", "bitcast"):
             return self.dtype
         if self.kind == "scalar":
             return None
@@ -1111,6 +1126,8 @@ class BufferExpr:
             return repr(self.scalar)
         if self.kind == "cast":
             return f"cast({self.args[0]!r}, {self.dtype!r})"
+        if self.kind == "bitcast":
+            return f"bitcast({self.args[0]!r}, {self.dtype!r})"
         if self.kind == "unary":
             return f"{self.op}({self.args[0]!r})"
         if self.kind == "select":

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -940,6 +940,12 @@ class BufferExpr:
             # buffer's element type -- which is what the hand-written channel
             # examples spell as arith.index_cast(T.i32(), ty).
             return BufferExpr("scalar", scalar=value)
+        from .ops import _Switch
+
+        if isinstance(value, _Switch):
+            # Resolved to an SSA value by _resolve_switches, once the
+            # destination's element type is known.
+            return BufferExpr("scalar", scalar=value)
         if isinstance(value, BufferSlice):
             # A plain region reads elementwise; a view, a strided region or a
             # dynamic offset does not, and _as_leaf says which.

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -1029,7 +1029,7 @@ def switch(index, values):
                 f"got {type(v).__name__}. Choosing between *buffers* would run "
                 "one of two loop nests, which is ops.branch"
             )
-    return _Switch(coerce_index(index), [float(v) for v in values])
+    return _Switch(coerce_index(index), list(values))
 
 
 class _Switch:
@@ -1041,18 +1041,44 @@ class _Switch:
         self.index = index
         self.values = values
 
+    def _typed(self, value, dtype):
+        """``value`` in the destination's element type, or a refusal.
+
+        The values are kept exactly as written until here, because which type
+        they should be built in is the *destination's* and a switch is written
+        before the destination is known. Coercing at construction -- everything
+        to float, as this did first -- reached arith.ConstantOp with a Python
+        float for an integer type, which fails inside FloatAttr with "expected
+        floating point type" and names neither the switch nor the value.
+        """
+        if dtype.is_float:
+            return float(value)
+        if isinstance(value, float):
+            # A whole-number float is a harmless way to write an integer, and
+            # the elementwise emitter accepts one for the same reason. Anything
+            # else would silently truncate.
+            if not value.is_integer():
+                raise ValueError(
+                    f"air.api.ops.switch: {value} is not an integer, but the "
+                    f"expression it is used in has element type {dtype}. It "
+                    f"would be truncated"
+                )
+            return int(value)
+        return int(value)
+
     def materialize(self, dtype):
         from air.dialects import arith
         from air.dialects.scf import index_switch, yield_
+
+        values = [self._typed(v, dtype) for v in self.values]
 
         index = self.index.materialize()
         if isinstance(index, int):
             # A constant index needs no switch at all, and folding it leaves the
             # same IR as writing the value out by hand.
-            picked = self.values[min(index, len(self.values) - 1)]
+            picked = values[min(index, len(values) - 1)]
             return arith.ConstantOp(dtype.mlir(), picked).result
 
-        values = self.values
         result = index_switch(
             [dtype.mlir()],
             index,

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -48,6 +48,7 @@ __all__ = [
     "copy",
     "fill",
     "cast",
+    "bitcast",
     "maximum",
     "minimum",
     # equal/not_equal/select were added with the comparison operators and were
@@ -378,7 +379,7 @@ def _elementwise(name, key, a, b):
     return BufferExpr("binary", op=key, args=(a, b))
 
 
-def cast(x, dtype):
+def cast(x, dtype, signed=True):
     """Convert an elementwise expression to another element type.
 
         l1_out[:] = air.api.ops.cast(l1_in[:], air.api.i32)
@@ -404,6 +405,16 @@ def cast(x, dtype):
       half of all inputs, so compare with a tolerance.
     * **Narrowing between integer types is refused**, not supported-with-caveats.
       See ``_conversion_op`` below for the measurement.
+
+    ``signed=False`` widens an integer by zero-filling (``arith.extui``) rather
+    than by replicating the top bit (``arith.extsi``). It applies only to an
+    integer widening, and it is not a property of the source type: MLIR's arith
+    ops take *signless* integers, so a byte is eight bits until something widens
+    it and has to decide what the top one meant. A byte holding 0xB4 widens to
+    -76 signed and to 180 unsigned, and nothing about the buffer says which was
+    intended -- the two examples that pack data into bytes want the second, and
+    every other caller wants the first, which is why it is a per-cast argument
+    with a signed default rather than a second set of element types.
     """
     from .types import DType
 
@@ -459,13 +470,104 @@ def cast(x, dtype):
     require_signless(dtype, "air.api.ops.cast")
     if not _clamped_into(expr, dtype):
         # raises here, at the call site, not at emit
-        _conversion_op(source, dtype)
-    return BufferExpr("cast", args=(expr,), dtype=dtype)
+        _conversion_op(source, dtype, signed=signed)
+    elif not signed:
+        # _clamped_into proved a *narrowing* safe, and unsigned has no meaning
+        # there: trunci keeps the low bits whatever the top one meant.
+        _conversion_op(source, dtype, signed=signed)
+    return BufferExpr("cast", args=(expr,), dtype=dtype, signed=signed)
+
+
+def bitcast(x, dtype):
+    """Reinterpret the bits of ``x`` as ``dtype``, changing no bits at all.
+
+        scale  = air.api.ops.bitcast(bits[:], air.api.bf16)     # same width
+        nibble = air.api.ops.bitcast(q[b : b + 32], air.api.i4)  # 32 -> 64 lanes
+
+    The sibling of :func:`cast`, and the distinction is the whole of it: ``cast``
+    preserves the *value* and changes the representation -- 5 becomes 5.0 --
+    while ``bitcast`` preserves the representation and lets the value fall where
+    it may. Reach for it when a buffer's element type is a container rather than
+    a meaning: bytes holding a packed float, or holding two quantised weights.
+
+    Two forms, told apart by the widths.
+
+    **Same width** is a relabelling: ``i16`` bits read as ``bf16``. It applies to
+    any expression, because nothing about the shape moves -- an AWQ scale
+    arrives as two bytes, is assembled with a shift and an or, and is a bf16
+    only once it is bitcast. This lowers to ``arith.bitcast``, or to
+    ``vector.bitcast`` where the surrounding expression is vectorised.
+
+    **Different width** re-counts the lanes: 32 bytes are 64 half-bytes. That
+    changes how many elements a fixed run of memory holds, so it is allowed only
+    directly on a buffer region -- ``q[b : b + 32]``, not on something computed.
+    That is not a limitation so much as what the operation means: it
+    reinterprets *memory*, and a computed value has no memory to reinterpret.
+    The narrower type is a container's contents, so it must divide the wider one
+    exactly.
+
+    The i4 case is the reason this exists, and it has to be spelled exactly this
+    way. ``mlir-aie``'s ``LowerExtUIOfBitcastI4ToUnpackPattern`` matches a
+    ``vector.bitcast`` from ``vector<Nxi8>`` to ``vector<2Nxi4>`` feeding an
+    ``arith.extui`` to ``vector<2Nxi8>``, with 2N of 64 or 128, and rewrites the
+    pair into ``aievec.unpack`` -- one hardware instruction. Unpacking by hand
+    with a mask and a shift computes the same numbers and misses it entirely, so
+    the shape of this op is not a matter of taste.
+    """
+    from .types import DType
+
+    if not isinstance(dtype, DType):
+        raise TypeError(
+            f"air.api.ops.bitcast needs an air.api element type as its second "
+            f"argument (air.api.i4, air.api.bf16, ...), got {dtype!r}"
+        )
+    expr = BufferExpr.coerce(x)
+    source = expr.element_dtype()
+    if source is None:
+        raise TypeError(
+            "air.api.ops.bitcast needs an expression with an element type to "
+            f"reinterpret; {x!r} has none. A bare scalar is already built in "
+            "whatever type surrounds it"
+        )
+    if source is dtype:
+        return expr
+    require_signless(source, "air.api.ops.bitcast")
+    require_signless(dtype, "air.api.ops.bitcast")
+
+    if source.bits == dtype.bits:
+        return BufferExpr("bitcast", args=(expr,), dtype=dtype)
+
+    # Width-changing. The lane count moves, so this has to happen at the read.
+    if expr.kind != "buffer":
+        raise TypeError(
+            f"air.api.ops.bitcast from {source} to {dtype} changes how many "
+            f"elements a run of memory holds ({source.bits} bits each becoming "
+            f"{dtype.bits}), so it reinterprets memory rather than a value and "
+            f"has to be applied to a buffer region directly -- q[b : b + 32] -- "
+            f"not to something computed from one. A same-width bitcast has no "
+            f"such restriction"
+        )
+    wide, narrow = max(source.bits, dtype.bits), min(source.bits, dtype.bits)
+    if wide % narrow:
+        raise ValueError(
+            f"air.api.ops.bitcast from {source} to {dtype} does not divide "
+            f"evenly ({wide} bits is not a whole number of {narrow}), so a run "
+            f"of one type is not a whole number of the other"
+        )
+    if dtype.bits > source.bits:
+        raise NotImplementedError(
+            f"air.api.ops.bitcast from {source} to the wider {dtype} would "
+            f"*pack* elements together rather than unpack them. Only widening "
+            f"the container -- reading bytes as the smaller things inside them "
+            f"-- has a consumer in this tree, and packing has different "
+            f"alignment rules that nothing has needed yet"
+        )
+    return BufferExpr("bitcast", args=(expr,), dtype=dtype)
 
 
 def _int_range(dtype):
     """The inclusive [lo, hi] a signed integer dtype can represent."""
-    bits = dtype.itemsize * 8
+    bits = dtype.bits
     return -(2 ** (bits - 1)), 2 ** (bits - 1) - 1
 
 
@@ -517,7 +619,7 @@ def _clamped_into(expr, target):
     return lo >= t_lo and hi <= t_hi and lo <= hi
 
 
-def _conversion_op(source, target, narrowing_ok=False):
+def _conversion_op(source, target, narrowing_ok=False, signed=True):
     """The arith op converting ``source`` to ``target``, or a refusal.
 
     Shared by ``cast`` (so a bad pair is rejected where the user wrote it) and
@@ -525,8 +627,27 @@ def _conversion_op(source, target, narrowing_ok=False):
 
     ``narrowing_ok`` is set only for the int -> int narrowing that
     ``_clamped_into`` has proven safe; see the comment on the refusal below.
+
+    ``signed`` selects extsi or extui for an integer widening. It is refused
+    anywhere else rather than ignored: silently accepting ``signed=False`` on a
+    float conversion would read as a promise the op does not keep.
     """
     from air.dialects import arith
+
+    if not signed and (source.is_float or target.is_float):
+        raise TypeError(
+            f"air.api.ops.cast(signed=False) applies to an integer widening, "
+            f"but this converts {source} to {target}. Signedness is what "
+            f"distinguishes arith.extsi from arith.extui; a conversion "
+            f"involving a float type has no such pair"
+        )
+    if not signed and target.bits <= source.bits:
+        raise TypeError(
+            f"air.api.ops.cast(signed=False) applies to a widening, but "
+            f"{target} is no wider than {source}. Narrowing keeps the low bits "
+            f"whatever the top one meant, so there is nothing for signedness "
+            f"to select"
+        )
 
     if source.is_float and target.is_float:
         if target.itemsize > source.itemsize:
@@ -545,8 +666,8 @@ def _conversion_op(source, target, narrowing_ok=False):
         return arith.FPToSIOp
     if target.is_float:
         return arith.SIToFPOp
-    if target.itemsize > source.itemsize:
-        return arith.ExtSIOp
+    if target.bits > source.bits:
+        return arith.ExtSIOp if signed else arith.ExtUIOp
     # Narrowing int -> int. Refused on evidence rather than on principle:
     # measured on npu1, arith.trunci wraps on the scalar path (matching both
     # MLIR's own semantics and numpy) and *saturates* on the vector path --

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -60,6 +60,7 @@ __all__ = [
     "reduce_add",
     "reduce_max",
     "argmax",
+    "switch",
     "relu",
     "tanh",
     "exp",
@@ -845,6 +846,104 @@ def reduce_max(x):
     side.
     """
     return _reduce("reduce_max", "max", x)
+
+
+def switch(index, values):
+    """Pick one of ``values`` by a runtime ``index``.
+
+        addend = air.api.ops.switch(step, [1.0, 10.0])
+        acc[:] = acc[:] + addend
+
+    An **expression**, not a statement: it yields the chosen value, the way a
+    Rust ``match`` or a C# switch expression does, and not the way C's statement
+    does. The N-way *statement* -- run one of N bodies for their effects -- is
+    nested ``ops.branch``, which is why this name is not taken by it.
+
+    Against its neighbours: ``ops.switch`` keys on an integer, ``ops.select``
+    keys on a per-element mask, and ``ops.branch`` keys on a single condition
+    and runs statements. Both arms of a select are evaluated and one is kept;
+    here exactly one case runs, because it lowers to ``scf.index_switch`` in its
+    value-returning form.
+
+    The index is a coordinate or a loop variable, and the values are compile-time
+    scalars: the case bodies are constants, so there is nothing to evaluate in
+    the arm that does not run. An out-of-range index selects the last value,
+    which is ``scf.index_switch``'s ``default`` and matches numpy's ``mode`` of
+    ``clip`` only at the top end -- so keep the index in range.
+
+    Emitted where it is written, not inside whatever elementwise loop consumes
+    it: it does not depend on the loop's induction variables, and hoisting it is
+    what the hand-written kernels do.
+    """
+    from ._cond import Condition
+    from ._index import coerce_index
+    from ._value import Buffer, BufferExpr, BufferSlice
+
+    # Name the neighbour rather than complaining about a type. The three are
+    # told apart by what they key on, and handing one the other's key is the
+    # likely mistake.
+    if isinstance(index, Condition):
+        raise TypeError(
+            "air.api.ops.switch keys on an integer, but this is a condition. "
+            "To pick a value with a condition use ops.select(cond, a, b); to "
+            "run statements under one use `with ops.branch(cond):`"
+        )
+    if isinstance(index, (Buffer, BufferExpr, BufferSlice)):
+        raise TypeError(
+            "air.api.ops.switch keys on a single integer -- a coordinate or a "
+            "loop variable -- but this is a buffer. A per-element choice is "
+            "ops.select(mask, a, b)"
+        )
+    if not values:
+        raise ValueError("air.api.ops.switch needs at least one value to pick from")
+    if len(values) == 1:
+        raise ValueError(
+            "air.api.ops.switch was given one value, so there is nothing to "
+            "choose: use the value itself"
+        )
+    for v in values:
+        if not isinstance(v, (int, float)) or isinstance(v, bool):
+            raise TypeError(
+                f"air.api.ops.switch takes compile-time scalars to pick from, "
+                f"got {type(v).__name__}. Choosing between *buffers* would run "
+                "one of two loop nests, which is ops.branch"
+            )
+    return _Switch(coerce_index(index), [float(v) for v in values])
+
+
+class _Switch:
+    """A pending ops.switch; the dtype comes from the buffer it is used with."""
+
+    __slots__ = ("index", "values")
+
+    def __init__(self, index, values):
+        self.index = index
+        self.values = values
+
+    def materialize(self, dtype):
+        from air.dialects import arith
+        from air.dialects.scf import index_switch, yield_
+
+        index = self.index.materialize()
+        if isinstance(index, int):
+            # A constant index needs no switch at all, and folding it leaves the
+            # same IR as writing the value out by hand.
+            picked = self.values[min(index, len(self.values) - 1)]
+            return arith.ConstantOp(dtype.mlir(), picked).result
+
+        values = self.values
+        result = index_switch(
+            [dtype.mlir()],
+            index,
+            list(range(len(values) - 1)),
+            case_body_builder=lambda op, i, cv: yield_(
+                [arith.ConstantOp(dtype.mlir(), values[i]).result]
+            ),
+            default_body_builder=lambda op: yield_(
+                [arith.ConstantOp(dtype.mlir(), values[-1]).result]
+            ),
+        )
+        return result[0] if isinstance(result, (list, tuple)) else result
 
 
 def argmax(x):

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -14,7 +14,6 @@ runner can never disagree about how a numpy dtype maps onto the device.
 
 import numpy as np
 from ml_dtypes import bfloat16
-from ml_dtypes import int4 as ml_int4
 
 __all__ = [
     "DType",
@@ -120,6 +119,16 @@ class DType:
 
     @property
     def itemsize(self):
+        if self.np_dtype is None:
+            # A sub-byte type has no honest answer: numpy would store an i4 in a
+            # whole byte and report 1, which is the number that made i4 -> i8
+            # look like a same-size conversion in the first place. Callers that
+            # mean "how wide" want `bits`; the ones that mean "how much memory"
+            # only ever see allocatable types.
+            raise TypeError(
+                f"{self} has no byte size: it is {self.bits} bits and no buffer "
+                f"can hold one. Use .bits for the width"
+            )
         return np.dtype(self.np_dtype).itemsize
 
     def mlir(self):
@@ -158,7 +167,13 @@ f32 = DType("f32", np.float32, 16, is_float=True)
 # quantised weights inside them. numpy has no sub-byte storage, so ml_dtypes'
 # int4 stands in for the data type while `bits=4` carries the width that
 # actually matters.
-i4 = DType("i4", ml_int4, 64, is_float=False, bits=4, allocatable=False)
+# `np_dtype=None`: there is deliberately no numpy type behind this one. numpy
+# has no sub-byte storage, and ml_dtypes' int4 -- the obvious stand-in -- would
+# make importing air.api fail on any older ml_dtypes that predates it, for a
+# type most kernels never name. Nothing needs it: `mlir()` builds the MLIR type
+# from `bits`, `type_mapper` is never reached, and `itemsize` is only ever asked
+# of a type a buffer can hold.
+i4 = DType("i4", None, 64, is_float=False, bits=4, allocatable=False)
 i8 = DType("i8", np.int8, 32, is_float=False)
 i16 = DType("i16", np.int16, 16, is_float=False)
 i32 = DType("i32", np.int32, 16, is_float=False)

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -14,12 +14,14 @@ runner can never disagree about how a numpy dtype maps onto the device.
 
 import numpy as np
 from ml_dtypes import bfloat16
+from ml_dtypes import int4 as ml_int4
 
 __all__ = [
     "DType",
     "bf16",
     "f16",
     "f32",
+    "i4",
     "i8",
     "i16",
     "i32",
@@ -80,6 +82,8 @@ class DType:
         is_float,
         is_unsigned=False,
         computes=True,
+        bits=None,
+        allocatable=True,
     ):
         self.name = name
         self.np_dtype = np_dtype
@@ -101,6 +105,18 @@ class DType:
         # shape of restriction as `is_unsigned` above, enforced at the same four
         # call sites -- see `require_computable`.
         self.computes = computes
+        # Width in bits. Everything but i4 is a whole number of bytes and takes
+        # it from numpy; i4 cannot, because numpy has no sub-byte storage and
+        # reports an itemsize of 1 for it. Widening and narrowing are decided on
+        # `bits`, not on `itemsize`, so that i4 -> i8 reads as the widening it
+        # is rather than as a same-size conversion with no op.
+        self.bits = bits if bits is not None else np.dtype(np_dtype).itemsize * 8
+        # False for a type a buffer cannot hold. i4 is the only one: a DMA moves
+        # whole bytes, the L1 budget is in bytes, and nothing in this tree wants
+        # a nibble-addressed memref. It exists to name the *result* of
+        # ops.bitcast -- half-bytes read out of a byte buffer -- and lives only
+        # inside one expression.
+        self.allocatable = allocatable
 
     @property
     def itemsize(self):
@@ -112,6 +128,14 @@ class DType:
         # air.api must stay cheap for callers that only want the type objects.
         from air.backend.xrt_runner import type_mapper
 
+        if self.bits % 8:
+            # type_mapper is keyed on numpy dtypes and cross-checks the MLIR
+            # width against numpy's itemsize, which a sub-byte type fails by
+            # construction: numpy stores an int4 in a whole byte. Build it
+            # directly.
+            from air.ir import IntegerType
+
+            return IntegerType.get_signless(self.bits)
         return type_mapper(self.np_dtype)
 
     def __repr__(self):
@@ -128,6 +152,13 @@ bf16 = DType("bf16", bfloat16, 16, is_float=True)
 # the type can still describe f16 *data* being moved, which does work.
 f16 = DType("f16", np.float16, 16, is_float=True, computes=False)
 f32 = DType("f32", np.float32, 16, is_float=True)
+# Half a byte. Not a type a buffer can hold -- a DMA moves whole bytes and the
+# L1 budget is counted in them -- but the type a *packed* buffer's contents are,
+# and so the type `ops.bitcast` names when it reinterprets bytes as the pairs of
+# quantised weights inside them. numpy has no sub-byte storage, so ml_dtypes'
+# int4 stands in for the data type while `bits=4` carries the width that
+# actually matters.
+i4 = DType("i4", ml_int4, 64, is_float=False, bits=4, allocatable=False)
 i8 = DType("i8", np.int8, 32, is_float=False)
 i16 = DType("i16", np.int16, 16, is_float=False)
 i32 = DType("i32", np.int32, 16, is_float=False)

--- a/python/test/api/bitcast.py
+++ b/python/test/api/bitcast.py
@@ -180,3 +180,54 @@ def the_refusals_say_what_the_operation_means():
                     ops.store(o, O)
 
     launch.mlir()
+
+
+# CHECK-LABEL: TEST: a_repack_is_refused_when_the_nest_makes_more_than_one_trip
+# The reinterpreted operand is indexed from its region's start alone -- there is
+# no induction variable in the right units to advance it -- so more than one
+# trip would read the same run of memory every time and quietly produce the
+# first vector's worth of output everywhere.
+#
+# The guard has to count *every* axis. Checking only the innermost let a
+# [4, 64] destination through at a width of 64: its innermost extent is exactly
+# one vector, and it is still four trips.
+# CHECK: two-dimensional destination: NotImplementedError: {{.*}}4 trips
+@run
+def a_repack_is_refused_when_the_nest_makes_more_than_one_trip():
+    P = air.tensor([128], i8)
+    O = air.tensor([4, 64], i8)
+
+    with air.launch(name="trips") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    p = air.alloc([128], i8, scope=h.private())
+                    o = air.alloc([4, 64], i8, scope=h.private(), vector=64)
+                    ops.load(p, P)
+                    expect(
+                        "two-dimensional destination",
+                        lambda: o.__setitem__(
+                            slice(None),
+                            ops.cast(ops.bitcast(p[0:32], i4), i8, signed=False),
+                        ),
+                    )
+                    ops.store(o, O)
+
+    launch.mlir()
+
+
+# CHECK-LABEL: TEST: i4_carries_no_numpy_dtype
+# Deliberately: numpy has no sub-byte storage, and ml_dtypes' int4 -- the
+# obvious stand-in -- would make importing air.api fail on any older ml_dtypes
+# that predates it, for a type most kernels never name. Nothing needs it, and
+# asking for a byte size says so rather than answering 1.
+# CHECK: np_dtype None bits 4
+# CHECK: itemsize: TypeError: {{.*}}no byte size
+@run
+def i4_carries_no_numpy_dtype():
+    print("np_dtype", i4.np_dtype, "bits", i4.bits)
+    expect("itemsize", lambda: i4.itemsize)

--- a/python/test/api/bitcast.py
+++ b/python/test/api/bitcast.py
@@ -1,0 +1,182 @@
+# ./python/test/api/bitcast.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api reinterprets bits with ops.bitcast, and widens without a sign.
+
+``cast`` preserves the value and changes the representation; ``bitcast``
+preserves the representation and lets the value fall where it may. The pair
+exists because a buffer's element type is sometimes a container rather than a
+meaning -- bytes holding a packed float, or holding two quantised weights.
+
+What these pin is mostly the int4 unpack, because its shape is not a matter of
+taste: mlir-aie's LowerExtUIOfBitcastI4ToUnpackPattern rewrites exactly
+`extui(vector.bitcast(<Nxi8> -> <2Nxi4>))` into one `aievec.unpack`, and any
+other spelling computes the same numbers while missing the instruction.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16, i4, i8, i16, i32
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+# CHECK-LABEL: TEST: int4_unpack_emits_the_sequence_aievec_matches
+# 32 bytes are 64 half-bytes: the read is at the operand's own lane count, the
+# bitcast re-counts them, and the extui widens each nibble into a byte. The
+# extui must be *unsigned* -- these are quantised magnitudes 0..15, and extsi
+# would read 0x9 as -7.
+# CHECK: vector.transfer_read %{{.*}} : memref<256xi8, 2 : i32>, vector<32xi8>
+# CHECK-NEXT: vector.bitcast %{{.*}} : vector<32xi8> to vector<64xi4>
+# CHECK-NEXT: arith.extui %{{.*}} : vector<64xi4> to vector<64xi8>
+@run
+def int4_unpack_emits_the_sequence_aievec_matches():
+    P = air.tensor([256], i8)
+    O = air.tensor([512], i8)
+
+    with air.launch(name="unpack") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    p = air.alloc([256], i8, scope=h.private())
+                    o = air.alloc([512], i8, scope=h.private(), vector=64)
+                    ops.load(p, P)
+                    for i in air.sequential(0, 8):
+                        o[i * 64 : i * 64 + 64] = ops.cast(
+                            ops.bitcast(p[i * 32 : i * 32 + 32], i4), i8, signed=False
+                        )
+                    ops.store(o, O)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: a_same_width_bitcast_is_a_relabelling
+# i16 bits read as bf16. Nothing about the shape moves, so unlike the unpack it
+# applies to a computed value -- which is the point: an AWQ scale is assembled
+# from two bytes with a shift and an or, and is a bf16 only once reinterpreted.
+# CHECK: arith.shli
+# CHECK: arith.ori
+# CHECK: vector.bitcast %{{.*}} : vector<16xi16> to vector<16xbf16>
+@run
+def a_same_width_bitcast_is_a_relabelling():
+    LO = air.tensor([64], i8)
+    HI = air.tensor([64], i8)
+    O = air.tensor([64], bf16)
+
+    with air.launch(name="relabel") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    lo = air.alloc([64], i8, scope=h.private())
+                    hi = air.alloc([64], i8, scope=h.private())
+                    o = air.alloc([64], bf16, scope=h.private(), vector=16)
+                    ops.load(lo, LO)
+                    ops.load(hi, HI)
+                    bits = ops.cast(lo[:], i16, signed=False) | (
+                        ops.cast(hi[:], i16, signed=False) << 8
+                    )
+                    o[:] = ops.bitcast(bits, bf16)
+                    ops.store(o, O)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: signed_is_the_default_and_unsigned_is_asked_for
+# The same widening, twice. Signedness belongs to the operation and not to the
+# type -- MLIR's arith ops take signless integers, so a byte is eight bits until
+# something widens it and has to decide what the top one meant.
+# CHECK: arith.extsi %{{.*}} : vector<16xi8> to vector<16xi32>
+# CHECK: arith.extui %{{.*}} : vector<16xi8> to vector<16xi32>
+@run
+def signed_is_the_default_and_unsigned_is_asked_for():
+    A = air.tensor([64], i8)
+    S = air.tensor([64], i32)
+    U = air.tensor([64], i32)
+
+    with air.launch(name="widen") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], i8, scope=h.private())
+                    s = air.alloc([64], i32, scope=h.private(), vector=16)
+                    u = air.alloc([64], i32, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    s[:] = ops.cast(a[:], i32)
+                    u[:] = ops.cast(a[:], i32, signed=False)
+                    ops.store(s, S)
+                    ops.store(u, U)
+
+    print(launch.mlir())
+
+
+def expect(what, fn):
+    try:
+        fn()
+    except Exception as e:
+        print(f"{what}: {type(e).__name__}: {e}")
+        return
+    raise AssertionError(f"{what}: expected a diagnostic, got none")
+
+
+# CHECK-LABEL: TEST: the_refusals_say_what_the_operation_means
+# Each of these is a place where accepting the call would compile and compute
+# something other than what was written, so each names the property that makes
+# it wrong rather than reporting a type.
+# CHECK: no i4 buffer: TypeError: {{.*}}whole bytes
+# CHECK: repack of a computed value: TypeError: {{.*}}reinterprets memory rather than a value
+# CHECK: unsigned float: TypeError: {{.*}}integer widening
+# CHECK: unsigned narrowing: TypeError: {{.*}}no wider than
+@run
+def the_refusals_say_what_the_operation_means():
+    expect("no i4 buffer", lambda: air.tensor([64], i4))
+
+    A = air.tensor([64], i8)
+    O = air.tensor([64], i8)
+
+    with air.launch(name="refuse") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], i8, scope=h.private(), vector=16)
+                    o = air.alloc([64], i8, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    expect(
+                        "repack of a computed value",
+                        lambda: ops.bitcast(a[:] + 1, i4),
+                    )
+                    expect(
+                        "unsigned float",
+                        lambda: ops.cast(a[:], bf16, signed=False),
+                    )
+                    expect(
+                        "unsigned narrowing",
+                        lambda: ops.cast(ops.cast(a[:], i32), i16, signed=False),
+                    )
+                    o[:] = a[:]
+                    ops.store(o, O)
+
+    launch.mlir()

--- a/python/test/api/switch.py
+++ b/python/test/api/switch.py
@@ -1,0 +1,137 @@
+# ./python/test/api/switch.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""air.api lowers ops.switch to scf.index_switch in its value-returning form.
+
+``ops.switch`` is the DSL's only N-way construct, and it is an expression: it
+yields the chosen value. The N-way *statement* -- run one of N bodies for their
+effects -- is nested ``ops.branch``, so what these pin is mostly the boundary
+between the three constructs that all look like a choice: switch keys on an
+integer, select keys on a per-element mask, branch keys on a condition and runs
+statements.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16
+
+
+def run(f):
+    print("\nTEST:", f.__name__)
+    f()
+    return f
+
+
+def build(pick, n=64, vector=16):
+    """A herd body whose accumulate adds a value chosen by ``pick(step)``."""
+    A = air.tensor([n], bf16)
+    OUT = air.tensor([n], bf16)
+
+    with air.launch(name="sw") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([n], bf16, scope=h.private(), vector=vector)
+                    ops.load(a, A)
+                    for step in air.sequential(0, 2):
+                        a[:] = a[:] + pick(step)
+                    ops.store(a, OUT)
+
+    return launch.mlir()
+
+
+# CHECK-LABEL: TEST: switch_lowers_to_a_value_returning_index_switch
+# One switch per assignment, hoisted above the elementwise loop it feeds: the
+# choice does not depend on that loop's induction variable, so evaluating it per
+# element would be N constants and N-1 dead arms per trip.
+# CHECK: scf.index_switch %{{.*}} -> bf16
+# CHECK: case 0
+# CHECK: arith.constant 1.0
+# CHECK: scf.yield
+# CHECK: default
+# CHECK: arith.constant 1.0{{0*}}e+01
+# CHECK: scf.yield
+# CHECK: scf.for
+# CHECK: arith.addf
+@run
+def switch_lowers_to_a_value_returning_index_switch():
+    print(build(lambda step: ops.switch(step, [1.0, 10.0])))
+
+
+# CHECK-LABEL: TEST: a_constant_index_emits_no_switch
+# `ops.switch(0, ...)` is a constant fold, not a one-armed switch: the same IR
+# as writing the value out by hand. A Python `for` unrolls at trace time, so its
+# counter is a constant and this is the path an unrolled loop takes.
+# CHECK-NOT: scf.index_switch
+# CHECK: arith.constant 1.0{{0*}}e+01
+@run
+def a_constant_index_emits_no_switch():
+    A = air.tensor([64], bf16)
+    OUT = air.tensor([64], bf16)
+
+    with air.launch(name="swc") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], bf16, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    for step in range(1, 2):
+                        a[:] = a[:] + ops.switch(step, [1.0, 10.0])
+                    ops.store(a, OUT)
+
+    print(launch.mlir())
+
+
+def expect(what, build_fn):
+    try:
+        build_fn()
+    except Exception as e:
+        print(f"{what}: {type(e).__name__}: {e}")
+        return
+    raise AssertionError(f"{what}: expected a diagnostic, got none")
+
+
+# CHECK-LABEL: TEST: the_three_choices_name_each_other
+# Switch, select and branch are told apart by what they key on, and handing one
+# the other's key is the likely mistake -- so each error names the neighbour it
+# was probably meant to be, rather than complaining about a type.
+# CHECK: a condition: TypeError: {{.*}}ops.select(cond, a, b)
+# CHECK: a buffer: TypeError: {{.*}}ops.select(mask, a, b)
+# CHECK: buffers to pick from: TypeError: {{.*}}ops.branch
+# CHECK: one value: ValueError: {{.*}}nothing to choose
+@run
+def the_three_choices_name_each_other():
+    A = air.tensor([64], bf16)
+    A_out = air.tensor([64], bf16)
+
+    with air.launch(name="swe") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], bf16, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    expect("a condition", lambda: ops.switch(tx == 0, [1.0, 2.0]))
+                    expect("a buffer", lambda: ops.switch(a, [1.0, 2.0]))
+                    expect("buffers to pick from", lambda: ops.switch(tx, [a, a]))
+                    expect("one value", lambda: ops.switch(tx, [1.0]))
+                    ops.store(a, A_out)
+
+    # The body runs when the module is built, which is where the diagnostics
+    # above are raised; the module itself is not what this test pins.
+    launch.mlir()

--- a/python/test/api/switch.py
+++ b/python/test/api/switch.py
@@ -135,3 +135,71 @@ def the_three_choices_name_each_other():
     # The body runs when the module is built, which is where the diagnostics
     # above are raised; the module itself is not what this test pins.
     launch.mlir()
+
+
+# CHECK-LABEL: TEST: switch_builds_its_constants_in_the_destinations_type
+# The values are kept exactly as written until the destination is known, because
+# which type to build them in is the destination's and a switch is written
+# before that. Coercing at construction -- everything to float, as this did
+# first -- reached arith.ConstantOp with a Python float for an integer type and
+# failed inside FloatAttr with "expected floating point type", naming neither
+# the switch nor the value.
+# CHECK: scf.index_switch %{{.*}} -> i32
+# CHECK: arith.constant 1 : i32
+# CHECK: arith.constant 10 : i32
+@run
+def switch_builds_its_constants_in_the_destinations_type():
+    from air.api.types import i32
+
+    A = air.tensor([64], i32)
+    OUT = air.tensor([64], i32)
+
+    with air.launch(name="swi") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], i32, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    for step in air.sequential(0, 2):
+                        a[:] = a[:] + ops.switch(step, [1, 10])
+                    ops.store(a, OUT)
+
+    print(launch.mlir())
+
+
+# CHECK-LABEL: TEST: a_fractional_value_in_an_integer_switch_is_refused
+# A whole-number float is a harmless way to write an integer and the elementwise
+# emitter accepts one; anything else would be truncated, so it is refused rather
+# than rounded.
+# CHECK: fractional: ValueError: {{.*}}not an integer
+@run
+def a_fractional_value_in_an_integer_switch_is_refused():
+    from air.api.types import i32
+
+    A = air.tensor([64], i32)
+    OUT = air.tensor([64], i32)
+
+    with air.launch(name="swf") as launch:
+
+        @launch.body
+        def _():
+            with air.herd(range(1), shape=(1,)) as h:
+
+                @h.body
+                def _(tx):
+                    a = air.alloc([64], i32, scope=h.private(), vector=16)
+                    ops.load(a, A)
+                    for step in air.sequential(0, 2):
+                        expect(
+                            "fractional",
+                            lambda: a.__setitem__(
+                                slice(None), a[:] + ops.switch(step, [1, 10.5])
+                            ),
+                        )
+                    ops.store(a, OUT)
+
+    launch.mlir()


### PR DESCRIPTION
Four commits, two examples, and three pieces of DSL surface — each landing with
its consumer. (This was stacked on #1938; that has merged and this is rebased
onto main, so the diff is only the four commits below.)

Both examples were on my blocked list. Neither was actually blocked, and the
reasons I thought they were are worth naming, because each was an inference from
reading rather than a probe that failed.

## `shared_l1_single_herd`

A column of four cores handing data down through L1 buffers that neighbouring
cores both address — no DMA and no hardware cascade between them.

* **The hop buffers are `<segment>.per_core()`.** I had read that scope's
  docstring — every core gets its own whole copy, no core can see another's —
  as ruling the hand-off out. That sentence describes the *allocation*. What it
  emits is exactly the predecessor's IR: a segment-scope L1 alloc handed to the
  herd whole, and what the cores may then do with it is the compiler's business.
* **The role dispatch needs no statement-form `index_switch`.** The DSL's
  position is that the N-way statement is nested `ops.branch`; this is that
  spelling.

`ops.switch` — the *value* half of `scf.index_switch`, which had no spelling —
lands here as its consumer. It was written earlier and parked unlanded for want
of one, and arrives with the test file it never had.

## `dequant_awq`

AWQ int4 → bf16, both codegen paths: the default call into `dequant.o`, and
`--direct-codegen`, whose body is now written in the DSL. This one *was* blocked,
on exactly one thing — no way to say "read these 32 bytes as 64 half-bytes":

```python
ops.cast(ops.bitcast(packed[b : b + R // 2], i4), i8, signed=False)
```

Both halves have to be spelled exactly so. mlir-aie's
`LowerExtUIOfBitcastI4ToUnpackPattern` matches `extui(vector.bitcast(<Nxi8> ->
<2Nxi4>))` with 2N of 64 or 128 and rewrites the pair into one `aievec.unpack`.
Masking and shifting by hand computes the same numbers and misses the
instruction — a rewrite of the example rather than a port of it.

### The surface it needed

* **`ops.bitcast`**, the sibling of `ops.cast`: cast preserves the value and
  changes the representation, bitcast preserves the representation and lets the
  value fall where it may. Same width is a relabelling and applies to any
  expression; different width re-counts the lanes and is allowed only directly
  on a buffer region, because it reinterprets *memory* and a computed value has
  none. That restriction is also what keeps the lane-count change at the read,
  so everything above the bitcast still runs at one lane count.
* **`i4`**, the type that change needs to name its result. Not allocatable, and
  `air.tensor`/`air.alloc` say so: a DMA moves whole bytes. `DType` now carries
  `bits` separately from `itemsize`, because numpy has no sub-byte storage and
  i4 → i8 would otherwise read as a same-size conversion with no op.
* **`ops.cast(..., signed=False)`**, selecting `arith.extui`. This was a live
  bug independent of dequant: widening a byte always sign-extended, so anything
  ≥ 0x80 came out negative — wrong anywhere bytes are packed data rather than
  small numbers. Signedness belongs to the operation, not the type, because
  arith takes signless integers.

## Gating

`shared_l1_single_herd`: `air.insts.bin` byte-identical, same-input control run,
`PASS!` both arms on npu1. Canonicalized op counts match exactly but for the
role dispatch becoming three `scf.if`, no `memref.subview`, and six more
`memref.dealloc`. Its chunk width is pinned with `vector=VEC` rather than left
to the emitter, because a producer's write to a shared buffer and the consumer's
read of it must carry matching per-chunk lock counts.

`dequant_awq`, extern path — fully gated: npu1 hardware PASS both arms,
`air.insts.bin` byte-identical, and compiled for npu2 the **per-core ELF is
byte-identical** too: the same code, not merely equivalent code.

`dequant_awq`, `--direct-codegen` — **cannot be run on the box this was
developed on**, and this is the one limitation worth reading. Its two lits are
`ryzen_ai_npu2` and that box is Phoenix; `aievec.unpack` has no npu1 lowering,
which is probed rather than assumed — it fails to legalize. What is checked is
that it compiles for npu2 with `air.insts.bin` byte-identical, that its per-core
op counts match the predecessor's except for the two departures its docstring
documents, and that it reaches the identical intrinsic: compiling it for npu1
fails on exactly `aievec.unpack (vector<32xi8>) -> vector<64xi8>`, the same op
and shape the predecessor fails on, which makes the npu1 legalization error a
free oracle for having hit the right instruction. **Its numerics are gated by
CI, on `amdhx370`, and not locally.**

Worth stating plainly since it shaped the gate: `air.insts.bin` is *blind* to
this example's compute — all four npu2 configs hash the same, direct-codegen and
extern alike — which is why the core ELF is the instrument here.

A print-module A/B over every converted example in the tree — 92 files — is
byte-identical but for the two converted here. All three additions add paths and
alter none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
