### PR TITLE
[flash_attention] Gate the drain de-tiling at tile_size_q != dv_tile

### DIFF
--- a/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
+++ b/programming_examples/flash_attention/kernel_fusion_based/attn_npu2.py
@@ -614,6 +614,7 @@ def parse_args():
     parser.add_argument("--lkp", type=int, default=64)
     parser.add_argument("--lq", type=int, default=512)
     parser.add_argument("--lqp", type=int, default=256)
+    parser.add_argument("--num-q-tiles", type=int, default=4)
     parser.add_argument("--dk", type=int, default=64)
     parser.add_argument("--dv", type=int, default=64)
     parser.add_argument("--num-cascade-stages", type=int, default=4)
@@ -645,7 +646,7 @@ def main():
 
     lk, lkp, lq, lqp = args.lk, args.lkp, args.lq, args.lqp
     dk, dv = args.dk, args.dv
-    num_q_tiles = 4
+    num_q_tiles = args.num_q_tiles
     num_heads = args.num_heads
     num_kv_heads = args.num_kv_heads if args.num_kv_heads is not None else num_heads
     causal = args.causal

--- a/programming_examples/flash_attention/kernel_fusion_based/run_detile_shape.lit
+++ b/programming_examples/flash_attention/kernel_fusion_based/run_detile_shape.lit
@@ -1,0 +1,17 @@
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+// Guards the drain's de-tiling view at a shape where tile_size_q != dv_tile.
+// The C slab is column-block-major, so the first two extents of the reshape are
+// [dv_tile/M, tile_size_q/M]; swapping them is a no-op at every shape that ships
+// except head_dim=256 (gemma3-4b), which is how the swap reached main twice --
+// #1961 and #1964. IR only, no device.
+//
+// head_dim=256's fa_headfirst tiling: lkp=32, lqp=256, num_q_tiles=8 (so
+// tile_size_q=32), dv_tile=128.
+//
+// RUN: %PYTHON %S/attn_npu2.py -p --lk 256 --lq 256 --lkp 32 --lqp 256 \
+// RUN:   --num-q-tiles 8 --dk 256 --dv 256 --dv-tile 128 --num-heads 1 \
+// RUN:   --num-kv-heads 1 --num-heads-per-unroll 1 --causal | FileCheck %s
+//
+// CHECK: air.channel.put {{.*}}@Gp2L2{{.*}}[4, 8, 16, 8] [64, 8, 256, 1]


### PR DESCRIPTION
The drain's de-tiling `reshape(dv_tile // M, tile_size_q // M, M, M)` is a no-op
whenever those two extents are equal, which is every shape that ships except
head_dim=256. That is how the swapped version reached main twice -- #1961 fixed
it in `attn_npu2_temporal_causal.py`, #1964 in the other three drains -- with a
green CI both times.

Nothing in the suite emits the asymmetric shape without a device: gemma3-4b is
the only model at head_dim=256, and its lit builds and runs the whole decode.

This adds an IR-only lit that emits `attn_npu2.py` at `fa_headfirst`'s
head_dim=256 tiling (lkp=32, lqp=256, num_q_tiles=8 so tile_size_q=32,
dv_tile=128) and FileChecks the `@Gp2L2` put:

    [4, 8, 16, 8] [64, 8, 256, 1]

Reaching that tiling from the CLI needs `num_q_tiles`, which `main()` hardcoded
to 4; it becomes `--num-q-tiles` with the same default, so no existing
invocation changes.

Verified both ways: passes on main, fails with the pre-#1964 reshape restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)