### PR TITLE
[fused_decode] Make round-to-nearest opt-in; it costs the big decodes accuracy

### DIFF
--- a/programming_examples/fused_decode/kernels/aie_kernel_utils.h
+++ b/programming_examples/fused_decode/kernels/aie_kernel_utils.h
@@ -210,8 +210,15 @@ void copy_bf16_to_bf16(bfloat16 *y, const bfloat16 *y_bf16) {
 // it. Call it FIRST in every extern "C" entry point -- the register is per
 // core, but a core runs whichever kernels its herd assigns, so relying on some
 // other entry point having set it is how one path silently keeps flooring.
+//
+// Opt-in per model via -DDECODE_ROUND_NEAREST: llama31_8b, qwen25_7b and
+// qwen25_3b score WORSE under round-to-nearest than under the power-up floor
+// (8B top-k gate: 5/5 flooring, 4/5 nearest), so the mode a model wants is a
+// property of that model, not of the kernels.
 static inline void aie_round_nearest_even() {
+#ifdef DECODE_ROUND_NEAREST
   ::aie::set_rounding(aie::rounding_mode::conv_even);
+#endif
 }
 
 #endif

--- a/programming_examples/fused_decode/kernels/aie_kernel_utils.h
+++ b/programming_examples/fused_decode/kernels/aie_kernel_utils.h
@@ -191,7 +191,15 @@ void copy_bf16_to_bf16(bfloat16 *y, const bfloat16 *y_bf16) {
   }
 }
 
-// Round-to-nearest-even for every accumulator narrowing in this core.
+// Round-to-nearest-even for every accumulator narrowing in this core, if the
+// model asked for it.
+//
+// NO-OP unless -DDECODE_ROUND_NEAREST. Without the flag this writes nothing and
+// the core keeps whatever mode it already has, which for a decode dispatch is
+// the power-up FLOOR -- so a model bringing up on the default is flooring every
+// accum->bf16 narrowing, by design. Read the two blocks below together: the
+// first is why nearest is the better mode, the last is why it is not the
+// default.
 //
 // An AIE core comes up with its rounding mode set to FLOOR (toward -inf), and
 // the mode is a core register that nothing else here writes -- so a kernel that
@@ -211,10 +219,11 @@ void copy_bf16_to_bf16(bfloat16 *y, const bfloat16 *y_bf16) {
 // core, but a core runs whichever kernels its herd assigns, so relying on some
 // other entry point having set it is how one path silently keeps flooring.
 //
-// Opt-in per model via -DDECODE_ROUND_NEAREST: llama31_8b, qwen25_7b and
-// qwen25_3b score WORSE under round-to-nearest than under the power-up floor
-// (8B top-k gate: 5/5 flooring, 4/5 nearest), so the mode a model wants is a
-// property of that model, not of the kernels.
+// Opt-in per model via -DDECODE_ROUND_NEAREST, and OFF by default, because
+// llama31_8b, qwen25_7b and qwen25_3b score WORSE under round-to-nearest than
+// under the power-up floor (8B top-k gate: 5/5 flooring, 4/5 nearest). The mode
+// a decode wants is a property of that model, not of the kernels. A new model
+// should measure both; if its gate moves, say which it picked in its Makefile.
 static inline void aie_round_nearest_even() {
 #ifdef DECODE_ROUND_NEAREST
   ::aie::set_rounding(aie::rounding_mode::conv_even);

--- a/programming_examples/llms/lfm2_1_2b_q4nx/Makefile
+++ b/programming_examples/llms/lfm2_1_2b_q4nx/Makefile
@@ -94,6 +94,9 @@ PEANO_KBASE := -std=c++20 --target=aie2p-none-unknown-elf \
   -DNDEBUG -DMODEL_TYPE=LFM2_1_2B -D__AIE_API_AIE_ADF_HPP__ \
   -I $(AIEOPT_DIR)/include -I $(DEC)/kernels -I $(DEC)/models \
   -DAIE_API_EMULATE_BFLOAT16_MMUL_WITH_BFP16
+# Round accum->bf16 to nearest instead of the power-up floor: this decode's
+# residual stream compounds the floor bias (cosine 0.876 -> 0.962).
+PEANO_KBASE += -DDECODE_ROUND_NEAREST
 # 4x-finer SiLU LUT (same [-8,8) range, 256 segments instead of 64). LFM2's
 # SwiGLU gate is p99 = 1.2 / max 4.1 across all 16 layers, so the shipped
 # 0.25-wide segments put almost the whole distribution in ~10 of 64 entries;


### PR DESCRIPTION
#1929 set round-to-nearest-even in every `fused_decode` kernel entry point, unconditionally. It is the right mode for LFM2-1.2B, whose residual stream compounds the power-up floor bias (decode cosine 0.876 → 0.962), but it is the wrong one for the larger q4nx decodes.

Measured on NPU2, forcing a kernel rebuild each time:

| model | flooring | round-to-nearest |
|---|---|---|
| llama31_8b_q4nx, top-k gate, 5 prompts | **5/5 PASS** | 4/5 FAIL |
| lfm2_1_2b_q4nx, top-k gate, 2 prompts | 2/2 PASS | 2/2 PASS |

`qwen25_7b_q4nx` and `qwen25_3b_q4` regressed with it too — those three are the nightly's `verify_status: fail` set since 08-27.

So the mode a decode wants is a property of the model, not of the kernels. This gates the call on `-DDECODE_ROUND_NEAREST`, the same way #1929's other half gates the finer SiLU LUT on `-DSILU_LUT_FINE`, and sets it for LFM2 only. Default-off is the configuration every model was green on before #1929. LFM2 keeps both its 2/2 gate and its 0.962 cosine; the LUT half of #1929 is untouched, and it is the half LFM2's token gate actually rides on (it passes 2/2 with the LUT and no rounding).

### Why this took a day to find

The decode kernels are cached `.o`/`.ll` and `compile-decode` skips when the templates are already present. #1929's own message says it — *"each picks the fix up when it next rebuilds"* — so the 08-26 nightly went green on pre-#1929 objects and the three models turned red the first night the runner rebuilt them. Source and artifact were a rebuild out of phase, which defeats a plain `git log` bisect: every arm has to `rm -f decode_L*.{xclbin,insts.bin} .decode_flags` first.

Bisect, all with a forced rebuild, classifying on prompt 1 step 1 of the 8B gate (token 20 = in HF's top-5, 2366 = not):

| arm | token | |
|---|---|---|
| `f66a370a` (parent of #1929) | 20 | GREEN, gate 2/2 |
| `980a8acc` (#1929) | 2366 | RED |
| `0655483d` (main) | 2366 | RED |
| main, the 38 calls commented out | 20 | GREEN |
| main + rounding, `DECODE_STACK=7680` | 2366 | RED |

Ruled out along the way: `transformers` version (HF top-5 byte-identical under 5.8.0 / 5.15.1 / 5.16.1), the FastFlowLM bundle (unchanged since 2026-08-04, and the local fingerprint matches CI's), the requant cache and every input to it, stack size, and Xilinx/mlir-aie#3625 (needs a stack larger than a bank; the 8B's is 8064 B).

### Not addressed here

Why round-to-nearest is worse for those three when it is the principled mode — either they were implicitly calibrated against the floor bias, or something in their path has a bias that flooring was cancelling. This restores the gates; that question deserves its own issue.

### Gates

- `lfm2_1_2b_q4nx` `make verify` **2/2 PASS** with the flag
- `llama31_8b_q4nx` top-k gate at 5 prompts **5/5 PASS** without it

🤖 Generated with [Claude Code](https://claude.com/claude-code)