### PR TITLE
[air.api] Let an explicit vector= outrank the 512-bit region cap

### DIFF
--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -534,7 +534,19 @@ def _cap_by_ops(width, dst, expr):
 
 
 def _nest_width(dst, expr):
-    """Lanes for one assignment: the destination's, capped by its widest region."""
+    """Lanes for one assignment: the destination's, capped.
+
+    A width the caller *derived* -- the dtype's default for the target -- is
+    capped by the widest region in the expression, so a widened default cannot
+    ask for a vector the backend will not legalize. A width the caller *named*
+    is a decision about this buffer and skips that cap: dequant_awq allocates
+    ``vector=64`` so its ``ops.bitcast`` assignment covers exactly one vector,
+    and narrowing it to 32 makes that two trips.
+
+    The op cap applies either way. It is about accuracy at a width nobody
+    measured rather than about legalization, so an explicit request does not
+    buy past it.
+    """
     width = dst.vector_width
     if width <= 0:
         return width

--- a/python/air/api/_emit.py
+++ b/python/air/api/_emit.py
@@ -538,7 +538,8 @@ def _nest_width(dst, expr):
     width = dst.vector_width
     if width <= 0:
         return width
-    width = _cap_by_regions(width, _regions_in(expr, dst.dtype, []))
+    if not getattr(dst, "vector_width_explicit", False):
+        width = _cap_by_regions(width, _regions_in(expr, dst.dtype, []))
     return _cap_by_ops(width, dst, expr)
 
 

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -1766,6 +1766,7 @@ def alloc(
         # Resolved here rather than in Buffer, which is deliberately independent
         # of the tracer and so has no way to ask what is being compiled for.
         vector_width=dtype.width_for(current_target()) if vector is None else vector,
+        vector_width_explicit=vector is not None,
         value=op.result,
         space=space,
     )

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -515,6 +515,7 @@ class Buffer(_Reshapable):
         vector_width=None,
         value=None,
         space="L1",
+        vector_width_explicit=False,
     ):
         self.shape = tuple(int(s) for s in shape)
         self.dtype = dtype
@@ -525,6 +526,14 @@ class Buffer(_Reshapable):
         self.vector_width = (
             dtype.default_vector_width if vector_width is None else int(vector_width)
         )
+        # Whether the CALLER named the width or took the dtype's default.
+        # air.alloc resolves the default before constructing, so this cannot be
+        # inferred from vector_width being None -- it has to be passed. The
+        # 512-bit region cap keeps a *widened default* legal; a width asked for
+        # explicitly is a decision about this buffer and outranks it.
+        # dequant_awq needs vector=64 so its ops.bitcast assignment covers
+        # exactly one vector, and capping it to 32 makes that two trips.
+        self.vector_width_explicit = bool(vector_width_explicit)
         # The memref SSA value produced by memref.alloc.
         self.value = value
         self.strides = _row_major_strides(self.shape)
@@ -693,6 +702,10 @@ class BufferSlice(_StridedView):
     @property
     def vector_width(self):
         return self.buffer.vector_width
+
+    @property
+    def vector_width_explicit(self):
+        return self.buffer.vector_width_explicit
 
     @property
     def base(self):


### PR DESCRIPTION
`buildAndTestRyzenAI` has been red on main since 073ec20a (#1957) and green at
f1ea06d7, the commit before it. Two tests fail:
`dequant_awq/run_makefile_peano_inline.lit` and `..._elf_inline.lit`. It also
blocks #1958 and #1959, whose only red check is this one.

## Cause

#1957 widened bf16 on npu2 and added a region cap so a widened **default** stays
legalizable. The cap runs unconditionally in `_nest_width`, so it also narrows a
width the caller named:

```python
width = dst.vector_width              # 64, as dequant_awq asked for
width = _cap_by_regions(width, ...)   # -> 512 // 16 = 32
```

`dequant_awq.py:119` allocates `vector=R_SUB` (64) precisely so its `ops.bitcast`
assignment covers exactly one vector. At 32 it is two trips and the emitter
refuses:

```
NotImplementedError: air.api.ops.bitcast reinterprets a run of memory, so the
assignment it appears in has to cover exactly one vector. This destination is
(64,) at a width of 32, which is 2 trips of the nest ...
```

#1957's blast-radius table lists `dequant_awq | PASS | PASS`; only the two
`--direct-codegen` lits fail, so that arm most likely ran the plain one.

## Fix

Skip the region cap when the width was named.

Two details worth stating, because both cost me a wrong first attempt:

- The flag **cannot** be inferred from `vector_width is None` inside `Buffer`.
  `air.alloc` resolves the default before constructing
  (`vector_width=dtype.width_for(current_target()) if vector is None else vector`),
  so it is always non-None by then. Inferring it there makes *every* buffer look
  explicit and silently disables the cap — which showed up as #1957's own
  `an_f32_region_caps_the_whole_nest` failing. The caller's intent is passed
  through instead.
- `BufferSlice` has to delegate it, as it already delegates `vector_width`: an
  assignment's destination is a slice of the buffer, not the buffer.

The **transcendental cap is untouched**. That one is about accuracy at a width
nobody measured, not about legalization, so it should keep applying either way.

## Verification

- `check-air-python`: **44 passed, 0 failed**, including #1957's `vector_width.py`
  — its `an_f32_region_caps_the_whole_nest` case takes the default and still caps
  to 16.
- `dequant_awq`, both variants on npu2: `--direct-codegen` **PASS!**, plain **PASS!**
  (reproduced the failure on the parent commit first).