### PR TITLE
[ci] Fetch chat_template.jinja with the LLM weights

### DIFF
--- a/.github/workflows/downloadLLMWeights.yml
+++ b/.github/workflows/downloadLLMWeights.yml
@@ -111,7 +111,13 @@ jobs:
 
           # Weight/config/tokenizer files only. (*.q4nx = the FastFlowLM Q4NX
           # bundle used by llama32_1b_q4nx.)
-          ALLOW = ["*.safetensors", "*.json", "*.txt", "*.model", "*.tiktoken", "*.q4nx"]
+          # *.jinja: newer HF repos ship the chat template as a separate
+          # chat_template.jinja instead of a "chat_template" key in
+          # tokenizer_config.json. Without it apply_chat_template raises
+          # "tokenizer.chat_template is not set", which is what fails
+          # lfm2_1_2b_q4nx profile -- LiquidAI/LFM2-1.2B has only the file.
+          ALLOW = ["*.safetensors", "*.json", "*.txt", "*.model", "*.tiktoken",
+                   "*.q4nx", "*.jinja"]
           # Skip files transformers/our loader never use but that otherwise make
           # snapshot_download report the snapshot "incomplete" if they fail to
           # fetch on the flaky link: the Llama `original/` dir (sentencepiece +


### PR DESCRIPTION
Fixes `lfm2_1_2b_q4nx/run_npu2_profile`, which has failed every nightly since
08-27:

```
ValueError: Cannot use chat template functions because tokenizer.chat_template
is not set and no template argument was passed!
```

Newer HF repos ship the chat template as a separate `chat_template.jinja`
instead of a `"chat_template"` key inside `tokenizer_config.json`.
`LiquidAI/LFM2-1.2B` has only the file. The prefetch allow-list is

```python
ALLOW = ["*.safetensors", "*.json", "*.txt", "*.model", "*.tiktoken", "*.q4nx"]
```

which matches no `.jinja`, so CI ends up with a tokenizer that has no template
at all and `apply_chat_template` raises. Nothing about the NPU, the kernels or
the model is involved.

## Scope

I checked every model in the local HF cache for which representation it uses.
**LFM2 is the only one that keeps the template solely in the file.**
`unsloth/gemma-3-4b-it` ships the `.jinja` *and* an inline copy, which is why it
has never failed this way — but it would silently start depending on the inline
copy alone, so fetching the file is right for it too.

## Verification

Ran the real download logic against the Hub, both pattern sets, into throwaway
cache dirs:

```
current ALLOW      chat_template.jinja fetched: False   (5 files)
ALLOW + "*.jinja"  chat_template.jinja fetched: True    (6 files)
```