### PR TITLE
[CI] Run the prefill sweep on the schedule, and stop it over-requiring weights

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -358,9 +358,10 @@ jobs:
           # NOT applied to it -- so this literal, not the `default:` above, is
           # what the nightly actually runs. The two must be kept in step: when
           # they drifted, the schedule silently dropped a whole suite and still
-          # reported green, because publishing is guarded on `event_name ==
-          # 'schedule'` (true) while the missing results file is skipped by an
-          # `if [ -f ... ]`. Neither check can see a suite that never ran.
+          # reported green, because publishing is guarded on
+          # `github.event_name == 'schedule'` (true) while the results file it
+          # consumes is guarded by an `if [ -f ... ]` (a no-op when absent).
+          # Neither check can see a suite that never ran.
           SUITES="${{ github.event.inputs.suites || 'verify,profile,sweep,prefill-sweep' }}"
           echo "running suites: $SUITES"
           want() { case ",$SUITES," in *",$1,"*) return 0;; *) return 1;; esac; }

--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -354,7 +354,14 @@ jobs:
 
           rc=0
           pushd build_assert
-          SUITES="${{ github.event.inputs.suites || 'verify,profile,sweep' }}"
+          # A scheduled run has no `inputs`, and workflow_dispatch defaults are
+          # NOT applied to it -- so this literal, not the `default:` above, is
+          # what the nightly actually runs. The two must be kept in step: when
+          # they drifted, the schedule silently dropped a whole suite and still
+          # reported green, because publishing is guarded on `event_name ==
+          # 'schedule'` (true) while the missing results file is skipped by an
+          # `if [ -f ... ]`. Neither check can see a suite that never ran.
+          SUITES="${{ github.event.inputs.suites || 'verify,profile,sweep,prefill-sweep' }}"
           echo "running suites: $SUITES"
           want() { case ",$SUITES," in *",$1,"*) return 0;; *) return 1;; esac; }
 

--- a/programming_examples/llms/llama31_8b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama31_8b_q4nx/run_npu2_prefill_sweep.lit
@@ -16,8 +16,12 @@
 // the prefill ELFs, and sweep_prefill.py fails the point rather than reporting
 // a number if the engines came out at some other length.
 //
-// Unlike the decode sweep this needs real weights -- a prefill is a prefill --
-// so it carries the same weight/token requirements as run_npu2_profile.lit.
+// Unlike the decode sweep this needs real weights -- a prefill is a prefill.
+// It needs only the q4nx bundle, though, NOT the base HF checkpoint that
+// run_npu2_profile.lit also requires: this path loads weights solely from
+// *_q4nx_weights, prompts with hardcoded token ids, and builds no tokenizer.
+// Requiring the base checkpoint anyway would silently SKIP the point on a
+// runner that lacks it, and drop the model's row from the published table.
 // Latency only, never a correctness gate (run_npu2_verify.lit is that); the
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.

--- a/programming_examples/llms/llama31_8b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama31_8b_q4nx/run_npu2_prefill_sweep.lit
@@ -22,7 +22,7 @@
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_nousresearch_meta_llama_3_1_8b_instruct, hfweights_fastflowlm_llama_3_1_8b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_llama_3_1_8b_npu2
 //
 // RUN: mkdir -p test_peano_prefill_sweep
 // RUN: cd test_peano_prefill_sweep

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_prefill_sweep.lit
@@ -22,7 +22,7 @@
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_1b_instruct, hfweights_fastflowlm_llama_3_2_1b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_llama_3_2_1b_npu2
 //
 // RUN: mkdir -p test_peano_prefill_sweep
 // RUN: cd test_peano_prefill_sweep

--- a/programming_examples/llms/llama32_1b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama32_1b_q4nx/run_npu2_prefill_sweep.lit
@@ -16,8 +16,12 @@
 // the prefill ELFs, and sweep_prefill.py fails the point rather than reporting
 // a number if the engines came out at some other length.
 //
-// Unlike the decode sweep this needs real weights -- a prefill is a prefill --
-// so it carries the same weight/token requirements as run_npu2_profile.lit.
+// Unlike the decode sweep this needs real weights -- a prefill is a prefill.
+// It needs only the q4nx bundle, though, NOT the base HF checkpoint that
+// run_npu2_profile.lit also requires: this path loads weights solely from
+// *_q4nx_weights, prompts with hardcoded token ids, and builds no tokenizer.
+// Requiring the base checkpoint anyway would silently SKIP the point on a
+// runner that lacks it, and drop the model's row from the published table.
 // Latency only, never a correctness gate (run_npu2_verify.lit is that); the
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_prefill_sweep.lit
@@ -16,8 +16,12 @@
 // the prefill ELFs, and sweep_prefill.py fails the point rather than reporting
 // a number if the engines came out at some other length.
 //
