### PR TITLE
[fused_decode] Re-pin the q broadcast memtile; #1928 unpinned it and qwen3-4b hangs

### DIFF
--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -3574,8 +3574,12 @@ def build_module():
                         # fan out per-CU 512 reordered (pack_q [8,8,8]/[8,64,1]).
                         def _qmtb_dec():
                             qmtb = AllocOp(qmt_l2, [], [])
-                            # Column is compiler-derived (lands on the reference
-                            # mem_5_1); only the split opt-out is load-bearing.
+                            # Pinned: the derived column is template-length
+                            # dependent (qwen3-4b at ATTN_MAXL=128 lands on
+                            # mem_2_1, and that build times out on NPU2).
+                            qmtb.operation.attributes["air.memtile_col"] = (
+                                IntegerAttr.get(T.i32(), 5)
+                            )
                             qmtb.operation.attributes["air.no_split"] = UnitAttr.get()
                             ChannelGet("ropeQ", qmtb, indices=[idx(0)])
                             for c in range(N_ATTN_CU):


### PR DESCRIPTION
Replaces #1968, which was branched off an unrelated branch and carried a second
commit. This one is the single-line change only.

Fixes the `qwen3_4b_q4nx` nightly failure: `RuntimeError: decode dispatch pos6
state=ert_cmd_state.ERT_CMD_STATE_TIMEOUT` (pos24 in profile, plus 6
`xrt_incomplete` points in `sweep.json`). Red every night since 2026-08-28.

#1928 dropped the `air.memtile_col` pin on the q broadcast L2 buffer, on the
grounds that the column-affinity derivation lands it on the same `mem_5_1`
anyway -- verified byte-identical on llama-3.2-1b, llama-3.2-3b and gemma3-4b.
qwen3-4b already existed and was not in that list, and it is the model the
premise fails on.

### Bisect

The 08-27 -> 08-28 window contained two artifact-moving commits, #1928 and
#1929 (rounding). #1962 made #1929's rounding opt-in, so the nightly after it
dispatched an artifact without the rounding -- and qwen3-4b still hung, which
left #1928. Within #1928's five sub-changes, the q pin is the whole delta:

| variant | `decode_L128.xclbin` | |
|---|---:|---|
| pin restored | **171966** | the artifact the 08-27 nightly passed on |
| main | 171854 | the artifact that times out |
| pin restored | 171966 | A/B/A |

`insts.bin` is byte-identical throughout (md5 `e46990f81d58`); the delta is
entirely PDI. The placed IR differs by exactly the one attribute, and the AIE IR
shows what it buys: with the pin the `memref<4096xbf16, 1>` q buffer is on
`mem_tile_5_1`, without it on `mem_tile_2_1`, whose lock count goes 9 -> 15.

### Blast radius

The byte-identity #1928 measured holds at L2048 but not at the length CI builds.
At `LBUILD=128` the pin also moves gemma3-4b (164766 -> 164974) and llama32-3b
(166238 -> 166478). Both passed the 08-27 nightly with the pin, so this returns
all three to a placement that was green rather than to an untested one.

`air.no_split` stays: with the pin, `air-split-l2-memref` skips the alloc
anyway, but it is the load-bearing half and should not depend on that. The other
two pins #1928 dropped (the per-CU K/V staging buffers) are NOT restored -- they
sit on the non-MULTIBLK path, which no shipping model takes, and they are
genuinely inert.

### What is not proven

qwen3-4b passes on this box at every config tried, including CI's exact
`LBUILD=128`, so the hang itself is not reproducible here and the causal step
from "wrong column" to "timeout" is inferred, not observed. What is measured is
that this restores the exact artifact the model last passed on. The next nightly
is the test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)