### PR TITLE
[air.backend] Recognize Gorgon Point as npu2

### DIFF
--- a/programming_examples/lit.cfg.py
+++ b/programming_examples/lit.cfg.py
@@ -123,7 +123,15 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         # aligned with mlir-aie's hostruntime.py and the AIR XRT backend
         # (NPU_MODELS). Robust to xrt-smi table-format changes and covers newer
         # parts (Strix Halo, Krackan) that the old strict regex missed.
-        npu2_models = ["npu4", "strix", "npu5", "strix halo", "npu6", "krackan"]
+        npu2_models = [
+            "npu4",
+            "strix",
+            "npu5",
+            "strix halo",
+            "npu6",
+            "krackan",
+            "gorgon point",
+        ]
         npu1_models = ["npu1", "phoenix"]
         # Serializing through flock and run_on_npu.sh is POSIX-only: flock is
         # util-linux, and the script is bash that sources

--- a/python/air/backend/xrt.py
+++ b/python/air/backend/xrt.py
@@ -29,7 +29,15 @@ from ml_dtypes import bfloat16
 # Maps generation name to list of model strings that may appear in xrt-smi
 NPU_MODELS = {
     "npu1": ["npu1", "Phoenix"],
-    "npu2": ["npu4", "Strix", "npu5", "Strix Halo", "npu6", "Krackan"],
+    "npu2": [
+        "npu4",
+        "Strix",
+        "npu5",
+        "Strix Halo",
+        "npu6",
+        "Krackan",
+        "Gorgon Point",
+    ],
 }
 
 

--- a/test/lit.cfg.py
+++ b/test/lit.cfg.py
@@ -148,7 +148,15 @@ if config.xrt_lib_dir and config.enable_run_xrt_tests:
         # replaces predated Strix Halo and Krackan, so those parts fell to the
         # "unknown model" branch: `ryzen_ai_npu2` was never added and every
         # test gated on it reported UNSUPPORTED on hardware that can run it.
-        npu2_models = ["npu4", "strix", "npu5", "strix halo", "npu6", "krackan"]
+        npu2_models = [
+            "npu4",
+            "strix",
+            "npu5",
+            "strix halo",
+            "npu6",
+            "krackan",
+            "gorgon point",
+        ]
         npu1_models = ["npu1", "phoenix"]
         # Serializing through flock and run_on_npu.sh is POSIX-only: flock is
         # util-linux, and the script is bash that sources


### PR DESCRIPTION
## Problem

`xrt-smi` reports this part as `NPU Gorgon Point 1`, which contains none of the npu2 keywords, so the model list falls through. The list is duplicated in three places, kept in sync only by a comment, and all three miss it:

    python/air/backend/xrt.py        NPU_MODELS -> detect_target_device()
    test/lit.cfg.py                  npu2_models
    programming_examples/lit.cfg.py  npu2_models

They fail differently, which is why fixing one would not be enough:

- `detect_target_device()` falls back to npu1, and its own docstring names the consequence -- an `aie.device(npu1)` binary loads on npu2 without error and computes nothing.
- The lit configs take the "no recognized model" branch instead, so neither `ryzen_ai` nor `ryzen_ai_npu2` is added and **every NPU test reports UNSUPPORTED**. That is the same outcome those files' own comments record having already fixed once for Strix Halo and Krackan.

The silicon is npu2. This box is `1022:17f0 rev 10`, which `amdxdna_pci_drv.c` maps to `dev_npu4_info` -- already in the list as `npu4`/`Strix`. Only the marketing name is unmatched.

## Fix

Add the Gorgon Point name to all three lists, mirroring the same addition in mlir-aie's `hostruntime.py`, which the comments above each list already name as the alignment target.

## Test

Verified on the part against this box's real `xrt-smi` output, using the pre-patch lists as controls rather than by inspection:

- `detect_target_device()`: npu1 -> npu2 (the pre-patch arm also prints its own fallback warning)
- lit match: UNKNOWN -> npu2

`black` clean on all three files.

## Known limitation

The three lists remain duplicated. Having the lit configs import the backend's list instead of re-declaring it is the durable fix; it is a larger change than this one and I have kept it out of scope.