### PR TITLE
[qwen25_3b_q4] Fix the decode wedge on Krackan: dual weight feed + a leaked builder env

### DIFF
--- a/programming_examples/llms/bench/decode_geometry.py
+++ b/programming_examples/llms/bench/decode_geometry.py
@@ -178,21 +178,26 @@ def geometry(model, vocab_chunk_i2, ctx, w_elems=None, n_layers=None, env_extra=
         DECODE_GOLDEN_L=str(ctx),
         W_DUAL_CHAN="1",
     )
+    # The whole mutate-import-restore sequence is one try/finally: a failure
+    # anywhere in it (a missing builder, a spec that will not load, a raising
+    # import) must still hand the caller its environment back, or the leak
+    # returns on exactly the paths nobody exercises.
     saved = {k: os.environ.get(k) for k in set(pinned) | set(env_extra or {})}
-    os.environ.update(pinned)
-    # Some models need extra builder env (qwen3-8b's DECODE_STACK/DECODE_WGROUP).
-    # Saved above too, so one call's extras cannot survive into the next: the
-    # builder reads these at import, and a leftover DECODE_WGROUP would make the
-    # following model come back split when it is not.
-    os.environ.update(env_extra or {})
-    # fused_decode.py imports its siblings (proj_qmm_pack, ...) by bare name.
-    if str(FUSED_DECODE) not in sys.path:
-        sys.path.insert(0, str(FUSED_DECODE))
-    spec = importlib.util.spec_from_file_location(
-        "_fused_decode_geom", FUSED_DECODE / "fused_decode.py"
-    )
-    fd = importlib.util.module_from_spec(spec)
     try:
+        os.environ.update(pinned)
+        # Some models need extra builder env (qwen3-8b's DECODE_STACK/
+        # DECODE_WGROUP). Saved above too, so one call's extras cannot survive
+        # into the next: the builder reads these at import, and a leftover
+        # DECODE_WGROUP would make the following model come back split when it
+        # is not.
+        os.environ.update(env_extra or {})
+        # fused_decode.py imports its siblings (proj_qmm_pack, ...) by bare name.
+        if str(FUSED_DECODE) not in sys.path:
+            sys.path.insert(0, str(FUSED_DECODE))
+        spec = importlib.util.spec_from_file_location(
+            "_fused_decode_geom", FUSED_DECODE / "fused_decode.py"
+        )
+        fd = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(fd)
     finally:
         for k, v in saved.items():

--- a/programming_examples/llms/bench/decode_geometry.py
+++ b/programming_examples/llms/bench/decode_geometry.py
@@ -95,11 +95,6 @@ _CHECK_WANT = dict(
 )
 
 
-# Builder env keys the last geometry() call set via env_extra, so the next one
-# can clear them (the builder reads its knobs at import time).
-_EXTRA_SET = set()
-
-
 def _rope_w_elems(fd):
     """The rope/qk-norm/qkv-bias region between the rms slabs and the final norm.
 
@@ -163,7 +158,17 @@ def geometry(model, vocab_chunk_i2, ctx, w_elems=None, n_layers=None, env_extra=
     present they are cross-checked, because a silent mismatch there is the one
     error in here that produces a number rather than a failure.
     """
