### PR TITLE
[air-runner] Price an execute region by what computes; let herds contend

### DIFF
--- a/mlir/lib/Util/Runner.cpp
+++ b/mlir/lib/Util/Runner.cpp
@@ -182,7 +182,20 @@ public:
     if (link_latency)
       *link_latency = 0;
 
-    if (type == "wait_all") {
+    if (name == "ReshapeOp") {
+      // memref.expand_shape / collapse_shape / reshape are metadata: they
+      // change how a buffer is indexed and lower to no instructions, so they
+      // cost nothing.
+      //
+      // This is not separable from the region pricing below. A metadata child
+      // gets its own vertex, and that vertex's op is the ENCLOSING region --
+      // so pricing it the way a region is priced charges the region's compute
+      // once per reshape. Twenty-one reshapes ahead of one 200-cycle matvec
+      // come to 21 x 210 cycles that way. The old front()-based pricing
+      // happened to return the reshape itself and fall through to the default
+      // of one cycle, which hid the problem without addressing it.
+      execution_time = 0;
+    } else if (type == "wait_all") {
       execution_time = 1;
     } else if (type == "dma") {
       auto Op = mlir::dyn_cast_if_present<xilinx::air::DmaMemcpyNdOp>(c.op);
@@ -235,7 +248,7 @@ public:
             << "Has 'execute' as event type, but op isn't of type "
                "air::ExecuteOp";
       auto child_op =
-          &dyn_cast_if_present<air::ExecuteOp>(c.op).getChildOps().front();
+          getPricedChildOp(dyn_cast_if_present<air::ExecuteOp>(c.op));
       if (auto Op = mlir::dyn_cast_if_present<linalg::LinalgOp>(child_op)) {
         uint64_t compute_xfer_cost = 0;
         uint64_t compute_op_cost = getComputeCostFromCostModel(d, child_op);
@@ -258,6 +271,41 @@ public:
       execution_time = 1;
     }
     return execution_time;
+  }
+
+  // The op an air.execute region is priced by.
+  //
+  // A region wraps whatever the producer put in it, and only some of that has
+  // a cost: a linalg op or an air.custom does, while memref.expand_shape,
+  // subview, cast and friends are metadata that lower to nothing. Pricing the
+  // region by whichever op happens to be FIRST therefore makes the cost depend
+  // on how the region was assembled rather than on what it computes.
+  //
+  // That is not hypothetical. air-dependency legitimately sinks a reshape into
+  // the region ahead of the compute it feeds, and the region then costs zero:
+  //
+  //     air.execute {
+  //       %e = memref.expand_shape ...                  <- first, free
+  //       linalg.generic {air.op_cost = "attn_qk"} ...  <- never reached
+  //     }
+  //
+  // Two of attention's three linalg ops went free that way, worth 569 cycles a
+  // layer on one model and 2.91% -> 6.45% over a 148-point sweep, with every
+  // point moving under. The IR was correct; the pricing was reading the wrong
+  // op.
+  //
+  // A region holding more than one priced op is still charged for the first of
+  // them, which is the behaviour that was already there and a separate
+  // question from this one.
+  static Operation *getPricedChildOp(air::ExecuteOp exe) {
+    if (!exe)
+      return nullptr;
+    for (Operation &child : exe.getChildOps())
+      if (isa<linalg::LinalgOp, air::CustomOp>(&child))
+        return &child;
+    // Nothing priced in there. Hand back the first op so the callers' type
+    // switch falls through exactly as it did before.
+    return exe.getChildOps().empty() ? nullptr : &exe.getChildOps().front();
   }
 
   bool processGraph(runnerNode &c, device &device_resource_node,

--- a/mlir/lib/Util/Runner/RunnerNode.cpp
+++ b/mlir/lib/Util/Runner/RunnerNode.cpp
@@ -363,7 +363,14 @@ public:
       return result;
     } else if (auto Op = dyn_cast_if_present<air::HerdOp>(op)) {
       bool result = this->checkResourceFulfillmentForOp(Op);
-      if (!result) {
+      // Only a herd that cannot fit the hierarchy at all is an error. A herd
+      // that fits but finds its tiles taken is contending with a sibling herd
+      // and defers, exactly as the channel ops below do -- two operators
+      // time-sharing one compute hierarchy is a mapping, not a mistake, and it
+      // is the only way to model a machine whose operators are resident in
+      // fewer tiles than the program names.
+      if (!result && this->getBatchDispatchCount(Op.getOperation(), true) >
+                         this->getTilesCapacity()) {
         op->emitOpError("isn't allocated with enough resources to run");
       }
       return result;
@@ -466,6 +473,21 @@ private:
   void getTilesPoolFromParent(std::vector<resource *> &resource_pool) {
     auto parent_runner_node = this->parent;
     parent_runner_node->getTilesPool(resource_pool);
+  }
+  // Every tile the resource hierarchy provides, reserved or not.
+  //
+  // The distinction this draws is between a herd that can never run and one
+  // that merely has to wait. Needing more tiles than exist is a property of the
+  // program and the machine, and no amount of waiting fixes it. Needing more
+  // than are free right now is ordinary contention, and the herd holding them
+  // will release them when it completes.
+  unsigned getTilesCapacity() {
+    unsigned capacity = 0;
+    for (auto res_hier : this->resource_hiers) {
+      auto col = static_cast<du *>(res_hier);
+      capacity += col->tiles.size();
+    }
+    return capacity;
   }
   void getPortsPool(std::vector<resource *> &resource_pool,
                     std::string port_direction) {
@@ -724,10 +746,30 @@ private:
     // Note: forced to use dispatch multiplier to get tile count, since it is
     // checking for the entire herd op.
     unsigned tile_count = this->getBatchDispatchCount(Op.getOperation(), true);
-    if (tile_count <= resource_hier_pool.size()) {
-      return true;
-    } else
-      return false;
+    return tile_count + this->getTilesPromisedToWavefront() <=
+           resource_hier_pool.size();
+  }
+
+  // Tiles owed to herds already on this wavefront that have not taken them yet.
+  //
+  // A herd is gated here, on the parent, but reserves its tiles later and on
+  // its own runner node. Between those two moments its tiles are neither free
+  // nor held, so a gate that only looks at the free pool offers the same tiles
+  // to every herd it sees in one pass. Two herds are then admitted against one
+  // set of tiles, and the second one's reservation trips an assertion whose own
+  // comment says it should have been unreachable.
+  unsigned getTilesPromisedToWavefront() {
+    unsigned promised = 0;
+    for (auto &entry : this->wavefront) {
+      // A herd that has already reserved carries its resources here, and those
+      // tiles are out of the free pool -- counting it again would double-bill.
+      if (!std::get<1>(entry).empty())
+        continue;
+      auto &node = this->ctrl_g->g[std::get<0>(entry)];
+      if (auto herd = dyn_cast_if_present<air::HerdOp>(node.op))
+        promised += this->getBatchDispatchCount(herd.getOperation(), true);
+    }
+    return promised;
   }
   bool checkResourceFulfillmentForOp(memref::AllocOp Op) {
     // WORKAROUND: Temporarily disable memory resource checking

--- a/mlir/test/Util/Runner/execute_pricing/arch.json
+++ b/mlir/test/Util/Runner/execute_pricing/arch.json
@@ -1,0 +1,75 @@
+{
+  "clock": 1000000000,
+  "devicename": "execute_pricing",
+  "datatypes": [
+    {
+      "name": "i8",
+      "bytes": 1
+    }
+  ],
+  "dus": {
+    "count": [
+      1,
+      1
+    ],
+    "memory": {
+      "memory_space": "L2",
+      "bytes": 1048576
+    },
+    "ports": {
+      "outbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      },
+      "inbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      }
+    },
+    "tiles": {
+      "count": [
+        1,
+        1
+      ],
+      "memory": {
+        "memory_space": "L1",
+        "bytes": 65536
+      },
+      "ports": {
+        "outbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        },
+        "inbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        }
+      }
+    }
+  },
+  "noc": {
+    "outbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    },
+    "inbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    }
+  },
+  "cost_model": {
+    "op_costs": {
+      "priced": {
+        "name": "priced",
+        "datatypes": {
+          "i8": {
+            "cycles": "200"
+          }
+        }
+      }
+    },
+    "fallback": {
+      "kernel_invocation_overhead": 0
+    }
+  }
+}

--- a/mlir/test/Util/Runner/execute_pricing/metadata_before_compute.mlir
+++ b/mlir/test/Util/Runner/execute_pricing/metadata_before_compute.mlir
@@ -1,0 +1,89 @@
+//===- metadata_before_compute.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// An air.execute region is priced by the op in it that computes, not by
+// whichever op happens to come first.
+//
+// A region wraps whatever its producer put there, and only some of that has a
+// cost: a linalg op or an air.custom does, while memref.expand_shape, subview
+// and cast are metadata that lower to no instructions. air-dependency
+// legitimately sinks a reshape into the region ahead of the compute it feeds,
+// which used to leave the region costing nothing at all.
+//
+// Both herds below run one linalg.matvec priced at 200 cycles by the arch. The
+// only difference is that the second one has an expand_shape in front of it,
+// so if the region were priced by its first op the second herd would be free.
+// Both must take the same time.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.00[[#%d,BARE:]],
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#BARE + 200]],
+
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "B",
+// CHECK: "ts": 0.[[#%d,BEHIND_RESHAPE:]],
+// CHECK: "name": "LinalgOp(linalg.matvec)",
+// CHECK: "ph": "E",
+// CHECK: "ts": 0.[[#BEHIND_RESHAPE + 200]],
+
+module {
+  func.func @test(%arg0: memref<64xi8>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%la=%arg0) : memref<64xi8> attributes {id = 1 : i32} {
+      %1 = air.segment async args(%sa=%la) : memref<64xi8> attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+
+        // The compute is the first op in its region.
+        %2 = air.herd @bare async tile (%hx, %hy) in (%hsx=%c1_s, %hsy=%c1_s) attributes {id = 3 : i32} {
+          %tok_w, %w = air.execute -> (memref<8x8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8x8xi8, 2>
+            air.execute_terminator %alloc : memref<8x8xi8, 2>
+          }
+          %tok_v, %v = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o, %o = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c = air.execute [%tok_w, %tok_v, %tok_o] {
+            linalg.matvec {air.op_cost = "priced"} ins(%w, %v : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o : memref<8xi8, 2>)
+          }
+        }
+
+        // The same compute, with metadata ahead of it in the region.
+        %3 = air.herd @behind_reshape async [%2] tile (%hx2, %hy2) in (%hsx2=%c1_s, %hsy2=%c1_s) attributes {id = 4 : i32} {
+          %tok_f, %f = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %tok_v2, %v2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o2, %o2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c2 = air.execute [%tok_f, %tok_v2, %tok_o2] {
+            %w2 = memref.expand_shape %f [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            linalg.matvec {air.op_cost = "priced"} ins(%w2, %v2 : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o2 : memref<8xi8, 2>)
+          }
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/execute_pricing/reshape_is_free.mlir
+++ b/mlir/test/Util/Runner/execute_pricing/reshape_is_free.mlir
@@ -1,0 +1,77 @@
+//===- reshape_is_free.mlir ------------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// memref.expand_shape / collapse_shape / reshape cost nothing.
+//
+// They change how a buffer is indexed and lower to no instructions. Each one
+// still becomes its own vertex in the dependence graph, though, and the vertex
+// used to take the runner's one-cycle default. That is not nothing: this is
+// the shape air-dependency emits, a reshape sunk into the region ahead of the
+// op it feeds, and a pass will emit them by the hundred.
+//
+// Twenty-one of them in one region ahead of a linalg.matvec priced at 200
+// cycles. A metadata vertex must be free rather than priced as the region it
+// sits in: the vertex's op IS the enclosing region, so pricing it by the
+// region's compute charges the matvec once per reshape. That is 21 x 210
+// cycles here, 4.410us against 0.231us -- which is why this is one fix with
+// the region-pricing change beside it and not an independent nicety.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: Latency (all-iterations mode): 0.231us
+
+module {
+  func.func @test(%arg0: memref<64xi8>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%la=%arg0) : memref<64xi8> attributes {id = 1 : i32} {
+      %1 = air.segment async args(%sa=%la) : memref<64xi8> attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 1 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+        %2 = air.herd @reshapes async tile (%hx, %hy) in (%hsx=%c1_s, %hsy=%c1_s) attributes {id = 3 : i32} {
+          %tok_f, %f = air.execute -> (memref<64xi8, 2>) {
+            %alloc = memref.alloc() : memref<64xi8, 2>
+            air.execute_terminator %alloc : memref<64xi8, 2>
+          }
+          %tok_v, %v = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o, %o = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c = air.execute [%tok_f, %tok_v, %tok_o] {
+            %e0 = memref.expand_shape %f [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e1 = memref.collapse_shape %e0 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e2 = memref.expand_shape %e1 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e3 = memref.collapse_shape %e2 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e4 = memref.expand_shape %e3 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e5 = memref.collapse_shape %e4 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e6 = memref.expand_shape %e5 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e7 = memref.collapse_shape %e6 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e8 = memref.expand_shape %e7 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e9 = memref.collapse_shape %e8 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e10 = memref.expand_shape %e9 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e11 = memref.collapse_shape %e10 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e12 = memref.expand_shape %e11 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e13 = memref.collapse_shape %e12 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e14 = memref.expand_shape %e13 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e15 = memref.collapse_shape %e14 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e16 = memref.expand_shape %e15 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e17 = memref.collapse_shape %e16 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %e18 = memref.expand_shape %e17 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            %e19 = memref.collapse_shape %e18 [[0, 1]] : memref<8x8xi8, 2> into memref<64xi8, 2>
+            %w = memref.expand_shape %e19 [[0, 1]] output_shape [8, 8] : memref<64xi8, 2> into memref<8x8xi8, 2>
+            linalg.matvec {air.op_cost = "priced"} ins(%w, %v : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o : memref<8xi8, 2>)
+          }
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/herd_tile_contention/arch.json
+++ b/mlir/test/Util/Runner/herd_tile_contention/arch.json
@@ -1,0 +1,75 @@
+{
+  "clock": 1000000000,
+  "devicename": "herd_tile_contention",
+  "datatypes": [
+    {
+      "name": "i8",
+      "bytes": 1
+    }
+  ],
+  "dus": {
+    "count": [
+      1,
+      1
+    ],
+    "memory": {
+      "memory_space": "L2",
+      "bytes": 1048576
+    },
+    "ports": {
+      "outbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      },
+      "inbound": {
+        "count": 4,
+        "bytes_per_second": 4000000000
+      }
+    },
+    "tiles": {
+      "count": [
+        1,
+        8
+      ],
+      "memory": {
+        "memory_space": "L1",
+        "bytes": 65536
+      },
+      "ports": {
+        "outbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        },
+        "inbound": {
+          "count": 2,
+          "bytes_per_second": 4000000000
+        }
+      }
+    }
+  },
+  "noc": {
+    "outbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    },
+    "inbound": {
+      "count": 4,
+      "bytes_per_second": 4000000000
+    }
+  },
+  "cost_model": {
+    "op_costs": {
+      "priced": {
+        "name": "priced",
+        "datatypes": {
+          "i8": {
+            "cycles": "200"
+          }
+        }
+      }
+    },
+    "fallback": {
+      "kernel_invocation_overhead": 0
+    }
+  }
+}

--- a/mlir/test/Util/Runner/herd_tile_contention/fits.mlir
+++ b/mlir/test/Util/Runner/herd_tile_contention/fits.mlir
@@ -1,0 +1,66 @@
+//===- fits.mlir                                    -*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// Two herds with NO dependence between them, on a hierarchy of eight tiles.
+// Three tiles each, so both are resident at once and they overlap. The tile
+// budget is the only thing that could order them, and here it does not.
+//
+// Its pair is oversubscribed.mlir, which is the same design asking for five
+// tiles each.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: Latency (all-iterations mode): 0.210us
+
+module {
+  func.func @test(%arg0: memref<64xi8>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%la=%arg0) : memref<64xi8> attributes {id = 1 : i32} {
+      %1 = air.segment async args(%sa=%la) : memref<64xi8> attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 8 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+        %cn_s = arith.constant 3 : index
+        %2 = air.herd @first async tile (%hx, %hy) in (%hsx=%c1_s, %hsy=%cn_s) attributes {id = 3 : i32} {
+          %tok_w, %w = air.execute -> (memref<8x8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8x8xi8, 2>
+            air.execute_terminator %alloc : memref<8x8xi8, 2>
+          }
+          %tok_v, %v = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o, %o = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c = air.execute [%tok_w, %tok_v, %tok_o] {
+            linalg.matvec {air.op_cost = "priced"} ins(%w, %v : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o : memref<8xi8, 2>)
+          }
+        }
+        %3 = air.herd @second async tile (%hx2, %hy2) in (%hsx2=%c1_s, %hsy2=%cn_s) attributes {id = 4 : i32} {
+          %tok_w2, %w2 = air.execute -> (memref<8x8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8x8xi8, 2>
+            air.execute_terminator %alloc : memref<8x8xi8, 2>
+          }
+          %tok_v2, %v2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o2, %o2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c2 = air.execute [%tok_w2, %tok_v2, %tok_o2] {
+            linalg.matvec {air.op_cost = "priced"} ins(%w2, %v2 : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o2 : memref<8xi8, 2>)
+          }
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}

--- a/mlir/test/Util/Runner/herd_tile_contention/oversubscribed.mlir
+++ b/mlir/test/Util/Runner/herd_tile_contention/oversubscribed.mlir
@@ -1,0 +1,70 @@
+//===- oversubscribed.mlir                          -*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// The same two independent herds, five tiles each, on a hierarchy of eight.
+// They cannot both be resident, so the second waits for the first to release
+// and the two serialise -- twice the latency of fits.mlir.
+//
+// A herd that cannot get its tiles used to be a hard error: the runner emitted
+// 'isn't allocated with enough resources to run' and refused the design, while
+// the channel ops beside it deferred and retried. Only a herd that cannot fit
+// the hierarchy AT ALL is a configuration error; one that fits but finds its
+// tiles busy is contending with a sibling, and two operators time-sharing one
+// compute hierarchy is a mapping rather than a mistake.
+
+// RUN: air-runner %s -f test -m %S/arch.json | FileCheck %s
+
+// CHECK: Latency (all-iterations mode): 0.414us
+
+module {
+  func.func @test(%arg0: memref<64xi8>) {
+    %c1 = arith.constant 1 : index
+    %0 = air.launch async (%tx, %ty) in (%sx=%c1, %sy=%c1) args(%la=%arg0) : memref<64xi8> attributes {id = 1 : i32} {
+      %1 = air.segment async args(%sa=%la) : memref<64xi8> attributes {id = 2 : i32, x_loc = 0 : i64, x_size = 8 : i64, y_loc = 0 : i64, y_size = 1 : i64} {
+        %c1_s = arith.constant 1 : index
+        %cn_s = arith.constant 5 : index
+        %2 = air.herd @first async tile (%hx, %hy) in (%hsx=%c1_s, %hsy=%cn_s) attributes {id = 3 : i32} {
+          %tok_w, %w = air.execute -> (memref<8x8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8x8xi8, 2>
+            air.execute_terminator %alloc : memref<8x8xi8, 2>
+          }
+          %tok_v, %v = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o, %o = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c = air.execute [%tok_w, %tok_v, %tok_o] {
+            linalg.matvec {air.op_cost = "priced"} ins(%w, %v : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o : memref<8xi8, 2>)
+          }
+        }
+        %3 = air.herd @second async tile (%hx2, %hy2) in (%hsx2=%c1_s, %hsy2=%cn_s) attributes {id = 4 : i32} {
+          %tok_w2, %w2 = air.execute -> (memref<8x8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8x8xi8, 2>
+            air.execute_terminator %alloc : memref<8x8xi8, 2>
+          }
+          %tok_v2, %v2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_o2, %o2 = air.execute -> (memref<8xi8, 2>) {
+            %alloc = memref.alloc() : memref<8xi8, 2>
+            air.execute_terminator %alloc : memref<8xi8, 2>
+          }
+          %tok_c2 = air.execute [%tok_w2, %tok_v2, %tok_o2] {
+            linalg.matvec {air.op_cost = "priced"} ins(%w2, %v2 : memref<8x8xi8, 2>, memref<8xi8, 2>) outs(%o2 : memref<8xi8, 2>)
+          }
+        }
+        air.segment_terminator
+      }
+      air.launch_terminator
+    }
+    return
+  }
+}


### PR DESCRIPTION
Three faults in air-runner's cost and resource model, all reached by running the runner over the output of `air-opt --air-dependency` — the ordinary compiler path rather than a corner of it.

### 1. An `air.execute` region was priced by `getChildOps().front()`

A region wraps whatever its producer put in it, and only some of that has a cost: a `linalg` op or an `air.custom` does, while `memref.expand_shape`, `subview` and `cast` are metadata that lower to nothing. Pricing by whichever op came first therefore priced the region by how it had been assembled rather than by what it computes — and `air-dependency` legitimately sinks a reshape into the region ahead of the compute it feeds:

```mlir
air.execute {
  %e = memref.expand_shape ...            // first, free
  linalg.generic {air.op_cost = "..."}    // never reached
}
```

The region is now priced by the first op in it that has a cost.

### 2. A metadata vertex was priced as its enclosing region

A metadata child gets its own vertex, and that vertex's op is the **enclosing region** — so pricing it the way a region is priced charges the region's compute once per reshape. Twenty-one reshapes ahead of one 200-cycle matvec come to 21 × 210 cycles.

This is not separable from the change above. The old `front()`-based pricing happened to return the reshape itself and fall through to the one-cycle default, which hid the double-charging rather than avoiding it; fixing (1) alone makes it 21× worse.

### 3. A herd that could not reserve its tiles was a fatal error

`isn't allocated with enough resources to run`, while the channel ops three lines below deferred and retried. Needing more tiles than the hierarchy has is a property of the program and no amount of waiting fixes it; needing more than are free at this instant is contention with a sibling herd, which resolves when that herd completes. Only the first is an error now — two operators time-sharing one compute hierarchy is a mapping, and a machine whose operators outnumber its tiles could not be modelled at all before.

The gate also has to account for tiles it has already promised. A herd is gated on the parent but reserves later on its own runner node, and in between its tiles are neither free nor held — so a gate reading only the free pool offered the same tiles to every herd it saw in one pass. Two were admitted against one set, and the second one's reservation tripped an assertion whose own comment says it should have been unreachable.

### Tests

Four, each verified to **fail without its corresponding change**:

| test | what it catches |
|---|---|
| `execute_pricing/metadata_before_compute.mlir` | two herds running the same priced matvec, one with a reshape ahead of it in the region — both must take the same time |
| `execute_pricing/reshape_is_free.mlir` | twenty-one reshapes ahead of one matvec: 0.231us, not 4.410us |
| `herd_tile_contention/oversubscribed.mlir` | two independent herds wanting five tiles each of eight — they serialise instead of aborting |
| `herd_tile_contention/fits.mlir` | the control: three tiles each, so they still overlap |

All 49 pre-existing `mlir/test/Util/Runner` tests pass unchanged; 53 total.