### PR TITLE
[flash_attention] Keep the causal triangle at 8 q-rounds, not 6

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -313,14 +313,29 @@ def build_module(
     _merge_out_into_kv = num_lq_iters > 4
     # The causal triangle gives every round its own DIFFERENT-sized K/V shim
     # transfer, so the round count IS the number of simultaneously in-flight
-    # tasks on that MM2S channel. Measured on NPU2: up to 6 rounds run, 7 and
-    # 8 deadlock. Past the limit, stream the FULL prefix every round instead --
-    # the per-round BDs become identical, AIR folds them into ONE repeated
-    # task, and the in-core causal mask (q_block = lx*NQ + s) still discards
-    # the extra K blocks, so the result is unchanged. The price is the causal
-    # DMA/compute saving (2x the K/V work at large round counts), which is
-    # what buys the design the ability to run at all past 6 rounds.
-    _MAX_ROUNDS_IN_FLIGHT = 6
+    # tasks on that MM2S channel. Past the limit, stream the FULL prefix every
+    # round instead -- the per-round BDs become identical, AIR folds them into
+    # ONE repeated task, and the in-core causal mask (q_block = lx*NQ + s) still
+    # discards the extra K blocks, so the result is unchanged. The price is the
+    # causal DMA/compute saving (2x the K/V work at large round counts), which
+    # is what buys the design the ability to run at all past the limit.
+    #
+    # The limit was 6 when this design landed (7 and 8 deadlocked). 8 runs now
+    # that the shim-BD rebalance is in -- which is in turn a hard prerequisite
+    # for these lengths compiling at all -- and 8 rounds is what a 4096 prefill
+    # needs at lqp=512. Restoring the triangle there is worth 12% of prefill
+    # TTFT on llama-3.2-1B (2251 -> 1981 ms; flash_attn 48.6 -> 31.7 ms/layer),
+    # because attention is the only quadratic term and the uniform fallback was
+    # making a 2x-work cliff appear exactly at the length that crossed 6.
+    #
+    # Raising this further will not help until an R > 8 shape compiles at all:
+    # both R=16 configurations (lq 8192 at lqp 512, and lq 4096 at lqp 256 /
+    # dk 128) fail to build today, uniform prefix included. When one does, the
+    # better shape than another bump is to QUANTIZE the prefix -- group rounds
+    # and have each round stream its group's last prefix, which the mask makes
+    # correct for any group size and which holds the work at (G+1)/2G of the
+    # square (0.56 at G=8) instead of collapsing to 1.0.
+    _MAX_ROUNDS_IN_FLIGHT = 8
     _uniform_cps = num_lq_iters > _MAX_ROUNDS_IN_FLIGHT
     _cps_blocks = lambda lx: (num_lq_iters if _uniform_cps else lx + 1) * NQ
     tile_size_q = lqp // num_q_tiles


### PR DESCRIPTION
## What

Under causal masking this kernel has q-round `lx` stream only its causal prefix of `(lx+1)*NQ` K/V blocks. Each round is then a *different-sized* shim transfer, so the round count is the number of in-flight tasks on that MM2S channel — and past a limit the design gives up and streams the **full** prefix every round. That is still correct (the in-core mask discards the excess) but it is 2× the K/V work.

The limit was 6, measured when this landed in #1773: 7 and 8 rounds deadlocked. **8 runs now** that the shim-BD rebalance (#1937) is in — which is in any case a hard prerequisite for these lengths compiling at all. This raises it to 8.

## Why one constant is worth 10–12% of TTFT

Attention is the only quadratic term in prefill. Below the limit the 2× is absent; above it, the curve takes a step. So the cost is invisible at short lengths and then appears all at once — llama-3.2-1B's prefill throughput was *peaking at 2k and regressing at 4k*:

| | 1k | 2k | 4k |
|:--|--:|--:|--:|
| before | 1969 | 2094 | **1848** tok/s |
| after | 1969 | 2094 | **2068** tok/s |

## Blast radius

Two callers build this kernel at different `lqp`, so the step lands at different lengths:

| caller | lqp | 8 rounds at | models |
|:--|--:|--:|:--|
| `llms/llama32_1b/llama32_1b_prefill.py` | 512 | L=4096 | llama32_1b(`_q4nx`, `_int4`), smollm2_1_7b |
| `llms/shared/infra/fa_temporal.py` | 256 | L=2048 | llama32_3b(`_q4nx`), phi4_mini_q4nx |

Note the second row: this also fires at **2048**, not only at the new 4096 column.

Not affected: `llama31_8b_q4nx` (NB=4, so `supports()` routes it head-first past 4 rounds); gemma3_4b / qwen3_8b / qwen25_7b / lfm2, which never import this kernel; every length ≤ 1024; and 4096 for the `lqp=256` models, which is 16 rounds and still takes the uniform prefix.

## Measured

NPU2 (Ryzen AI 9 HX 370), A/B with the kernel cache purged on **both** sides, every run passing the driver's first-token argmax gate:

| model | length | before | after | | flash_attn / layer |
|:--|--:|--:|--:|--:|--:|
| llama32_1b_q4nx | 4096 | 2251 ms | **1981 ms** | −12.0% | 48.6 → 31.7 ms |
| llama32_3b_q4nx | 2048 | 2666 ms | **2389 ms** | −10.4% | 27.3 → 17.6 ms |
| phi4_mini_q4nx | 2048 | 3059 ms | **2741 ms** | −10.4% | 27.4 → 17.6 ms |

The 4096 point is 4 consecutive runs, 1943–1981 ms.

## Why this is safe below 8 rounds

Only 7- and 8-round shapes change. Generated IR at 2048 for `lqp=512` is **byte-identical** to before — verified by diffing the printed module — so nothing at or below 6 rounds can move, and the 4096 IR is byte-identical to the variant that produced the numbers above.

## Not done

Raising the limit further does not help until an R > 8 shape compiles at all. Both R=16 configurations fail to build today, uniform prefix included: `lq 8192` at `lqp 512` and `lq 4096` at `lqp 256 / dk 128`. When one does, the better move than another bump is to **quantize** the prefix — group rounds and have each round stream its group's last prefix, which the mask makes correct for any group size, and which holds the work at `(G+1)/2G` of the square (0.56 at G=8) instead of collapsing to 1.0. I implemented and IR-tested that version; it is described in the comment rather than shipped, because with no R > 8 shape building there is no way to exercise it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
