### PR TITLE
[flash_attention] Cap the causal triangle by shim descriptors, so the 8-round shapes build

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -159,9 +159,17 @@ def build_launch(
     # already does -- every round streams the full prefix, the in-core mask
     # discards the extra blocks, and the descriptors collapse back to one
     # because they are identical. It costs the causal DMA saving and it builds.
+    #
+    # `not causal` is the third way in, and it is a correctness one rather than
+    # a budget one: the prefix is only sound because the in-core mask discards
+    # what lies past the diagonal, and with no mask a round that streams
+    # (lx + 1) * NQ blocks simply does not see the rest of K. Non-causal
+    # attention has to read all of it.
     _kv_descriptors = num_lq_iters * num_heads_per_unroll * 2  # K and V
     _uniform_cps = (
-        num_lq_iters > _MAX_ROUNDS_IN_FLIGHT or _kv_descriptors > _SHIM_KV_DESCRIPTORS
+        not causal
+        or num_lq_iters > _MAX_ROUNDS_IN_FLIGHT
+        or _kv_descriptors > _SHIM_KV_DESCRIPTORS
     )
 
     def cps_blocks(lx):

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -77,6 +77,13 @@ M = 8  # mmul_m = mmul_k = mmul_n
 # size and which holds the work at (G+1)/2G of the square rather than at 1.0.
 _MAX_ROUNDS_IN_FLIGHT = 8
 
+# K/V shim descriptors the unrolled triangle may hold open at once. A shim tile
+# has 16 and the Q relay and output gather need the rest; 8 is what
+# llama32_1b_q4nx runs at (4 rounds, one kv-head per unroll) and 16 is what
+# llama32_3b failed to build at. Only reachable when the prefix VARIES -- a
+# uniform prefix emits one descriptor whatever the round count.
+_SHIM_KV_DESCRIPTORS = 8
+
 
 def build_launch(
     lk=512,
@@ -139,7 +146,23 @@ def build_launch(
     num_lq_iters = lq // lqp
     tile_size_q = lqp // num_q_tiles
     _merge_out_into_kv = num_lq_iters > 4
-    _uniform_cps = num_lq_iters > _MAX_ROUNDS_IN_FLIGHT
+    # A varying prefix is a varying transfer size, air.api needs sizes static,
+    # so the triangle costs one shim descriptor per round per kv-head rather
+    # than one for the whole loop. A shim tile holds 16 simultaneously-active
+    # BDs and the Q relay and output gather want their share, so past
+    # _SHIM_KV_DESCRIPTORS the K/V descriptors alone would exhaust it:
+    #
+    #   'aiex.dma_configure_task' op Too many simultaneously active buffer
+    #   descriptors on tile (0,0), which supports up to 16.
+    #
+    # Uniform is the documented way out and is what the round-count cap below
+    # already does -- every round streams the full prefix, the in-core mask
+    # discards the extra blocks, and the descriptors collapse back to one
+    # because they are identical. It costs the causal DMA saving and it builds.
+    _kv_descriptors = num_lq_iters * num_heads_per_unroll * 2  # K and V
+    _uniform_cps = (
+        num_lq_iters > _MAX_ROUNDS_IN_FLIGHT or _kv_descriptors > _SHIM_KV_DESCRIPTORS
+    )
 
     def cps_blocks(lx):
         """The round's causal prefix, in K blocks.


### PR DESCRIPTION
Fixes 8 of the 18 failures in last night's LLM perf nightly (run 33236790246).
The regression is mine, from #1950.

## What #1950 traded

#1950 gave each round its own causal prefix, fixing a producer/consumer desync.
A varying prefix is a varying transfer **size**, air.api needs sizes static, so
the round axis unrolls in Python — and each unrolled round costs its own K and V
descriptor on the shim. A shim tile holds 16:

```
air_project/npu.air.mlir:3711:13: error: 'aiex.dma_configure_task' op Too many
simultaneously active buffer descriptors on tile (0,0), which supports up to 16.
```

`llama32_1b_q4nx` is 4 rounds → 8 descriptors → fits. That is exactly the gate I
ran on #1950, and it is why this got through. `llama32_3b` and `phi4_mini_q4nx`
are 8 rounds at `lqp=256` → 16 → they do not build.

## Failures this explains

| test | signature |
|---|---|
| `llama32_3b` verify, profile | BD exhaustion |
| `llama32_3b_q4nx` profile | BD exhaustion |
| `phi4_mini_q4nx` verify, profile | BD exhaustion |
| `llama32_1b_q4nx` / `llama32_3b_q4nx` / `phi4_mini_q4nx` prefill_sweep | `"status": "bd_exhaustion"` at the longer lengths |

## The fix

Cap the unroll on the **descriptor budget** as well as the round count. Past it,
take the uniform prefix this file already documents and already used past
`_MAX_ROUNDS_IN_FLIGHT`: every round streams the whole prefix, the in-core mask
discards the extra blocks, and the per-round descriptors collapse back to one
because they become identical. Same answer, one descriptor, no causal DMA saving.

Capping on descriptors rather than rounds is what keeps the saving where it fits
— 8 K/V descriptors is what `llama32_1b_q4nx` runs at today, and it keeps the
triangle.

## Verification

Reproduced `llama32_3b`'s exact BD error standalone first, then:

| config | rounds | K/V descriptors | path | result |
|---|---:|---:|---|---|
| `lq=lk=1024` (the lit added in #1950) | 2 | 4 | triangle | **PASS!** |
| `llama32_1b_q4nx verify-paris` | 4 | 8 | triangle | **argmax 12366, PARIS** |
| `llama32_3b` / `phi4_mini` config | 8 | 16 → uniform | uniform | **Compilation complete** |

So the shapes that had the triangle keep it, and the shapes that could not build
now build.

## Not fixed here

The other 10 nightly failures are three unrelated causes still under
investigation: decode dispatch `ERT_CMD_STATE_TIMEOUT` at pos6 (`gemma3_4b_q4nx`,
`qwen3_4b_q4nx`), decode top-k numerics (`llama31_8b_q4nx`, `qwen25_7b_q4nx`,
`qwen25_3b_q4`), and `lfm2_1_2b_q4nx` profile. None of them is this.