### PR TITLE
[flash_attention] Fix the two head_dim > lkp breaks in the temporal kernel

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -115,11 +115,12 @@ def build_launch(
     # fa_temporal.py compiles that microkernel with dk_tile = dv_tile = head_dim
     # -- so a builder that chunks d disagrees with the kernel it calls, and the
     # Makefile says what that costs: "a mismatch here does not fail the build, it
-    # produces wrong results". Splitting d also puts dk_chunks puts from distinct
-    # memrefs on one channel per loop iteration, which air-opt-memtile-dma-bds
-    # cannot fold; it unrolls the whole causal prefix into the memtile BD chain
-    # instead (measured 175 BDs against a 48 cap). Capacity at head_dim > lkp
-    # comes from a smaller lkp (tile_size_q must stay == lkp), not from d.
+    # produces wrong results". Splitting d also lands dk_chunks separate puts,
+    # each from a distinct memref, on one channel per loop iteration, which
+    # air-opt-memtile-dma-bds cannot fold; it unrolls the whole causal prefix
+    # into the memtile BD chain instead (measured 175 BDs against a 48 cap).
+    # Capacity at head_dim > lkp comes from a smaller lkp (tile_size_q must
+    # stay == lkp), not from d.
     dk_tile = dk
     dv_tile = dv
     dk_chunks = 1

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -159,9 +159,17 @@ def build_launch(
     # already does -- every round streams the full prefix, the in-core mask
     # discards the extra blocks, and the descriptors collapse back to one
     # because they are identical. It costs the causal DMA saving and it builds.
+    #
+    # `not causal` is the third way in, and it is a correctness one rather than
+    # a budget one: the prefix is only sound because the in-core mask discards
+    # what lies past the diagonal, and with no mask a round that streams
+    # (lx + 1) * NQ blocks simply does not see the rest of K. Non-causal
+    # attention has to read all of it.
     _kv_descriptors = num_lq_iters * num_heads_per_unroll * 2  # K and V
     _uniform_cps = (
-        num_lq_iters > _MAX_ROUNDS_IN_FLIGHT or _kv_descriptors > _SHIM_KV_DESCRIPTORS
+        not causal
+        or num_lq_iters > _MAX_ROUNDS_IN_FLIGHT
+        or _kv_descriptors > _SHIM_KV_DESCRIPTORS
     )
 
     def cps_blocks(lx):

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -592,9 +592,17 @@ def build_launch(
                             every dv chunk, so one de-tiling view emits
                             row-major [tile_size_q, dv] for the whole slab.
                             """
+                            # dv // M FIRST: the slab is stored column-block-
+                            # major, so a dv block strides over every
+                            # tile_size_q block. Naming tile_size_q first
+                            # describes a row-block-major slab and emits the
+                            # right 4096 elements in the wrong order. The two
+                            # spellings coincide when tile_size_q == dv, which
+                            # is every shape shipping today (d=64, lkp=64) and
+                            # is why this survived.
                             packed = (
                                 gps_j[j]
-                                .reshape(tile_size_q // M, dv // M, M, M)
+                                .reshape(dv // M, tile_size_q // M, M, M)
                                 .transpose(1, 2, 0, 3)
                             )
 

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -77,6 +77,13 @@ M = 8  # mmul_m = mmul_k = mmul_n
 # size and which holds the work at (G+1)/2G of the square rather than at 1.0.
 _MAX_ROUNDS_IN_FLIGHT = 8
 
+# K/V shim descriptors the unrolled triangle may hold open at once. A shim tile
+# has 16 and the Q relay and output gather need the rest; 8 is what
+# llama32_1b_q4nx runs at (4 rounds, one kv-head per unroll) and 16 is what
+# llama32_3b failed to build at. Only reachable when the prefix VARIES -- a
+# uniform prefix emits one descriptor whatever the round count.
+_SHIM_KV_DESCRIPTORS = 8
+
 
 def build_launch(
     lk=512,
@@ -139,7 +146,23 @@ def build_launch(
     num_lq_iters = lq // lqp
     tile_size_q = lqp // num_q_tiles
     _merge_out_into_kv = num_lq_iters > 4
-    _uniform_cps = num_lq_iters > _MAX_ROUNDS_IN_FLIGHT
+    # A varying prefix is a varying transfer size, air.api needs sizes static,
+    # so the triangle costs one shim descriptor per round per kv-head rather
+    # than one for the whole loop. A shim tile holds 16 simultaneously-active
+    # BDs and the Q relay and output gather want their share, so past
+    # _SHIM_KV_DESCRIPTORS the K/V descriptors alone would exhaust it:
+    #
+    #   'aiex.dma_configure_task' op Too many simultaneously active buffer
+    #   descriptors on tile (0,0), which supports up to 16.
+    #
+    # Uniform is the documented way out and is what the round-count cap below
+    # already does -- every round streams the full prefix, the in-core mask
+    # discards the extra blocks, and the descriptors collapse back to one
+    # because they are identical. It costs the causal DMA saving and it builds.
+    _kv_descriptors = num_lq_iters * num_heads_per_unroll * 2  # K and V
+    _uniform_cps = (
+        num_lq_iters > _MAX_ROUNDS_IN_FLIGHT or _kv_descriptors > _SHIM_KV_DESCRIPTORS
+    )
 
     def cps_blocks(lx):
         """The round's causal prefix, in K blocks.

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_temporal_causal.py
@@ -110,10 +110,20 @@ def build_launch(
         lqp % num_q_tiles == 0
     ), f"lqp ({lqp}) must be divisible by num_q_tiles ({num_q_tiles})"
     assert lk % lkp == 0, f"lk ({lk}) must be divisible by lkp ({lkp})"
-    dk_tile = min(dk, lkp)
-    dv_tile = min(dv, lkp)
-    dk_chunks = dk // dk_tile
-    dv_chunks = dv // dv_tile
+    # d is NEVER split for this kernel, unlike attn_npu2 / seqfirst / npu1 which
+    # tile it at lkp. mmul walks d as k-blocks of 8 inside the microkernel, and
+    # fa_temporal.py compiles that microkernel with dk_tile = dv_tile = head_dim
+    # -- so a builder that chunks d disagrees with the kernel it calls, and the
+    # Makefile says what that costs: "a mismatch here does not fail the build, it
+    # produces wrong results". Splitting d also puts dk_chunks puts from distinct
+    # memrefs on one channel per loop iteration, which air-opt-memtile-dma-bds
+    # cannot fold; it unrolls the whole causal prefix into the memtile BD chain
+    # instead (measured 175 BDs against a 48 cap). Capacity at head_dim > lkp
+    # comes from a smaller lkp (tile_size_q must stay == lkp), not from d.
+    dk_tile = dk
+    dv_tile = dv
+    dk_chunks = 1
+    dv_chunks = 1
     if num_kv_heads is None:
         num_kv_heads = num_heads
     gqa_group_size = num_heads // num_kv_heads


### PR DESCRIPTION
**Stacked on #1958** — contains its two commits. Review that one first.

Found by following a reviewer's objection on #1958: `llama32_3b` verify fails
0/2 even once the build is fixed. That is a pre-existing #1944 break at
`head_dim > lkp`, not the descriptor cap. **Two independent defects**, both
invisible at the only shape anyone runs.

**Result: `llama32_3b` and `phi4_mini_q4nx` verify both go 0/2 -> PASS 2/2.**

## Defect 1 — the builder and the microkernel disagree about `d`

| | `dk_tile` | `dk_chunks` at d=128, lkp=32 |
|---|---|---|
| pre-#1944 | `dk`, chunks hardcoded to **1** | 1 |
| main | `min(dk, lkp)` | **4** |
| the microkernel, via `fa_temporal.py` and the Makefile's `IS_TEMPORAL` branch | `head_dim` | 1 |

#1944 gave this builder the convention the other three kernels use — but those
compile their `.o` with `dk_tile = lkp`, and this one compiles with the whole
`head_dim`. The Makefile is explicit: *"a mismatch here does not fail the build,
it produces wrong results."*

The predecessor hardcoded `dk_chunks = dv_chunks = 1` and said why: `mmul` walks
`d` as k-blocks of 8 inside the kernel, and chunking at the channel level
defeats BD folding (measured 175 BDs against a 48 cap). Capacity at
`head_dim > lkp` comes from a smaller `lkp`, not from splitting `d`.

## Defect 2 — the de-tiling view names its axes in storage order

`emit_out` reshapes the accumulator `tile_size_q`-blocks first, three lines
below a docstring stating the slab is **column-block-major**. That describes a
row-block-major slab: the descriptor covers the right 4096 elements in the wrong
order.

```
predecessor  [4, 8, 16, 8]  [64, 8, 256, 1]
before       [16, 8, 4, 8]  [64, 8, 1024, 1]
after        [4, 8, 16, 8]  [64, 8, 256, 1]     <- byte-identical again
```

## Why neither was ever caught

Both are no-ops when `tile_size_q == dv`. Defect 2 is literally the same
permutation there, and defect 1 needs `head_dim > lkp` to bite. Every shape that
ships today is d=64 at lkp=64, and `llama32_1b_q4nx` is the only model on this
kernel in CI — so the entire failing region is untested.

## Verification, on npu2, causal

| config | rounds / path | before | after |
|---|---|---|---|
| lkp=32, d=128, 24/8 (**llama32_3b's own**) | 8, uniform | 6288779 / 6291456 | **PASS**, mean_rel_L1 3.730e-02 |
| lkp=32, d=128, 24/8 | 4, triangle | 3145728 / 3145728 | **PASS** |
| lkp=64, d=64, 4/1 | 2, triangle | PASS | **PASS** |
| lkp=64, d=64, 4/1 | 5, uniform | PASS | **PASS** |

End to end:

- `llama32_3b make verify`: **`topk_passed: 2, topk_failed: 0`, PASS** (was 0/2)
- `phi4_mini_q4nx make verify` (same path, imports llama32_3b's
  `compile_all_kernels` / `use_temporal_fa` at head_dim=128):
  **`topk_passed: 2, topk_failed: 0`, PASS**
- `llama32_1b_q4nx make verify-paris`: **argmax 12366, PARIS** — unaffected

Control, same command and shapes with only the kernel file swapped: pre-#1944
PASSes at `mean_rel_L1 3.548e-02` where main is 100% wrong.

Both models the nightly reported under this cause now pass end to end.
