### PR TITLE
[ci] Gate qwen25_3b_q4's verify/profile on the bundle they actually load

### DIFF
--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_profile.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_profile.lit
@@ -13,7 +13,7 @@
 // "Tokens/second: X" -- gen's human-readable "(X tok/s device-only)" line does
 // NOT parse, because TOKS_RE needs "tok/s" immediately before the paren.
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct, hfweights_fastflowlm_qwen2_5_3b_instruct_npu2
 //
 // RUN: mkdir -p test_peano_profile
 // RUN: cd test_peano_profile

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
@@ -4,9 +4,10 @@
 // Qwen2.5-3B Q4_0 verify gate: top-k token-level inclusion check, NPU q4 vs HF
 // bf16, 2 prompts x 32 greedy tokens, k=5 (use `make verify-full` for the full
 // sweep locally). Exercises the full production prefill + fused decode path
-// through the verify subsystem (verify/verify_runner.py); the NPU side is Q4_0
-// quantized from the HF checkpoint on the host, the reference is that same
-// checkpoint in bf16.
+// through the verify subsystem (verify/verify_runner.py); the NPU side reads
+// FastFlowLM's pre-quantized Q4_0 bundle (model.q4nx) directly -- #1943 stopped
+// it re-quantizing on the host -- and the reference is the HF bf16 checkpoint
+// that bundle was built from.
 //
 // This gate also covers what the old deterministic string check covered: the
 // decode runs 32 fused dispatches per prompt, so an under-primed fill lock (the

--- a/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
+++ b/programming_examples/llms/qwen25_3b_q4/run_npu2_verify.lit
@@ -18,7 +18,7 @@
 //
 // Skips cleanly when HF_TOKEN is unset (weight + tokenizer downloads need it).
 //
-// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct
+// REQUIRES: ryzen_ai_npu2, peano, llvm_link_pre23, hf_token, hfweights_qwen_qwen2_5_3b_instruct, hfweights_fastflowlm_qwen2_5_3b_instruct_npu2
 //
 // RUN: mkdir -p test_peano_verify
 // RUN: cd test_peano_verify


### PR DESCRIPTION
Follow-up to #1963, from tonight's nightly (run 33342856621 on `b9c04174`).

#1943 moved `llms/qwen25_3b_q4` onto `FastFlowLM/Qwen2.5-3B-Instruct-NPU2` but left `REQUIRES` naming only the bf16 reference (`hfweights_qwen_qwen2_5_3b_instruct`). So when the bundle is not in the runner's HF cache the tests **fail** with `OfflineModeIsEnabled` instead of skipping. Every sibling gates on both:

| example | REQUIRES |
|---|---|
| `qwen3_4b_q4nx` | `hfweights_fastflowlm_qwen3_4b_npu2, hfweights_qwen_qwen3_4b` |
| `gemma3_4b_q4nx` | `hfweights_fastflowlm_gemma3_4b_npu2, hfweights_unsloth_gemma_3_4b_it` |
| `llama32_3b_q4nx` | `hfweights_meta_llama_llama_3_2_3b_instruct, hfweights_fastflowlm_llama_3_2_3b_npu2` |
| `qwen25_3b_q4` | reference only ← |

#1963 listed the repo for `downloadLLMWeights.yml`, which is what actually puts the bundle in the cache — but that workflow is `workflow_dispatch`-only and last ran 2026-08-26, so the nightly still saw no bundle tonight and `qwen25_3b_q4` failed identically. **#1963 needs the download workflow dispatched to take effect**; this PR is the other half, so that a missing bundle is an honest skip rather than a red test.

Not added to `run_npu2_compile_decode.lit` or `run_npu2_sweep.lit` — both state they need no HF weights, and gating them would cut coverage for nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)