### PR TITLE
[smolvla] Define PYTHON, like every other llms/ Makefile does

### DIFF
--- a/programming_examples/llms/smolvla/Makefile
+++ b/programming_examples/llms/smolvla/Makefile
@@ -28,6 +28,13 @@
 
 srcdir := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
 
+# Every sibling Makefile under llms/ carries this line, and this one did not:
+# both interpreters below default to $(PYTHON), which was never set, so a bare
+# `make compile` ran the script as its own interpreter and got
+# "Permission denied" (exit 126). It worked under lit only because
+# programming_examples/lit.cfg.py exports PYTHON into the test environment.
+PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)
+
 # The interpreter that runs the model. It needs torch + lerobot (installed by
 # requirements.txt) AND air + pyxrt (from the sourced mlir-air environment) in
 # ONE process, which is what makes the in-process NPU path work. Defaults to


### PR DESCRIPTION
Raised in review on #1951/#1952, and correct.

`smolvla/Makefile` sets `LEROBOT_PYTHON ?= $(PYTHON)` and
`NPU_PYTHON ?= $(PYTHON)` but never defines `PYTHON`. All fifteen sibling
Makefiles under `llms/` carry
`PYTHON ?= $(if $(filter Windows_NT,$(OS)),python,python3)`; this one does not,
so the variable expands to nothing and make runs the script as its own
interpreter:

```
$ make compile
cd build &&  .../smolvla_inference.py --compile-only
/bin/sh: 1: .../smolvla_inference.py: Permission denied
make: *** [Makefile:81: compile] Error 126
```

## Why it was invisible

Three ways to not see it, and between them they cover everyone who has run this
recently:

- **lit** — `programming_examples/lit.cfg.py:60` does
  `config.environment["PYTHON"] = config.python_executable`, so all three
  smolvla `.lit` files work. The nightly runs through lit, which is why smolvla
  recorded `verify_status: pass` on 08-28.
- **an exported `PYTHON`** in the developer's shell.
- **an explicit override** — my own `make compile` check on #1951 passed
  `NPU_PYTHON=python3`, which is exactly the thing that hides this. That check
  was real but it did not test the path `docs/usage.md` documents.

So #1951 fixed the builder call but a clean `make compile` still could not reach
it.

## Verification

With `PYTHON` unset in the environment (`env -u PYTHON make compile`), against
`main` at 36ce5af9:

```
All 5 vision kernels compiled to .../build/vision_kernel_cache/
Compiled 5 ELFs: ['flash_attn', 'gemm_connector', 'layer_norm', 'vit_ln_qkv', 'vit_o_ffn']
Compilation passed.
```

Reproduced the failure first on the parent commit, same command.