-    os.environ.update(
+    # The builder reads its configuration from the environment at import, so
+    # these have to be set for the import -- but they are RESTORED afterwards.
+    # Leaking them poisons whatever the caller does next: sweep_decode.py shells
+    # out to `make` for the following context, a model Makefile setting a knob
+    # with `?=` cannot override an environment variable, and the next build
+    # silently comes back configured the way this pin says rather than the way
+    # the Makefile says. That is not hypothetical -- W_DUAL_CHAN=1 leaking from
+    # here rebuilt qwen25_3b_q4 with the dual weight feed from the second
+    # context onward, and every one of those dispatches wedged on a Krackan NPU
+    # while the first context, built before this ran, was fine.
+    pinned = dict(
         DECODE_MODEL=model,
         VOCAB_CHUNK_I2=str(vocab_chunk_i2),
         LM_HEAD="0",
@@ -173,14 +178,12 @@ def geometry(model, vocab_chunk_i2, ctx, w_elems=None, n_layers=None, env_extra=
         DECODE_GOLDEN_L=str(ctx),
         W_DUAL_CHAN="1",
     )
+    saved = {k: os.environ.get(k) for k in set(pinned) | set(env_extra or {})}
+    os.environ.update(pinned)
     # Some models need extra builder env (qwen3-8b's DECODE_STACK/DECODE_WGROUP).
-    # Drop whatever a previous call in this process set and this one does not:
-    # the builder reads these at import, so a leftover DECODE_WGROUP would make
-    # the next model come back split when it is not (which --check would hit).
-    global _EXTRA_SET
-    for k in _EXTRA_SET - set(env_extra or {}):
-        os.environ.pop(k, None)
-    _EXTRA_SET = set(env_extra or {})
+    # Saved above too, so one call's extras cannot survive into the next: the
+    # builder reads these at import, and a leftover DECODE_WGROUP would make the
+    # following model come back split when it is not.
     os.environ.update(env_extra or {})
     # fused_decode.py imports its siblings (proj_qmm_pack, ...) by bare name.
     if str(FUSED_DECODE) not in sys.path:
@@ -189,7 +192,14 @@ def geometry(model, vocab_chunk_i2, ctx, w_elems=None, n_layers=None, env_extra=
         "_fused_decode_geom", FUSED_DECODE / "fused_decode.py"
     )
     fd = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(fd)
+    try:
+        spec.loader.exec_module(fd)
+    finally:
+        for k, v in saved.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
 
     # `is not None`, not truthiness: 0 is a wrong answer to "how many layers",
     # not an absent one, and silently falling back to a head-only weight BO

--- a/programming_examples/llms/qwen25_3b_q4/Makefile
+++ b/programming_examples/llms/qwen25_3b_q4/Makefile
@@ -56,8 +56,17 @@ ATTN_L      ?= $(LBUILD)
 # W_DUAL_CHAN feeds each proj column's weights on BOTH of its shim MM2S channels
 # and reorders the DDR cascade accordingly, so the build and the weight packer
 # must agree. The packer reads the flag off the loaded engine rather than the
-# environment, so the two cannot disagree; this only records it in the stamp.
-W_DUAL_CHAN ?= 1
+# environment, so the two cannot disagree.
+#
+# OFF for this model, unlike the other nine. The dual feed wedges every decode
+# dispatch on a Krackan NPU -- 0 of 13 complete, at every context from 1024 to
+# 32768, with no prefill and no weights involved, while llama32_3b_q4nx runs at
+# 28 tok/s on the same part minutes apart. Turning it off completes 10 of 10
+# across that whole range. Costs ~16% decode on Strix (23.4 -> 19.6 tok/s).
+# EXPORTED because the builder reads it from the environment: a plain `?=`
+# reaches the stamp but never the engine, so the value here would be cosmetic.
+W_DUAL_CHAN ?= 0
+export W_DUAL_CHAN
 
 # Per-kernel -O is LOAD-BEARING (see fused_decode/Makefile): proj_qmm/rms_residual/
 # glu/rope MUST be -O2 (rope.cc at -O1 miscompiles -> the decode HANGS on device);


### PR DESCRIPTION
`llms/qwen25_3b_q4` is the only model failing the LLM perf nightly, and it fails all three targets that dispatch the fused decode — `verify`, `profile` and `sweep` — while the two that only build pass.

## What the failure is not

`run_npu2_sweep.lit` is decode-only and synthetic: no prefill, no HF weights. It reported `xrt_incomplete` at **every** context from 1024 to 32768. So the decode superkernel completes zero dispatches on that runner, and neither the prefill→decode KV handoff nor the template length can be involved. The attention column is not the variable either: `ATTN_PCOL` 3 and 4 both wedge and 5 does not build.

## Two independent bugs

**1. `decode_geometry.geometry()` leaks the builder env.** It pins seven variables into `os.environ` so the builder import picks them up, and never restores them. `sweep_decode.py` calls it once per context and shells out to `make` for the next one, so from the second context on every build runs with the previous call's pins in its environment — and a Makefile `?=` cannot override an environment variable.

`W_DUAL_CHAN` is pinned to `1` here, so a model whose Makefile turns it off gets the first context built correctly and every later context built with the flag back on. That reads as `ctx=1024` fine and 2048 upward `xrt_incomplete` — a shape that looks like a context-scaling limit and is not one. Passing the same flag through `--builder-env` masked it, because that re-set the variable after the pin.

**2. The dual weight feed wedges this model's decode.** Bisecting the builder knobs one at a time on the runner, with `llama32_3b_q4nx` passing at 28.04 tok/s in the same step as a control and an unmodified qwen wedging as a second control:

| arm | ctx=1024 |
|---|---|
| `DECODE_COALESCE=0` | `xrt_incomplete` |
| `PROJ_RC_CACHE=0` | `xrt_incomplete` |
| `KV_RB_1D=1` | `xrt_incomplete` |
| **`W_DUAL_CHAN=0`** | **ok, 21.61 tok/s** |

Repeated, `W_DUAL_CHAN=0` completes 10 of 10 across 1024–32768. All four knobs build and pass on a Strix box, so the arm measures the part, not the option.

The `export` in the Makefile is not decoration: the builder reads this flag from the environment, and this Makefile — unlike the other five that set it — never exported it, so the assignment reached the build stamp and never the engine.

## Result on the runner

All three previously-failing lits pass, run through the nightly's own step:

```
builder sees W_DUAL_CHAN=[0]
W_DUAL_CHAN after geometry(): None
verify   pass
profile  pass
sweep    pass
```

The step asserts the value the build actually sees and the absence of the leak before running anything, so neither can silently regress into a device-looking result.

## Cost and open question

About 16% decode on Strix (23.4 → 19.6 tok/s), on this model only; the other nine are untouched. Why the doubled feed is fatal on that part is not established — the one structural difference is that it takes all six S2MM channels on each proj-column memtile instead of five.

The `decode_geometry` fix stands on its own: any model whose Makefile sets a builder knob with `?=` was exposed to the same silent rebuild.

## Blast radius of the `decode_geometry` fix

`sweep_decode.py` is its only importer and it drives all ten fused-decode models, so the full sweep suite was run on the perf runner with both commits applied — no filter, the suite's own selection:

```
gemma3_4b_q4nx    pass    llama32_3b_q4nx   pass    qwen25_7b_q4nx  pass
lfm2_1_2b_q4nx    pass    phi4_mini_q4nx    pass    qwen3_4b_q4nx   pass
llama31_8b_q4nx   pass    qwen25_3b_q4      pass    qwen3_8b_q4nx   pass
llama32_1b_q4nx   pass
Passed: 10   Failed: 0
```

The same run confirms `hfweights_fastflowlm_qwen2_5_3b_instruct_npu2` is present in the runner's cache, so the gate #1965 added does not turn qwen's verify/profile into skips.