### PR TITLE
[fused_decode] Re-pin the q broadcast memtile; #1928 unpinned it and qwen3-4b hangs

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -433,12 +433,44 @@ jobs:
             exit 1
           fi
           LLVM_AIE_VERSION=$(python3 -m pip show llvm-aie | awk '/^Version:/{print $2}')
+          # Runtime provenance under the pinned compilers: a decode hang that
+          # only ever reproduces on this runner is unattributable after the fact
+          # without it. Best effort -- a missing xrt-smi just leaves the fields out.
+          xrt-smi examine > xrt_examine.txt 2>/dev/null || true
           mkdir -p perf_out
           python3 - "$MLIR_AIE_HASH" "$LLVM_AIE_VERSION" "${{ github.sha }}" <<'PY'
-          import datetime, glob, json, os, re, shutil, sys
+          import datetime, glob, json, os, platform, re, shutil, sys
           import xml.etree.ElementTree as ET
 
           aie_hash, peano_ver, air_sha = sys.argv[1], sys.argv[2], sys.argv[3]
+
+          def runtime_fields():
+              out = {"kernel": platform.release()}
+              try:
+                  txt = open("xrt_examine.txt").read()
+              except OSError:
+                  return out
+              # "Version"/"Hash" repeat per section, so read them out of the XRT
+              # block only; the rest are unique enough to match anywhere.
+              xrt = re.search(r"^XRT\n(.*?)(?:\n\S|\Z)", txt, re.M | re.S)
+              for key, pat, where in (
+                  ("xrt_version", r"^\s*Version\s*:\s*(\S+)", xrt),
+                  ("xrt_hash", r"^\s*Hash\s*:\s*(\S+)", xrt),
+                  ("amdxdna_version", r"amdxdna Version\s*:\s*([^\s,]+)", None),
+                  ("npu_firmware", r"NPU Firmware Version\s*:\s*(\S+)", None),
+              ):
+                  hay = txt if where is None else (where.group(1) if where else "")
+                  m = re.search(pat, hay, re.M)
+                  if m:
+                      out[key] = m.group(1)
+              return out
+
+          TOOLCHAIN = {
+              "mlir_air_sha": air_sha,
+              "mlir_aie_hash": aie_hash,
+              "llvm_aie_version": peano_ver,
+              **runtime_fields(),
+          }
 
           # Per-model verify status from the verify xunit output. A model may
           # contribute several run_npu2_verify* lits (e.g. int4 ships a skipped
@@ -478,11 +510,7 @@ jobs:
                   print(f"WARNING: {f} unreadable ({e}); recording as failed", file=sys.stderr)
                   continue
               d["runner"] = "amdryzenai5pro340"
-              d["toolchain"] = {
-                  "mlir_air_sha": air_sha,
-                  "mlir_aie_hash": aie_hash,
-                  "llvm_aie_version": peano_ver,
-              }
+              d["toolchain"] = dict(TOOLCHAIN)
               d["verify_status"] = vstatus.get(d["model"], "")
               recs.append(d)
               prof = os.path.join(os.path.dirname(f), "profile.txt")
@@ -514,11 +542,7 @@ jobs:
                       "decode_tokens_per_sec": None,
                       "context_len": None,
                   },
-                  "toolchain": {
-                      "mlir_air_sha": air_sha,
-                      "mlir_aie_hash": aie_hash,
-                      "llvm_aie_version": peano_ver,
-                  },
+                  "toolchain": dict(TOOLCHAIN),
                   "run_params": {"n_tokens": None, "prompt": None},
               })
 
@@ -535,11 +559,7 @@ jobs:
           for f in sorted(glob.glob("build_assert/test/llms/**/*.sweep.json", recursive=True)):
               d = json.load(open(f))
               d["runner"] = "amdryzenai5pro340"
-              d["toolchain"] = {
-                  "mlir_air_sha": air_sha,
-                  "mlir_aie_hash": aie_hash,
-                  "llvm_aie_version": peano_ver,
-              }
+              d["toolchain"] = dict(TOOLCHAIN)
               d["verify_status"] = vstatus.get(d["model"], "")
               sweeps.append(d)
           sweeps.sort(key=lambda r: r["model"])
