### PR TITLE
[ci] List the Qwen2.5-3B Q4NX bundle the weight download never fetched

### DIFF
--- a/programming_examples/llms/hf_models.txt
+++ b/programming_examples/llms/hf_models.txt
@@ -60,9 +60,10 @@ Qwen/Qwen3-8B
 FastFlowLM/Qwen3-4B-NPU2
 
 # Same Q4NX packaging of Qwen2.5-3B-Instruct. Used by llms/qwen25_3b_q4, which
-# #1943 moved onto this bundle without listing it here -- so the offline nightly
-# raised OfflineModeIsEnabled before it reached the gate. Qwen/Qwen2.5-3B-Instruct
-# is already listed above and doubles as the bf16 reference `make verify` uses.
+# PR #1943 moved onto this bundle without listing it here -- so the offline
+# nightly raised OfflineModeIsEnabled before it reached the gate.
+# Qwen/Qwen2.5-3B-Instruct is already listed above and doubles as the bf16
+# reference `make verify` uses.
 FastFlowLM/Qwen2.5-3B-Instruct-NPU2
 
 # Qwen2.5-7B-Instruct is listed ONCE, not as a pair: FastFlowLM publishes no

--- a/programming_examples/llms/hf_models.txt
+++ b/programming_examples/llms/hf_models.txt
@@ -59,6 +59,12 @@ Qwen/Qwen3-8B
 # doubles as the reference `make verify` compares against.
 FastFlowLM/Qwen3-4B-NPU2
 
+# Same Q4NX packaging of Qwen2.5-3B-Instruct. Used by llms/qwen25_3b_q4, which
+# #1943 moved onto this bundle without listing it here -- so the offline nightly
+# raised OfflineModeIsEnabled before it reached the gate. Qwen/Qwen2.5-3B-Instruct
+# is already listed above and doubles as the bf16 reference `make verify` uses.
+FastFlowLM/Qwen2.5-3B-Instruct-NPU2
+
 # Qwen2.5-7B-Instruct is listed ONCE, not as a pair: FastFlowLM publishes no
 # Qwen2.5-7B bundle, so llms/qwen25_7b_q4nx quantizes this checkpoint to Q4NX on
 # load and `make verify` compares against the same repo in bf16. Ungated.


### PR DESCRIPTION
#1943 moved `llms/qwen25_3b_q4` onto `FastFlowLM/Qwen2.5-3B-Instruct-NPU2` but did not add the repo to `hf_models.txt`, so `downloadLLMWeights.yml` never caches it. The nightly runs with `HF_HUB_OFFLINE` set, so the model dies before it reaches its gate:

```
huggingface_hub.errors.OfflineModeIsEnabled: Cannot reach
https://huggingface.co/api/models/FastFlowLM/Qwen2.5-3B-Instruct-NPU2/revision/main:
offline mode is enabled.
```

That is why `qwen25_3b_q4` reports null `ttft_ms` / `decode_tokens_per_sec` in `perf.json` rather than a topk count — it is a missing-weights failure, not the decode numerics regression the other two models in that failure group have (#1962).

The existing `ALLOW` list already covers every file the bundle ships — `config.json`, `model.q4nx`, `tokenizer.json`, `tokenizer_config.json` — via `"*.q4nx"` and `"*.json"`, so listing the repo is the whole fix. Same class of bug as #1959.

Swept the rest of `llms/` for repeats: every other HF repo id referenced from a `.py` is listed. The only other unlisted id is the `lerobot/droid_100` dataset, reached exclusively by smolvla's `INPUT=real` path and never by a gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)