### PR TITLE
[flash_attention] Fix the de-tiling swap #1944 left in all three drains

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu1.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu1.py
@@ -442,7 +442,7 @@ def build_launch(
                                     div_gp_sp(sp_c, gp_c)
                                     gp2l2.put(
                                         gp_c.reshape(
-                                            tile_size_q // M, dv_tile // M, M, M
+                                            dv_tile // M, tile_size_q // M, M, M
                                         ).transpose(1, 2, 0, 3),
                                         indices=[tx, 0],
                                     )

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
@@ -527,7 +527,7 @@ def build_launch(
                                     div_gp_sp(sp_c, gp_c)
                                     gp2l2.put(
                                         gp_c.reshape(
-                                            tile_size_q // M, dv_tile // M, M, M
+                                            dv_tile // M, tile_size_q // M, M, M
                                         ).transpose(1, 2, 0, 3),
                                         indices=[tx, 0],
                                     )

--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_seqfirst.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2_seqfirst.py
@@ -545,7 +545,7 @@ def build_launch(
                                     div_gp_sp(sp_c, gp_c)
                                     gp2l2.put(
                                         gp_c.reshape(
-                                            tile_size_q // M, dv_tile // M, M, M
+                                            dv_tile // M, tile_size_q // M, M, M
                                         ).transpose(1, 2, 0, 3),
                                         indices=[tx, 0],
                                     )


### PR DESCRIPTION
`emit_out`'s drain in the builders #1944 migrated writes

```python
gp_c.reshape(tile_size_q // M, dv_tile // M, M, M).transpose(1, 2, 0, 3)
```

but the mmul C tile is **column-block-major**, so the first two extents are the wrong way round. The predecessors spelled the same put by hand as sizes `[tile_size_q/M, M, dv_tile/M, M]`, strides `[M*M, M, tile_size_q*M, 1]`; swapping the reshape's first two dims reproduces that exactly. This is the same defect #1961 fixed twice in the temporal sibling — same shape, same reason it hid.

It is a **no-op whenever `tile_size_q == dv_tile`**, and every shape in tree makes them equal:

| builder | why they coincide | status |
|---|---|---|
| `attn_npu2` (head-first) | `_FA_TILING` gives 64/64 at head_dim=128 | **LIVE** at head_dim=256 (gemma3): `lkp=32`, `dv_tile=128` |
| `attn_npu2_seqfirst` | `dv_tile = lkp`, and causal asserts `tile_size_q == lkp`; the one non-causal caller (smolvla) runs `lkp = head_dim = 64 = lqp/num_q_tiles` | latent |
| `attn_npu1` | same construction | latent |

Emitted at shapes where the extents differ, all three now reproduce their pre-#1944 put exactly:

| builder | main | fixed / pre-#1944 |
|---|---|---|
| head-first, head_dim=256 | `[16, 8, 4, 8] [64, 8, 1024, 1]` | `[4, 8, 16, 8] [64, 8, 256, 1]` |
| seq-first, non-causal | `[8, 8, 4, 8] [64, 8, 512, 1]` | `[4, 8, 8, 8] [64, 8, 256, 1]` |
| npu1, non-causal | `[16, 4, 8, 4] [16, 4, 256, 1]` | `[8, 4, 16, 4] [16, 4, 128, 1]` |

### How the live one was found

gemma3 was in the nightly's failing set and I had wrongly filed it with the #1929 rounding regression (#1962). It is not that: gemma3 **passed on the 08-28 nightly, which already had #1929**, so its window is 08-28 → 08-29. Swapping in the pre-#1944 `attn_npu2.py` on today's main takes it 0/2 → 2/2, which pinned #1944; the audit above then found the other two.

### Gates

- `gemma3_4b_q4nx` verify **0/2 → PASS 2/2** (on plain `main`, so independent of #1962)
- `llama32_3b_q4nx` (head_dim=128) still **PASS 2/2**; `llama32_1b_q4nx` verify-paris still argmax **12366**
- **Byte-identical modules** before and after at every shipping shape: head-first head_dim=128, seq-first causal, seq-first non-causal at smolvla's config, npu1 defaults. So llama31_8b, qwen25_7b, qwen3_4b, smolvla and the npu1 example cannot be affected.

### Worth a follow-up

Nothing gates `tile_size_q != dv_tile` anywhere, which is why the defect shipped in three files. A lit that builds each drain at such a shape and FileCheck's the `@Gp2L2` put would catch the whole class at PR time, with no hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
