### PR TITLE
[smolvla] Stop calling .build() on a module the FA builder already built

### DIFF
--- a/programming_examples/llms/smolvla/smolvla_vision_encoder.py
+++ b/programming_examples/llms/smolvla/smolvla_vision_encoder.py
@@ -224,7 +224,7 @@ def _compile_flash_attn(cache, config, seq_len, fa_bfp16, fused_qkv=False, n_ima
         num_heads_per_unroll=num_heads_per_unroll,
         fused_qkv=fused_qkv,
         n_images=n_images,
-    ).build(target="npu2")
+    )
     compile_attn_npu2(head_dim=head_dim, bfp16=fa_bfp16, force=True)
     print(f"    (FA microkernel BFP16={fa_bfp16})")
     cache.compile_and_cache(
@@ -531,7 +531,7 @@ def compile_all_kernels(
         num_kv_heads=n_kv_heads,
         causal=False,
         num_heads_per_unroll=num_heads_per_unroll,
-    ).build(target="npu2")
+    )
     # Pre-build attn_npu2.o with the chosen precision mode and force=True. The
     # compile_and_cache below calls prepare_air_project → compile_all_external_kernels,
     # which rebuilds attn_npu2.o only if absent (force=False) — so this force=True


### PR DESCRIPTION
`main` is broken for smolvla right now: both FlashAttention call sites in
`smolvla_vision_encoder.py` raise `AttributeError` before anything compiles.

#1936 and #1950 landed forty minutes apart and each assumed it would be second.
#1936 worked around #1944's return-type break at smolvla's two call sites with
`.build(target="npu2")`; #1950 then fixed that break at the source, so
`attn_npu2_seqfirst.build_module` returns a `Module` — which has no `.build`.
Both PRs carried a note saying whichever merged second had to drop those calls,
and neither did, because the second one merged before the first was visible.

```python
>>> type(build_module(lk=512, lkp=64, lq=512, lqp=256, dk=64, dv=64)).__name__
'Module'
>>> hasattr(_, "build")
False
```

Dropping the two calls is the whole change. `build_module` pins
`target="npu2"` internally, so the compiled shape is byte-identical to what
#1936 measured.

The third `.build(target="npu2")` in the file is left alone: `gelu.gelu.build_gelu`
has not been migrated and still returns a `LaunchContext`.

## Verification

- `make compile`: **5 ELFs** (`flash_attn`, `gemm_connector`, `layer_norm`,
  `vit_ln_qkv`, `vit_o_ffn`), against `main` at 2c3f4bf5 with a freshly
  installed build.
- black clean.

Per-PR CI will not catch a recurrence — `buildAndTestRyzenAI.yml` runs the
programming examples with `--filter-out "llms/"`. `llms_builder_contract.py`
guards the builders' return type but not what a caller then does with it.