### PR TITLE
[air.api] Give a buffer region the operators a whole-buffer read already has

### DIFF
--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -757,6 +757,70 @@ class BufferSlice(_StridedView):
     def __neg__(self):
         return -self._as_leaf()
 
+    # Comparisons and bitwise, completing the operator surface a region shares
+    # with a whole-buffer read.
+    #
+    # `Buffer.__getitem__` returns a BufferExpr for `b[:]` and a BufferSlice for
+    # anything narrower, so these two spellings of the same read went down
+    # different paths. Arithmetic was on both; comparisons and bitwise were on
+    # BufferExpr only. `b[:] >= n` therefore worked and `b[3:4] >= n` raised
+    # `TypeError: '>=' not supported between instances of 'BufferSlice' and
+    # 'int'` -- a distinction with no rule behind it, which every existing
+    # comparison test missed because they all subscript the whole buffer.
+    #
+    # __eq__/__ne__ stay out, as they do on BufferExpr: defining __eq__ sets
+    # __hash__ to None and changes what `slice == slice` means for ordinary
+    # Python. ops.equal / ops.not_equal are the spelling.
+    def __lt__(self, o):
+        return self._arith(o, lambda a, b: a < b)
+
+    def __le__(self, o):
+        return self._arith(o, lambda a, b: a <= b)
+
+    def __gt__(self, o):
+        return self._arith(o, lambda a, b: a > b)
+
+    def __ge__(self, o):
+        return self._arith(o, lambda a, b: a >= b)
+
+    def __and__(self, o):
+        return self._arith(o, lambda a, b: a & b)
+
+    def __rand__(self, o):
+        return self._arith(o, lambda a, b: a & b, reflected=True)
+
+    def __or__(self, o):
+        return self._arith(o, lambda a, b: a | b)
+
+    def __ror__(self, o):
+        return self._arith(o, lambda a, b: a | b, reflected=True)
+
+    def __xor__(self, o):
+        return self._arith(o, lambda a, b: a ^ b)
+
+    def __rxor__(self, o):
+        return self._arith(o, lambda a, b: a ^ b, reflected=True)
+
+    def __lshift__(self, o):
+        return self._arith(o, lambda a, b: a << b)
+
+    def __rlshift__(self, o):
+        return self._arith(o, lambda a, b: a << b, reflected=True)
+
+    def __rshift__(self, o):
+        return self._arith(o, lambda a, b: a >> b)
+
+    def __rrshift__(self, o):
+        return self._arith(o, lambda a, b: a >> b, reflected=True)
+
+    def __bool__(self):
+        # The same guard BufferExpr carries, for the same reason, now that a
+        # region answers the same operators: `b[3:4] and x` would take the
+        # default object truthiness and emit nothing. Deferring to the leaf
+        # keeps one wording, and a region that cannot be read elementwise
+        # raises _as_leaf's explanation instead, which is the better message.
+        return bool(self._as_leaf())
+
     def materialize_offsets(self):
         return [o.materialize() for o in self.offsets]
 

--- a/python/test/api/cmp_select.py
+++ b/python/test/api/cmp_select.py
@@ -237,3 +237,57 @@ def a_comparison_can_name_one_element_of_a_buffer():
                     air.ops.store(a, OUT)
 
     print(launch.mlir())
