### PR TITLE
[ci] Prune rolling wheel release assets to stay under GitHub's 1000-asset cap

### DIFF
--- a/.github/workflows/pruneAIRReleaseAssets.yml
+++ b/.github/workflows/pruneAIRReleaseAssets.yml
@@ -1,0 +1,127 @@
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+name: Prune AIR release assets
+
+on:
+  schedule:
+    # 09:43 UTC daily. buildAIRWheels.yml starts its nightly at 04:00 UTC and
+    # the wheel matrix takes hours, so this runs well clear of the upload step.
+    # Off-the-hour to avoid the GH Actions traffic spike.
+    - cron: '43 9 * * *'
+  workflow_dispatch:
+    inputs:
+      max_age_days:
+        description: 'Delete wheels older than this many days'
+        type: string
+        default: '30'
+      dry_run:
+        description: 'List what would be deleted without actually deleting'
+        type: boolean
+        default: true
+
+permissions:
+  contents: write
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  prune:
+    # Why: the rolling latest-air-wheels* releases accumulate indefinitely.
+    # Wheel names embed DATETIME+HASH (see buildAIRWheels.yml), so every nightly
+    # lands 8 net-new assets per tag that never collide with an existing name --
+    # `replacesArtifacts: true` on the release step is a no-op for them. At
+    # ~8 assets/day/tag we hit GitHub's hard 1000-asset-per-release cap in about
+    # four months. That already happened: both tags sat at exactly 1000 and
+    # every scheduled run from 2026-08-25 onward failed at upload until 300
+    # assets per tag were deleted by hand. This janitor keeps that from
+    # recurring, so the tag URLs baked into docs and downstream find-links pages
+    # stay stable instead of being rolled to latest-air-wheels-2.
+    runs-on: ubuntu-latest
+    steps:
+      - name: Prune assets older than ${{ inputs.max_age_days || '30' }} days
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          MAX_AGE_DAYS: ${{ inputs.max_age_days || '30' }}
+          # Scheduled runs prune for real; manual runs default to a dry run so
+          # the blast radius can be eyeballed before anything is destroyed.
+          DRY_RUN: ${{ github.event_name == 'schedule' && 'false' || inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          cutoff=$(date -u -d "${MAX_AGE_DAYS} days ago" +%s)
+          echo "cutoff: $(date -u -d "@$cutoff" --iso-8601=seconds)  dry_run=${DRY_RUN}"
+
+          total_deleted=0
+          total_seen=0
+
+          for TAG in latest-air-wheels latest-air-wheels-no-rtti; do
+            echo "::group::${TAG}"
+
+            # Skip the tag on any fetch failure rather than letting set -e kill
+            # the run. Bailing out is also the only safe response to a partial
+            # response: the keep-floor is computed from this list, so pruning
+            # against a truncated one could delete a variant's last wheel.
+            if ! gh api "repos/${REPO}/releases/tags/${TAG}" --paginate \
+              -q '.assets[] | "\(.created_at)\t\(.id)\t\(.name)"' | sort > /tmp/assets.tsv; then
+              echo "::warning::failed to list assets for ${TAG}, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+
+            count=$(wc -l < /tmp/assets.tsv)
+            if [ "$count" -eq 0 ]; then
+              echo "::warning::no assets found for ${TAG}, skipping"
+              echo "::endgroup::"
+              continue
+            fi
+            echo "total assets: ${count}"
+
+            # Keep-floor: never delete the newest asset for a given wheel
+            # variant, however old it is. A wheel's last three dash-separated
+            # fields are its python tag, ABI tag and platform
+            # (e.g. cp312-cp312-linux_x86_64.whl), which is exactly the tuple
+            # pip resolves against. Without this floor a quiet month would empty
+            # the release and 404 every `pip install mlir_air`: the nightly is
+            # skipped entirely when HEAD already matches the last released wheel
+            # (see the check-new-commits job), so "no uploads for 30 days" is a
+            # normal state, not a broken one. The floor also retains the final
+            # wheel of a variant that has been dropped from the build matrix
+            # (cp310), which keeps existing installs resolving rather than
+            # breaking them on a janitor's schedule.
+            awk -F'\t' '{n=split($3,f,"-"); print f[n-2]"-"f[n-1]"-"f[n]"\t"$1"\t"$2}' /tmp/assets.tsv \
+              | sort -t$'\t' -k1,1 -k2,2r \
+              | awk -F'\t' '!seen[$1]++ {print $3}' | sort > /tmp/protected.ids
+            echo "protected (newest per variant): $(wc -l < /tmp/protected.ids)"
+
+            deleted=0
+            kept_by_floor=0
+            while IFS=$'\t' read -r created_at id name; do
+              asset_ts=$(date -u -d "$created_at" +%s)
+              [ "$asset_ts" -lt "$cutoff" ] || continue
+
+              if grep -qxF "$id" /tmp/protected.ids; then
+                echo "keep (newest of its variant): $created_at $name"
+                kept_by_floor=$((kept_by_floor+1))
+                continue
+              fi
+
+              if [ "$DRY_RUN" = "true" ]; then
+                echo "would delete: $created_at $name"
+              else
+                gh api -X DELETE "repos/${REPO}/releases/assets/${id}" >/dev/null
+                echo "deleted: $created_at $name"
+              fi
+              deleted=$((deleted+1))
+            done < /tmp/assets.tsv
+
+            echo "${TAG}: ${deleted} of ${count} pruned, ${kept_by_floor} held by keep-floor"
+            total_deleted=$((total_deleted+deleted))
+            total_seen=$((total_seen+count))
+            echo "::endgroup::"
+          done
+
+          echo "::notice::pruned ${total_deleted} of ${total_seen} assets across both tags (dry_run=${DRY_RUN})"

--- a/.github/workflows/pruneAIRReleaseAssets.yml
+++ b/.github/workflows/pruneAIRReleaseAssets.yml
@@ -61,12 +61,21 @@ jobs:
           for TAG in latest-air-wheels latest-air-wheels-no-rtti; do
             echo "::group::${TAG}"
 
+            # Restrict to .whl. These releases carry nothing but wheels today,
+            # so this changes no current behaviour -- it bounds future
+            # behaviour. Anything else attached later (a checksum file, a
+            # tarball, release notes) is both outside this job's remit and
+            # unparseable by the keep-floor below, which derives its key from
+            # wheel filename fields; excluding non-wheels here means they can
+            # never be deleted and can never corrupt a wheel's key.
+            #
             # Skip the tag on any fetch failure rather than letting set -e kill
             # the run. Bailing out is also the only safe response to a partial
             # response: the keep-floor is computed from this list, so pruning
             # against a truncated one could delete a variant's last wheel.
             if ! gh api "repos/${REPO}/releases/tags/${TAG}" --paginate \
-              -q '.assets[] | "\(.created_at)\t\(.id)\t\(.name)"' | sort > /tmp/assets.tsv; then
+              -q '.assets[] | select(.name | endswith(".whl")) | "\(.created_at)\t\(.id)\t\(.name)"' \
+              | sort > /tmp/assets.tsv; then
               echo "::warning::failed to list assets for ${TAG}, skipping"
               echo "::endgroup::"
               continue
@@ -74,11 +83,11 @@ jobs:
 
             count=$(wc -l < /tmp/assets.tsv)
             if [ "$count" -eq 0 ]; then
-              echo "::warning::no assets found for ${TAG}, skipping"
+              echo "::warning::no wheel assets found for ${TAG}, skipping"
               echo "::endgroup::"
               continue
             fi
-            echo "total assets: ${count}"
+            echo "total wheel assets: ${count}"
 
             # Keep-floor: never delete the newest asset for a given wheel
             # variant, however old it is. A wheel's last three dash-separated


### PR DESCRIPTION
## Problem

Both rolling wheel releases are at GitHub's hard cap of 1000 assets per release:

| Tag | Assets before manual cleanup |
|---|---|
| `latest-air-wheels` | 1000 |
| `latest-air-wheels-no-rtti` | 1000 |

Wheel names embed `DATETIME+HASH`, so every nightly uploads 8 net-new assets per tag that never collide with an existing name — `replacesArtifacts: true` on the release step is a no-op for them. At that rate each tag fills in roughly four months.

This was not hypothetical: **every scheduled `buildAIRWheels` run from 2026-08-25 onward failed at the upload step**, so the published wheels went stale while `main` moved on. I deleted the 300 oldest assets per tag by hand to unblock the nightly, which buys about 37 days. This PR stops it recurring.

## Approach

A daily janitor pruning assets older than 30 days from both tags. Steady state is ~240 assets per tag.

The alternative — rolling to `latest-air-wheels-2`, as mlir-aie did with `latest-wheels-2/3/4` — was rejected because it breaks every published install URL: the release body in `buildAIRWheels.yml`, `docs/buildingRyzenLin.md`, `utils/build-mlir-air-using-wheels.sh`, and any downstream pinning the find-links page. Keeping the URL stable is the point of a rolling tag. mlir-aie's current answer is a janitor (`pruneReleaseAssets.yml`), which this ports.

### Differences from the mlir-aie workflow

- **Iterates both AIR tags** instead of a single hardcoded release.
- **Keep-floor** — the newest asset per `pytag-abitag-platform` variant is never deleted, however old. Pure age-based pruning would empty the release during a quiet month, because the nightly is skipped entirely when HEAD already matches the last released wheel (see the `check-new-commits` job), so "no uploads for 30 days" is a normal state rather than a broken one. It also preserves the last wheel of a variant dropped from the build matrix (currently cp310) instead of breaking existing installs on a janitor's schedule.
- **Manual dispatch defaults to a dry run**; only the schedule prunes for real.
- **A failed or partial asset listing skips that tag** rather than aborting under `set -e`. Bailing out is the only safe response to a truncated response, since the keep-floor is computed from that list and pruning against partial data could delete a variant's last wheel.

Cron is 09:43 UTC, well clear of the 04:00 UTC wheel build.

## Verification

The workflow's `run:` body was extracted from the YAML and executed against the live releases in dry-run mode, so this exercises the real script rather than a re-implementation. No assets were deleted by any of it.

| Check | Result |
|---|---|
| YAML parses | OK |
| Dry run, both live tags | 537/700 and 534/700 would prune |
| Keep-floor | correctly held back the 4 cp310 wheels (last built 2026-05-29) that a pure age prune would have deleted |
| Fault injection (bogus tag) | warns, skips, still processes the good tag, exit 0 |

## Note for the merger

Scheduled workflows only fire from the default branch, so this does nothing until merged — the ~37 days of headroom from the manual cleanup is the real deadline.

The first real run will prune ~1071 assets (the five-month backlog), taking both tags to ~165. That is correct, but it is worth one manual `workflow_dispatch` — which defaults to `dry_run: true` — to eyeball the list before the cron does it unattended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)