### PR TITLE
[fused_decode] Check ATTN_SCALE against 1/sqrt(DH)

### DIFF
--- a/programming_examples/fused_decode/kernels/model_spec.h
+++ b/programming_examples/fused_decode/kernels/model_spec.h
@@ -31,6 +31,23 @@ static_assert(
     "assume a DH-wide cos/sin LUT; make them ROPE_DIM-relative first");
 #endif
 
+// Attention scale. Every model here sets ATTN_SCALE to 1/sqrt(DH), but the two
+// are different quantities: Gemma scales by 1/sqrt(query_pre_attn_scalar), which
+// equals the head dim in the configs carried here and need not in general
+// (gemma-3-27b: 168 against a head dim of 128). So the model header stays
+// authoritative and this only catches a value copied from a neighbour with a
+// different head dim -- which has no runtime symptom, because a wrong scale
+// still produces plausible logits. Written squared to keep it a constant
+// expression; sqrt is not constexpr. A model that genuinely scales by something
+// else defines ATTN_SCALE_NOT_INV_SQRT_DH.
+#ifndef ATTN_SCALE_NOT_INV_SQRT_DH
+static_assert(ATTN_SCALE * ATTN_SCALE * DH > 0.999f &&
+                  ATTN_SCALE * ATTN_SCALE * DH < 1.001f,
+              "ATTN_SCALE is not 1/sqrt(DH) for this model; if that is "
+              "deliberate (a Gemma-style query_pre_attn_scalar differing from "
+              "the head dim), define ATTN_SCALE_NOT_INV_SQRT_DH");
+#endif
+
 constexpr int DQ = NUM_ATTN_HEADS * DH;
 constexpr int DK = NUM_KV_HEADS * DH;
 constexpr int DV = DK;

--- a/programming_examples/fused_decode/kernels/model_spec.h
+++ b/programming_examples/fused_decode/kernels/model_spec.h
@@ -32,8 +32,8 @@ static_assert(
 #endif
 
 // Attention scale. Every model here sets ATTN_SCALE to 1/sqrt(DH), but the two
-// are different quantities: Gemma scales by 1/sqrt(query_pre_attn_scalar), which
-// equals the head dim in the configs carried here and need not in general
+// are different quantities: Gemma scales by 1/sqrt(query_pre_attn_scalar),
+// which equals the head dim in the configs carried here and need not in general
 // (gemma-3-27b: 168 against a head dim of 128). So the model header stays
 // authoritative and this only catches a value copied from a neighbour with a
 // different head dim -- which has no runtime symptom, because a wrong scale


### PR DESCRIPTION
## Problem

`ATTN_SCALE` is a hand-written float in each `models/<model>.h`. A value copied from a neighbour with a different head dim has no runtime symptom -- a wrong attention scale still produces plausible logits, so nothing downstream flags it.

`GLU_SLICE` already has this guard (`glu.cc`'s `GLU_SLICE_EXPECTED`, fed from the builder via the `FUSED_DECODE_PRINT_CONST` hook). This is the same failure class one file over.

## Fix

A `static_assert` in `model_spec.h` that rejects a scale disagreeing with `1/sqrt(DH)`.

Deliberately *not* a rewrite of `ATTN_SCALE` as `1/sqrt(DH)`. Gemma scales by `1/sqrt(query_pre_attn_scalar)`, which equals the head dim in the configs carried here but need not in general -- gemma-3-27b is 168 against a head dim of 128. So the model header stays authoritative, and a model that genuinely differs defines `ATTN_SCALE_NOT_INV_SQRT_DH`. Written in squared form because `sqrt` is not `constexpr`.

This follows `model_spec.h`'s own `ROPE_DIM` idiom: derived default, named reason, `static_assert`, documented opt-out.

## Test

Verified in both directions rather than only compiled, with Peano (`--target=aie2p-none-unknown-elf`) and the Makefile's own `PEANO_KBASE` flags, compiling `model_spec.h` once per `MODEL_TYPE`:

- **10/10 shipped model headers compile.**
- The bug is **caught**: pasting llama3.2-1b's DH=64 scale into qwen3-4b (DH=128) fails with the intended diagnostic. Run on a copy of the tree, so the worktree was never modified.
- **Model-scoped, not a blanket break**: in that same corrupted tree an unaffected model still compiles.
- It survives `-DNDEBUG`, since `static_assert` is a compile-time construct rather than an `assert`.