+
+
+# A region narrower than the whole buffer takes a different path in
+# Buffer.__getitem__: `b[:]` short-circuits to a BufferExpr, anything else
+# builds a BufferSlice. Every test above subscripts the whole buffer, so all of
+# them exercise BufferExpr and none of them exercise BufferSlice -- which is how
+# BufferSlice came to answer `+` but not `>=`, and how attn_npu2's
+# `ctr[3:4] >= dv_chunks - 1` reached a TypeError at trace time. The two
+# spellings name the same read and must answer the same operators.
+
+
+# CHECK-LABEL: TEST: a_partial_region_compares
+# CHECK: arith.cmpi sgt
+# CHECK: arith.select
+@run
+def a_partial_region_compares():
+    def body(a, b):
+        # Rank stays 1 and the extent is the tile, so this is a plain region of
+        # the buffer rather than a view -- the case _as_leaf admits.
+        return air.ops.select(a[0:1024] > b[0:1024], a[0:1024], b[0:1024])
+
+    print(build(i32, body).mlir())
+
+
+# CHECK-LABEL: TEST: a_partial_region_compares_against_a_scalar
+# The spelling that failed: a region on the left, a plain Python int on the
+# right, with no arithmetic in between to promote it first.
+# CHECK: arith.cmpi sge
+# CHECK: arith.select
+@run
+def a_partial_region_compares_against_a_scalar():
+    print(
+        build(i32, lambda a, b: air.ops.select(a[0:1024] >= 1, a[0:1024], b[:])).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: a_partial_region_compares_reflected
+# Python answers `1 <= region` by swapping the operands and calling the
+# region's __ge__, so the reflected form needs no separate dunder -- but it
+# does need pinning, because that is a language rule and not an obvious one.
+# CHECK: arith.cmpi sge
+@run
+def a_partial_region_compares_reflected():
+    print(
+        build(i32, lambda a, b: air.ops.select(1 <= a[0:1024], a[0:1024], b[:])).mlir()
+    )
+
+
+# CHECK-LABEL: TEST: a_partial_region_is_bitwise
+# Same gap, same fix: `&` was on BufferExpr only.
+# CHECK: arith.andi
+@run
+def a_partial_region_is_bitwise():
+    print(build(i32, lambda a, b: a[0:1024] & b[0:1024]).mlir())


### PR DESCRIPTION
`Buffer.__getitem__` short-circuits: `b[:]` returns a `BufferExpr`, anything
narrower returns a `BufferSlice`. Arithmetic was defined on both; comparisons
and bitwise on `BufferExpr` only. So two spellings of the same read answered
different operators:

```python
b[:]   >= n    # works
b[3:4] >= n    # TypeError: '>=' not supported between instances of
               #            'BufferSlice' and 'int'
```

## Why it matters now

`attn_npu2.py:551` is the second spelling:

```python
head_next = ctr[2:3] + 1
wrapped   = head_next >= num_head_groups      # fine -- `+ 1` promoted it
if dv_chunks > 1:
    last_dv = ctr[3:4] >= dv_chunks - 1       # TypeError at trace time
```

`dv_chunks > 1` needs `head_dim > lkp`, so this branch is reached only by
**qwen3-4b, llama31-8b, qwen25-7b and llama32-3b** — every `fa_headfirst` model
with a 128-wide head. On main they fail to build:

```
File ".../flash_attention/kernel_fusion_based/attn_npu2.py", line 551, in _
    last_dv = ctr[3:4] >= dv_chunks - 1
TypeError: '>=' not supported between instances of 'BufferSlice' and 'int'
make: *** [.../qwen3_4b_q4nx/Makefile:235: compile-prefill] Error 1
```

Found by running the `qwen3_4b_q4nx` verify gate locally. It is a **new** break
relative to the last nightly, which got as far as decode.

## The fix

In air.api, not in the example — `attn_npu2` was written against the surface
this restores. The comparison and bitwise dunders forward through `_as_leaf()`
exactly as `_arith` already does.

`__eq__`/`__ne__` stay out, as on `BufferExpr`: defining `__eq__` sets
`__hash__` to `None`. Python derives the reflected *comparisons* by swapping
operands, so only the bitwise ones need `__r*__` forms. `__bool__` comes along
too — a region now answers the very operators that guard's message points at.

## Why no test caught it

Every comparison and bitwise test in the suite subscripts the **whole** buffer
(`a[:] >= b[:]`), so all of them take the `BufferExpr` path and none take
`BufferSlice`. `cmp_select.py` gains the partial-region cases: region-vs-region,
region-vs-scalar (the spelling that failed), the reflected form, and bitwise.

Note `a_comparison_can_name_one_element_of_a_buffer` already covers
`ops.equal(ctr[1:2], 0)` — the *function* spelling had been taught about
regions; the *operator* spelling had not. That is the asymmetry this closes.

## Verification

- `check-air-python`: **43 passed, 0 failed** (54 discovered, 11 unsupported).
- `qwen3_4b_q4nx`: `make compile` now completes, prefill included; it raised the
  TypeError before.
- Trace-built all four migrated `flash_attention/kernel_fusion_based` builders
  across the branch-selecting configs — head_dim 64/128/256, causal on/off, GQA
  2:2 and 4:1, `fused_qkv`, `n_images`, and 1/2/4/5/8/9 q-rounds (which select
  the triangle, merge, fold and row-split branches). **24 build**; the remainder
  are L1-budget rejections that say so. This was the only trace-time defect in
  the matrix.
- `black` clean.