### PR TITLE
[air.api] Hotfix: conv1d_depthwise.build_module must return a module (#1927 regression)

### DIFF
--- a/programming_examples/conv1d_depthwise/conv1d_depthwise.py
+++ b/programming_examples/conv1d_depthwise/conv1d_depthwise.py
@@ -44,7 +44,7 @@ HALO = K_TAPS - 1  # 2 rows of left context
 L1_BYTES = 65536  # per-compute-tile L1 on AIE2P
 
 
-def build_module(seq, channels, tile_s, np_dtype_in=bfloat16, herd_x=8, herd_y=1):
+def build_launch(seq, channels, tile_s, np_dtype_in=bfloat16, herd_x=8, herd_y=1):
     assert (
         channels % herd_x == 0
     ), f"channels ({channels}) must be divisible by herd_x ({herd_x})"
@@ -169,6 +169,25 @@ def build_module(seq, channels, tile_s, np_dtype_in=bfloat16, herd_x=8, herd_y=1
     return launch
 
 
+def build_module(
+    seq, channels, tile_s, np_dtype_in=bfloat16, herd_x=8, herd_y=1, target="npu2"
+):
+    """The MLIR module. Signature and return type are the llms/ builders' contract.
+
+    Most air.api examples let `build_module` hand back the LaunchContext and
+    leave `.build()` to their own `main`, which is fine for an example nobody
+    imports. The four that llms/ imports — gelu_and_mul, layer_norm,
+    silu_and_mul, weighted_rms_norm — instead split the two: `build_launch` for
+    the context, `build_module` for a built module with an explicit target.
+    lfm2's prefill hands the result straight to `cache.compile_and_cache`, so it
+    needs the module; returning the context stringified an object repr into
+    air.mlir and failed as a parse error two passes downstream.
+    """
+    return build_launch(
+        seq, channels, tile_s, np_dtype_in, herd_x=herd_x, herd_y=herd_y
+    ).build(target=target)
+
+
 def conv1d_reference(x_pad, w_tapmajor, seq, channels):
     """FP32 reference for the causal depthwise conv.
 
@@ -268,7 +287,7 @@ if __name__ == "__main__":
     if args.perf_iters < 0:
         parser.error("--perf-iters must be >= 0")
 
-    launch = build_module(
+    launch = build_launch(
         args.seq,
         args.channels,
         args.tile_s,

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -380,9 +380,12 @@ class XRTBackend(AirBackend):
                 if hasattr(air_module, "build")
                 else ""
             )
+            # Quote the type name: it is dotted, so a bare sentence-ending
+            # period reads as another component of it.
             raise AirBackendError(
                 f"XRTBackend.compile expects an MLIR module, got "
-                f"{type(air_module).__module__}.{type(air_module).__name__}.{hint}"
+                f"'{type(air_module).__module__}.{type(air_module).__name__}'."
+                f"{hint}"
             )
 
         # Determine target device: use explicit parameter if provided, otherwise auto-detect

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -367,6 +367,24 @@ class XRTBackend(AirBackend):
                 "Cannot use XRTBackend to compile while the artifact is currently loaded. Call unload() first."
             )
 
+        # The module is written out with str() further down, so anything at all
+        # is accepted by Python and rejected by aircc's parser two passes later,
+        # as "air.mlir:1:1: expected operation name in quotes" -- a diagnostic
+        # that names neither the caller nor the type it passed. Check here
+        # instead, where the argument still has a name. The common slip is an
+        # air.api LaunchContext, which is one .build() away from a module, so
+        # say that rather than only naming the type.
+        if not isinstance(air_module, (air.ir.Module, air.ir.Operation, str)):
+            hint = (
+                " Call .build(target=...) on it first."
+                if hasattr(air_module, "build")
+                else ""
+            )
+            raise AirBackendError(
+                f"XRTBackend.compile expects an MLIR module, got "
+                f"{type(air_module).__module__}.{type(air_module).__name__}.{hint}"
+            )
+
         # Determine target device: use explicit parameter if provided, otherwise auto-detect
         if self.target_device is not None:
             target_device = self.target_device

--- a/python/test/api/llms_builder_contract.py
+++ b/python/test/api/llms_builder_contract.py
@@ -1,0 +1,116 @@
+# ./python/test/api/llms_builder_contract.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s %air_src_root | FileCheck %s
+
+"""The builders under programming_examples/llms/ import must return a module.
+
+An air.api example normally ends `build_module` with `return launch`, handing
+back the LaunchContext and leaving `.build()` to its own `main`. That is fine
+for an example nobody imports, and it is what ~78 of them do. It is wrong for
+the handful that llms/ imports: those hand the result straight to
+`KernelCache.compile_and_cache`, which writes `str(mlir_module)` into air.mlir.
+A LaunchContext stringifies to `<air.api._compile.LaunchContext object at 0x..>`
+and aircc rejects it as `air.mlir:1:1: expected operation name in quotes` -- a
+diagnostic that names neither the importer nor the builder.
+
+That is how #1927 reddened the nightly for lfm2_1_2b_q4nx. It could not be
+caught on the PR: llms/ runs under `check-programming-examples-llms-*`, which
+only nightlyPerfBenchmark invokes, and #1927 touched no llms/ file. So the
+check lives here instead, in a PR-gated suite, and it needs no NPU -- building
+the module is enough, because the failure is in the return type and not in the
+IR.
+
+Adding an import to llms/ therefore means adding a row below. The list is the
+contract, and it is short on purpose.
+"""
+
+import sys
+
+sys.path[:0] = [
+    sys.argv[1] + "/programming_examples",
+    sys.argv[1] + "/programming_examples/llms",
+]
+
+import air.ir
+from ml_dtypes import bfloat16
+
+# Each row: (module path, builder, kwargs, the llms/ file that imports it).
+# Configs are the smallest legal ones, not the ones llms/ passes -- the return
+# type does not depend on the shape, and a prefill-scale build is slow.
+BUILDERS = [
+    (
+        "conv1d_depthwise.conv1d_depthwise",
+        "build_module",
+        dict(seq=128, channels=256, tile_s=8, np_dtype_in=bfloat16, herd_x=8, herd_y=1),
+        "lfm2_1_2b_q4nx/lfm2_1_2b_q4nx_prefill.py",
+    ),
+    (
+        "layer_norm.layer_norm",
+        "build_module",
+        dict(M=8, N=128),
+        "shared/builders (smolvla)",
+    ),
+    (
+        "weighted_rms_norm.weighted_rms_norm",
+        "build_module",
+        dict(M=8, N=128),
+        "shared/infra",
+    ),
+    (
+        "gelu_and_mul.gelu_and_mul",
+        "build_module_2d",
+        dict(rows=8, cols=256, tile_n=32),
+        "shared/infra",
+    ),
+    (
+        "silu_and_mul.silu_and_mul",
+        "build_module_2d",
+        dict(rows=8, cols=256, tile_n=32),
+        "shared/infra",
+    ),
+    (
+        "flash_attention.kernel_fusion_based.attn_npu2",
+        "build_module",
+        dict(lk=512, lkp=64, lq=512, lqp=256, dk=64, dv=64),
+        "shared/infra/fa_headfirst.py",
+    ),
+]
+
+
+def check(modpath, fnname, kwargs, importer):
+    mod = __import__(modpath, fromlist=[fnname])
+    built = getattr(mod, fnname)(**kwargs)
+    text = str(built)
+    # Assert it is non-empty before asking whether it looks like MLIR: the
+    # failure mode this guards is a one-line object repr, and "does not contain
+    # air.launch" would also be true of the empty string.
+    assert text.strip(), f"{modpath}.{fnname} stringified to nothing"
+    # Reparse rather than pattern-match: this is exactly what aircc does with
+    # the file, so a text that survives it is a text aircc will accept. Pinning
+    # a substring instead would be a guess about which air ops the builder is
+    # expected to emit, which is not what this test is about -- layer_norm has
+    # no air.launch at all.
+    ok = isinstance(built, air.ir.Module)
+    if ok:
+        with air.ir.Context(), air.ir.Location.unknown():
+            air.ir.Module.parse(text)
+    print(
+        f"{modpath}.{fnname}: {'MLIR' if ok else 'NOT MLIR'} "
+        f"({type(built).__name__}, {len(text.splitlines())} lines) <- {importer}"
+    )
+    return ok
+
+
+# CHECK: conv1d_depthwise.conv1d_depthwise.build_module: MLIR
+# CHECK: layer_norm.layer_norm.build_module: MLIR
+# CHECK: weighted_rms_norm.weighted_rms_norm.build_module: MLIR
+# CHECK: gelu_and_mul.gelu_and_mul.build_module_2d: MLIR
+# CHECK: silu_and_mul.silu_and_mul.build_module_2d: MLIR
+# CHECK: flash_attention.kernel_fusion_based.attn_npu2.build_module: MLIR
+# CHECK: 6/6 builders return a module
+bad = [row for row in BUILDERS if not check(*row)]
+assert not bad, f"not a module: {[f'{m}.{f}' for m, f, _, _ in bad]}"
+print(f"{len(BUILDERS)}/{len(BUILDERS)} builders return a module")

--- a/python/test/api/llms_builder_contract.py
+++ b/python/test/api/llms_builder_contract.py
@@ -84,24 +84,34 @@ def check(modpath, fnname, kwargs, importer):
     mod = __import__(modpath, fromlist=[fnname])
     built = getattr(mod, fnname)(**kwargs)
     text = str(built)
-    # Assert it is non-empty before asking whether it looks like MLIR: the
-    # failure mode this guards is a one-line object repr, and "does not contain
-    # air.launch" would also be true of the empty string.
-    assert text.strip(), f"{modpath}.{fnname} stringified to nothing"
-    # Reparse rather than pattern-match: this is exactly what aircc does with
-    # the file, so a text that survives it is a text aircc will accept. Pinning
-    # a substring instead would be a guess about which air ops the builder is
-    # expected to emit, which is not what this test is about -- layer_norm has
-    # no air.launch at all.
-    ok = isinstance(built, air.ir.Module)
-    if ok:
-        with air.ir.Context(), air.ir.Location.unknown():
-            air.ir.Module.parse(text)
+    # Every failure is reported through the status line rather than by raising
+    # here, so the run always says *which* builder is wrong. Raising first
+    # would leave the reader with a traceback and a half-finished table -- and
+    # the whole point of this test is to name the builder, since the
+    # diagnostic it stands in for (a parse error in air.mlir) does not.
+    if not isinstance(built, air.ir.Module):
+        why = "NOT MLIR"
+    elif not text.strip():
+        # Checked before the parse: an empty module is what an emitter that
+        # silently traced nothing produces, and MLIR parses "" quite happily.
+        why = "EMPTY"
+    else:
+        # Reparse rather than pattern-match: this is exactly what aircc does
+        # with the file, so a text that survives it is a text aircc will
+        # accept. Pinning a substring instead would be a guess about which air
+        # ops the builder should emit, which is not what this test is about --
+        # layer_norm has no air.launch at all.
+        try:
+            with air.ir.Context(), air.ir.Location.unknown():
+                air.ir.Module.parse(text)
+            why = "MLIR"
+        except Exception as e:  # noqa: BLE001 -- the message is the report
+            why = f"UNPARSABLE ({type(e).__name__}: {str(e).splitlines()[0]})"
     print(
-        f"{modpath}.{fnname}: {'MLIR' if ok else 'NOT MLIR'} "
+        f"{modpath}.{fnname}: {why} "
         f"({type(built).__name__}, {len(text.splitlines())} lines) <- {importer}"
     )
-    return ok
+    return why == "MLIR"
 
 
 # CHECK: conv1d_depthwise.conv1d_depthwise.build_module: MLIR

--- a/python/test/lit.cfg.py
+++ b/python/test/lit.cfg.py
@@ -70,6 +70,8 @@ air_runtime_lib = os.path.join(config.air_obj_root, "runtime_lib")
 config.substitutions.append(("%PATH%", config.environment["PATH"]))
 config.substitutions.append(("%shlibext", config.llvm_shlib_ext))
 config.substitutions.append(("%PYTHON", config.python_executable))
+# For tests that import a programming example's builder to check its contract.
+config.substitutions.append(("%air_src_root", config.air_src_root))
 
 # excludes: A list of directories to exclude from the testsuite. The 'Inputs'
 # subdirectories contain auxiliary inputs for various tests in their parent


### PR DESCRIPTION
## The failure

Nightly LLM perf CI has been red since 2026-08-28 (run 33149510099, air `6b9792a349d8`). `llms/lfm2_1_2b_q4nx` fails `run_npu2_verify`, `run_npu2_profile` and the prefill sweep at all four lengths:

```
air.backend.abc.AirBackendError: aircc compilation failed:
loc("air.mlir":1:1): error: expected operation name in quotes
```

`conv1d_depthwise.build_module` ended `return launch`, handing back the `air.api` `LaunchContext`. `llms/lfm2_1_2b_q4nx/lfm2_1_2b_q4nx_prefill.py:238` imports it and `:326` passes the result to `KernelCache.compile_and_cache`, which writes `str()` of it into `air.mlir`. The file therefore held one line — `<air.api._compile.LaunchContext object at 0x...>` — which is what aircc rejects at 1:1.

Credit to the reporter for the diagnosis and the repro.

## The fix

Returning the context is the *majority* convention, not a deviation: ~78 examples end `build_module` with `return launch`, and that is fine for an example nobody imports. It is wrong for the handful `llms/` imports, which hand the result straight to the cache. Those four — `gelu_and_mul`, `layer_norm`, `silu_and_mul`, `weighted_rms_norm` — split `build_launch` (the context) from `build_module` (a built module, explicit target). `conv1d_depthwise` now matches them. The module text is unchanged.

## Two things around it, because the return type is only half the defect

**A guard at the call site.** `XRTBackend.compile` `str()`s whatever it is given, so a type error surfaced as a parse error two passes downstream in a file nobody reads. It now rejects anything that is not a module, and names the remedy when the argument has one:

```
AirBackendError: XRTBackend.compile expects an MLIR module, got
air.api._compile.LaunchContext. Call .build(target=...) on it first.
```

**A PR-gated test.** `python/test/api/llms_builder_contract.py` builds every cross-directory builder `llms/` imports and reparses each with `air.ir.Module.parse` — what aircc does with the file. #1927 could not have been caught otherwise: it touched no `llms/` file, and `check-programming-examples-llms-*` runs only in `nightlyPerfBenchmark`, so the PR was green and the nightly went red hours later attributed to nobody. Adding an import to `llms/` now means adding a row.

The test is proven to fail on the bug, not merely to pass on the fix: reintroducing the defect gives `NOT MLIR (LaunchContext, 1 lines)` and names the builder.

## The scan turned up a second instance

Running the consumer scan for the fix found the same defect in **#1944**, still open: `flash_attention/kernel_fusion_based/attn_npu2.build_module` is imported by `llms/shared/infra/fa_headfirst.py:129` and passed straight to `compile_and_cache`. On `main` it returns an `ir.Module`; the conversion in #1944 makes it return a `LaunchContext`. Fixed on that branch (module text byte-identical, 715 lines). The test in this PR passes on plain `main` and would have caught it.

`channel_examples/dual_herd_packet_switch`, converted in the same PR as `conv1d_depthwise`, also ends `return launch` — but nothing imports it and its own `main` calls `.build()`, so it is not broken and is left alone.

## Gating

- Reporter's repro: **1 line → 40 lines**, non-empty, reparses.
- Module text byte-identical to the pre-edit builder (41 lines; baseline asserted non-empty first).
- The real lfm2 path — `build_conv1d(512, 2048, 8, ...)` → `KernelCache.compile_and_cache('conv1d', ...)` → aircc at `target_device=npu2` — produces `conv1d.xclbin` (21593 B) + `conv1d.insts.bin`. Control with the defect reintroduced fails at the new guard.
- `check-air-python` 46 pass (was 45), `check-air-mlir` 525 pass / 7 XFAIL.

**Not run, stated plainly:** the `conv1d_depthwise` lit is `REQUIRES: ryzen_ai_npu2` and my box is npu1 (Phoenix), so there is no hardware run here; and no lfm2 `make verify` end to end, which needs LFM2 weights I do not have. The npu2 aircc compile above covers the parse failure, not execution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)