### PR TITLE
[programming_examples] Apply Llama-3.2's llama3 RoPE scaling in the prefill LUT

### DIFF
--- a/programming_examples/llms/llama32_1b/llama32_1b_weights.py
+++ b/programming_examples/llms/llama32_1b/llama32_1b_weights.py
@@ -392,6 +392,13 @@ def synthetic_weights(
 # ---------------------------------------------------------------------------
 
 
+# llama3 rope scaling (config rope_scaling) for Llama-3.2.
+ROPE_FACTOR = 32.0
+ROPE_LOW_FREQ_FACTOR = 1.0
+ROPE_HIGH_FREQ_FACTOR = 4.0
+ROPE_OLD_CTX = 8192.0
+
+
 def generate_rope_lut(
     config: Optional[LlamaConfig] = None,
     seq_len: int = 2048,
@@ -427,6 +434,22 @@ def generate_rope_lut(
     # Compute inverse frequencies: shape (head_dim/2,)
     dim_indices = np.arange(0, head_dim, 2, dtype=np.float64)
     inv_freq = 1.0 / (theta ** (dim_indices / head_dim))
+
+    # Llama-3.2 specifies rope_type "llama3": high-frequency dims pass through,
+    # low-frequency dims are divided by `factor`, and the band between is
+    # interpolated. Omitting it left prefill on plain RoPE while the fused
+    # decode (_llama3_rope) applied the scaling, so the cached K and the decode
+    # query were rotated on different frequencies -- an error proportional to
+    # position, and the reason long prompts degraded.
+    wl = 2 * np.pi / inv_freq
+    low_wl = ROPE_OLD_CTX / ROPE_LOW_FREQ_FACTOR
+    high_wl = ROPE_OLD_CTX / ROPE_HIGH_FREQ_FACTOR
+    smooth = (ROPE_OLD_CTX / wl - ROPE_LOW_FREQ_FACTOR) / (
+        ROPE_HIGH_FREQ_FACTOR - ROPE_LOW_FREQ_FACTOR
+    )
+    med = (1 - smooth) * (inv_freq / ROPE_FACTOR) + smooth * inv_freq
+    inv_freq = np.where(wl > low_wl, inv_freq / ROPE_FACTOR, inv_freq)
+    inv_freq = np.where((wl <= low_wl) & (wl >= high_wl), med, inv_freq)
 
     # Compute angles: shape (seq_len, head_dim/2)
     positions = np.arange(seq_len, dtype=np.float64)

--- a/programming_examples/llms/llama32_3b/llama32_3b_weights.py
+++ b/programming_examples/llms/llama32_3b/llama32_3b_weights.py
@@ -392,6 +392,13 @@ def synthetic_weights(
 # ---------------------------------------------------------------------------
 
 
+# llama3 rope scaling (config rope_scaling) for Llama-3.2.
+ROPE_FACTOR = 32.0
+ROPE_LOW_FREQ_FACTOR = 1.0
+ROPE_HIGH_FREQ_FACTOR = 4.0
+ROPE_OLD_CTX = 8192.0
+
+
 def generate_rope_lut(
     config: Optional[LlamaConfig] = None,
     seq_len: int = 2048,
@@ -427,6 +434,22 @@ def generate_rope_lut(
     # Compute inverse frequencies: shape (head_dim/2,)
     dim_indices = np.arange(0, head_dim, 2, dtype=np.float64)
     inv_freq = 1.0 / (theta ** (dim_indices / head_dim))
+
+    # Llama-3.2 specifies rope_type "llama3": high-frequency dims pass through,
+    # low-frequency dims are divided by `factor`, and the band between is
+    # interpolated. Omitting it left prefill on plain RoPE while the fused
+    # decode (_llama3_rope) applied the scaling, so the cached K and the decode
+    # query were rotated on different frequencies -- an error proportional to
+    # position, and the reason long prompts degraded.
+    wl = 2 * np.pi / inv_freq
+    low_wl = ROPE_OLD_CTX / ROPE_LOW_FREQ_FACTOR
+    high_wl = ROPE_OLD_CTX / ROPE_HIGH_FREQ_FACTOR
+    smooth = (ROPE_OLD_CTX / wl - ROPE_LOW_FREQ_FACTOR) / (
+        ROPE_HIGH_FREQ_FACTOR - ROPE_LOW_FREQ_FACTOR
+    )
+    med = (1 - smooth) * (inv_freq / ROPE_FACTOR) + smooth * inv_freq
+    inv_freq = np.where(wl > low_wl, inv_freq / ROPE_FACTOR, inv_freq)
+    inv_freq = np.where((wl <= low_wl) & (wl >= high_wl), med, inv_freq)
 
     # Compute angles: shape (seq_len, head_dim/2)
     positions = np.arange(seq_len, dtype=np.float64)


### PR DESCRIPTION
Llama-3.2 declares `rope_scaling {rope_type: llama3, factor: 32, low_freq_factor: 1, high_freq_factor: 4, original_max_position_embeddings: 8192}`. `generate_rope_lut` built a plain `1/theta^(2i/d)` table and ignored it — while the fused decode's `_llama3_rope` applies the scaling in full.

So prefill and decode disagreed. Prefill wrote the KV cache with keys rotated on unscaled frequencies; decode rotated each new query on the scaled ones and attended against those keys. That phase error grows with position, which is why short prompts look fine and long ones fall apart.

## Evidence

Measured against a CPU model carrying the **same dequantized 4-bit weights** (so quantization is held constant and only the implementation differs), on a 742-token prompt:

| layer-0 K vs CPU reference | before | after |
|---|---|---|
| error std / logit std | 0.1451 | **0.0251** |
| share of squared error in 64 of 512 channels | 94% | 41% |

After the fix K is more accurate than V (0.072), and the spike in the affected frequency bands is gone. The rebuilt LUT matches the decode-side table to 1.95e-3 — the bf16 ulp.

The channels that carried the error were the giveaway: measured worst dims `[17,15,16,20,19,18,21]` against `[16,17,15,18,19,20,21]` predicted from the wavelength band where `llama3` scaling actually bites.

End to end on `llama32_1b_q4nx`, 742 tokens, greedy — before, it refused the task and looped a section header while leaking a prompt delimiter; after, it answers all three questions, including correctly identifying a contradiction planted in the source document.

## Blast radius

Five examples shared the omission, all fixed here:

| Example | RoPE source |
|---|---|
| `llama32_1b`, `llama32_1b_int4`, `llama32_1b_q4nx` | `llama32_1b_weights` |
| `llama32_3b`, `llama32_3b_q4nx` | `llama32_3b_weights` |

`llama32_3b_q4nx` had the identical prefill/decode mismatch. bf16 `llama32_3b` used the unscaled table on both sides — self-consistent, but still diverging from HF.

Not affected, checked rather than assumed: `llama31_8b_q4nx` implements the scaling already (factor 8), `gemma3_4b_q4nx` applies its `linear` factor, `phi4_mini_q4nx` selects the LongRoPE short/long table by `seq_len`, and the Qwen, LFM2 and SmolLM2 configs carry no `rope_scaling`. `phi4_mini_q4nx` and `llama31_8b_q4nx` do import from `llama32_3b_weights`, but only `LlamaConfig`, `LayerWeights` and `LlamaWeights`.

## Gates

`llama32_1b_q4nx` verify 2/2 PASS, `llama32_3b_q4nx` verify 2/2 PASS. Host-side only — the LUT is data, so no kernel rebuild.

## No gate detects this

`llama32_1b_q4nx verify-full` is **8/8 both with and without this change**. Every verify prompt is a one-liner and the defect only appears at long context, so the gate is blind in both directions. That is why this survived at least since `09ca164d9` and likely since the example landed on 2026-08-03 — and it means nothing in CI would notice if this were reverted.

A long-prompt gate is the missing coverage. It is deliberately not in this change, to keep the fix reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)