@@ -560,11 +580,7 @@ jobs:
                   print(f"WARNING: {f} unreadable ({e}); skipping", file=sys.stderr)
                   continue
               d["runner"] = "amdryzenai5pro340"
-              d["toolchain"] = {
-                  "mlir_air_sha": air_sha,
-                  "mlir_aie_hash": aie_hash,
-                  "llvm_aie_version": peano_ver,
-              }
+              d["toolchain"] = dict(TOOLCHAIN)
               d["verify_status"] = vstatus.get(d["model"], "")
               pf.append(d)
           pf.sort(key=lambda r: r["model"])

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -3574,8 +3574,12 @@ def build_module():
                         # fan out per-CU 512 reordered (pack_q [8,8,8]/[8,64,1]).
                         def _qmtb_dec():
                             qmtb = AllocOp(qmt_l2, [], [])
-                            # Column is compiler-derived (lands on the reference
-                            # mem_5_1); only the split opt-out is load-bearing.
+                            # Pinned: the derived column is template-length
+                            # dependent (qwen3-4b at ATTN_MAXL=128 lands on
+                            # mem_2_1, and that build times out on NPU2).
+                            qmtb.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), 5)
+                            )
                             qmtb.operation.attributes["air.no_split"] = UnitAttr.get()
                             ChannelGet("ropeQ", qmtb, indices=[idx(0)])
                             for c in range(N_ATTN_CU):


### PR DESCRIPTION
Fixes the `qwen3_4b_q4nx` nightly failure: `RuntimeError: decode dispatch pos6
state=ert_cmd_state.ERT_CMD_STATE_TIMEOUT` (pos24 in profile, plus 6
`xrt_incomplete` points in `sweep.json`). Red every night since 2026-08-28.

#1928 dropped the `air.memtile_col` pin on the q broadcast L2 buffer, on the
grounds that the column-affinity derivation lands it on the same `mem_5_1`
anyway -- verified byte-identical on llama-3.2-1b, llama-3.2-3b and gemma3-4b.
qwen3-4b already existed and was not in that list, and it is the model the
premise fails on.

### Bisect

The 08-27 -> 08-28 window contained two artifact-moving commits, #1928 and
#1929 (rounding). #1962 made #1929's rounding opt-in, so the nightly after it
dispatched an artifact without the rounding -- and qwen3-4b still hung, which
left #1928. Within #1928's five sub-changes, the q pin is the whole delta:

| variant | `decode_L128.xclbin` | |
|---|---:|---|
| pin restored | **171966** | the artifact the 08-27 nightly passed on |
| main | 171854 | the artifact that times out |
| pin restored | 171966 | A/B/A |

`insts.bin` is byte-identical throughout (md5 `e46990f81d58`); the delta is
entirely PDI. The placed IR differs by exactly the one attribute, and the AIE IR
shows what it buys: with the pin the `memref<4096xbf16, 1>` q buffer is on
`mem_tile_5_1`, without it on `mem_tile_2_1`, whose lock count goes 9 -> 15.

### Blast radius

The byte-identity #1928 measured holds at L2048 but not at the length CI builds.
At `LBUILD=128` the pin also moves gemma3-4b (164766 -> 164974) and llama32-3b
(166238 -> 166478). Both passed the 08-27 nightly with the pin, so this returns
all three to a placement that was green rather than to an untested one.

`air.no_split` stays: with the pin, `air-split-l2-memref` skips the alloc
anyway, but it is the load-bearing half and should not depend on that. The other
two pins #1928 dropped (the per-CU K/V staging buffers) are NOT restored -- they
sit on the non-MULTIBLK path, which no shipping model takes, and they are
genuinely inert.

### What is not proven

qwen3-4b passes on this box at every config tried, including CI's exact
`LBUILD=128`, so the hang itself is not reproducible here and the causal step
from "wrong column" to "timeout" is inferred, not observed. What is measured is
that this restores the exact artifact the model last passed on. The next nightly
is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)