-// Unlike the decode sweep this needs real weights -- a prefill is a prefill --
-// so it carries the same weight/token requirements as run_npu2_profile.lit.
+// Unlike the decode sweep this needs real weights -- a prefill is a prefill.
+// It needs only the q4nx bundle, though, NOT the base HF checkpoint that
+// run_npu2_profile.lit also requires: this path loads weights solely from
+// *_q4nx_weights, prompts with hardcoded token ids, and builds no tokenizer.
+// Requiring the base checkpoint anyway would silently SKIP the point on a
+// runner that lacks it, and drop the model's row from the published table.
 // Latency only, never a correctness gate (run_npu2_verify.lit is that); the
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.

--- a/programming_examples/llms/llama32_3b_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/llama32_3b_q4nx/run_npu2_prefill_sweep.lit
@@ -22,7 +22,7 @@
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_llama_3_2_3b_npu2
 //
 // RUN: mkdir -p test_peano_prefill_sweep
 // RUN: cd test_peano_prefill_sweep

--- a/programming_examples/llms/phi4_mini_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/phi4_mini_q4nx/run_npu2_prefill_sweep.lit
@@ -22,7 +22,7 @@
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_microsoft_phi_4_mini_instruct, hfweights_fastflowlm_phi4_mini_instruct_npu2
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_fastflowlm_phi4_mini_instruct_npu2
 //
 // RUN: mkdir -p test_peano_prefill_sweep
 // RUN: cd test_peano_prefill_sweep

--- a/programming_examples/llms/phi4_mini_q4nx/run_npu2_prefill_sweep.lit
+++ b/programming_examples/llms/phi4_mini_q4nx/run_npu2_prefill_sweep.lit
@@ -16,8 +16,12 @@
 // the prefill ELFs, and sweep_prefill.py fails the point rather than reporting
 // a number if the engines came out at some other length.
 //
-// Unlike the decode sweep this needs real weights -- a prefill is a prefill --
-// so it carries the same weight/token requirements as run_npu2_profile.lit.
+// Unlike the decode sweep this needs real weights -- a prefill is a prefill.
+// It needs only the q4nx bundle, though, NOT the base HF checkpoint that
+// run_npu2_profile.lit also requires: this path loads weights solely from
+// *_q4nx_weights, prompts with hardcoded token ids, and builds no tokenizer.
+// Requiring the base checkpoint anyway would silently SKIP the point on a
+// runner that lacks it, and drop the model's row from the published table.
 // Latency only, never a correctness gate (run_npu2_verify.lit is that); the
 // per-length first-token argmax the driver already prints is recorded with
 // each point because a bad build shows up there first.


### PR DESCRIPTION
## The bug

#1910 added the `prefill-sweep` suite and put it in the `workflow_dispatch` input default — but **the scheduled run never reads that default.** On a `schedule` event `github.event.inputs` is null, and `workflow_dispatch` defaults are not applied to it, so the run falls through to a literal that still listed only the three older suites:

```bash
SUITES="${{ github.event.inputs.suites || 'verify,profile,sweep' }}"
```

`want prefill-sweep` returns false and the suite is skipped. The nightly has never run the thing it was added for; the TTFT table would only ever have appeared if someone dispatched the workflow by hand.

## Why nothing caught it

It fails silently in both directions:

- Publishing is gated on `github.event_name == 'schedule'` — **true** — so the publish steps run and report healthy.
- The results file they consume is guarded by `if [ -f prefill_sweep.json ]`, so its absence is a no-op, not an error.

Green job, missing table, no signal. Neither check can see a suite that never ran. Fixed by keeping the literal in step with the `default:` above it, with a comment saying why, so the next suite added doesn't repeat it.

## Second fix: four lits over-require weights

Four of the eight sweep lits `REQUIRES` a base-model checkpoint the sweep never loads:

| lit | asked for | actually loads |
|:--|:--|:--|
| llama32_1b_q4nx | base + q4nx bundle | bundle |
| llama32_3b_q4nx | base + q4nx bundle | bundle |
| phi4_mini_q4nx | base + q4nx bundle | bundle |
| llama31_8b_q4nx | base + q4nx bundle | bundle |

`profile-prefill` runs `<model>_prefill.py`, which loads weights only from `*_q4nx_weights`, drives a hardcoded token-id prompt (`PROMPT = [128000, 791, 6864, 315, 9822, 374]`) plus a synthetic `t % VOCAB` bench prompt, and builds no tokenizer. The symbols it imports from the reference model are `LlamaConfig` / `generate_rope_lut` / `LayerWeights` — the module's `snapshot_download` lives inside `load_weights`, which this path never calls.

An unmet `REQUIRES` is an UNSUPPORTED **skip**, so on a runner without those checkpoints the table renders with half its rows missing and nothing reports it — the same silent-skip shape as the bug above.

`lfm2_1_2b` and `qwen25_7b` keep their base-checkpoint requirement: those two requantize the HF fp checkpoint rather than unpacking a bundle, so they genuinely need it. `gemma3_4b` and `qwen3_8b` were already correct.

## Not in this PR

A guard that fails the job summary when a lit that was expected to run reports UNSUPPORTED. That is the general fix for this class rather than for these four instances, and it touches the summary step rather than the suite wiring, so it is worth reviewing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
