### PR TITLE
[fused_decode] Build as a full ELF, and split the DYNSEQ knobs

### DIFF
--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -876,6 +876,13 @@ ATTN_L = 32  # KV context length
 DECODE_GOLDEN = _os.environ.get("DECODE_GOLDEN", "")
 if DECODE_GOLDEN:
     ATTN_L = int(_os.environ.get("DECODE_GOLDEN_L", "1"))
+# DECODE_ATTN_L sets the context length without the golden harness, which is
+# what a build used purely as a reference for another build wants: two same-
+# ATTN_MAXL builds to calibrate an instruction slope, or a static build to
+# check a runtime-L one against. It defers to DECODE_GOLDEN_L when both are set
+# so the golden path keeps its single source of truth.
+elif _os.environ.get("DECODE_ATTN_L"):
+    ATTN_L = int(_os.environ["DECODE_ATTN_L"])
 # Feed the reference's separate post_attention_layernorm weight to the on-chip 2nd rmsnorm
 # (the reference uses a distinct post_attention_layernorm; required for real the reference parity).
 POST_RMS = bool(DECODE_GOLDEN)
@@ -930,6 +937,32 @@ DYNSEQ = int(_os.environ.get("DECODE_DYNSEQ", "0"))
 # position the cores are about to read. Named separately only because each one
 # reads better at its use.
 DYNSEQ_RB = DYNSEQ_APPEND = DYNSEQ_RTP = DYNSEQ_MEM = bool(DYNSEQ)
+
+
+def _dynseq_knob(name, default):
+    return bool(int(_os.environ.get(name, str(int(default)))))
+
+
+# Individually overridable, for the full-ELF path. A static TXN binary -- what
+# --output-format=elf emits -- is a flat list of literal words, so it can hold
+# a runtime *value* (via a scratchpad parameter) but not a runtime instruction
+# *stream*: a loop whose trip count is unknown at compile time, or a BD payload
+# computed at dispatch, has no representation in it. DYNSEQ as a single switch
+# turns on both kinds at once, which is why it cannot build an ELF.
+#
+# Splitting them allows the combination that can: the mask threshold L runtime
+# (DYNSEQ_RTP), so one build serves every context length, while the core's
+# block loop stays a compile-time ATTN_ROUNDS and the far blocks are skipped by
+# masking (DYNSEQ_TRIP off) -- which is what the shipping xclbin design already
+# does, and it keeps the shim's push count fixed and agreeing with the cores.
+DYNSEQ_RB = _dynseq_knob("DECODE_DYNSEQ_RB", DYNSEQ_RB)
+DYNSEQ_APPEND = _dynseq_knob("DECODE_DYNSEQ_APPEND", DYNSEQ_APPEND)
+DYNSEQ_RTP = _dynseq_knob("DECODE_DYNSEQ_RTP", DYNSEQ_RTP)
+DYNSEQ_MEM = _dynseq_knob("DECODE_DYNSEQ_MEM", DYNSEQ_MEM)
+# The core's attention trip count. Defaults to following DYNSEQ_RTP, which is
+# the existing coupling; set to 0 with DYNSEQ_RTP on to get a runtime L with a
+# static loop.
+DYNSEQ_TRIP = _dynseq_knob("DECODE_DYNSEQ_TRIP", DYNSEQ_RTP)
 # DECODE_COALESCE=0: turn off the cross-wave shim-feed coalescing, for A/B.
 COALESCE = int(_os.environ.get("DECODE_COALESCE", "1"))
 # Core stack. At K=4096 (qwen3-8b) the seven K-wide L1 activation buffers leave
@@ -3884,7 +3917,7 @@ def build_module():
                                     pushes, which is what keeps the core off a channel get
                                     that never arrives.
                                     """
-                                    if not DYNSEQ_RTP:
+                                    if not DYNSEQ_TRIP:
                                         return idx(ATTN_ROUNDS)
                                     _s = arith.addi(
                                         Lh,
@@ -5161,14 +5194,40 @@ def run():
         print(str(module))
         return 0
 
+    # DECODE_OUTPUT_FORMAT=elf: build a full ELF instead of an xclbin. The ELF
+    # carries its instruction stream internally, so there is no insts.bin to
+    # patch per token -- see the note on instance_name below, and DYNSEQ.
+    out_fmt = _os.environ.get("DECODE_OUTPUT_FORMAT", "xclbin")
+    if out_fmt not in ("xclbin", "elf"):
+        raise SystemExit(f"DECODE_OUTPUT_FORMAT must be xclbin or elf, got {out_fmt!r}")
+
+    # For ELF, XRT resolves the kernel as "main:<instance_name>", and
+    # instance_name must be the module's func.func name -- the OUTER runtime
+    # sequence, the one holding `aiex.configure @seg` (which lowers to the
+    # load_pdi that configures locks, BDs, routing and core enable). Naming the
+    # inner @seg_sequence instead yields shim DMAs with no tile configuration:
+    # the dispatch does not fault, it hangs (ERT_CMD_STATE_TIMEOUT). Derive it
+    # from the module rather than hardcoding, so it cannot drift.
+    instance_name = ""
+    if out_fmt == "elf":
+        import re as _re
+
+        _fns = _re.findall(r"func\.func @(\w+)\(", str(module))
+        if len(_fns) != 1:
+            raise SystemExit(
+                f"expected exactly one func.func for the ELF entry point, found {_fns}"
+            )
+        instance_name = _fns[0]
+
     # use_lock_race_condition_fix_v2: emit the reference-style daisy-chained locks for the
     # shared-L2 fan-in (group/main asymmetric gather) -- matches the reproducer's
     # serialized 4-writer chain (mem_0_1 lock_0_1->_159->...->_162). Without it AIR
     # emits a counting lock whose writer/reader counts mismatch -> deadlock.
     backend = XRTBackend(
         omit_while_true_loop=False,
-        output_format="xclbin",
+        output_format=out_fmt,
         kernel_name="MLIR_AIE",
+        instance_name=instance_name,
         stack_size=STACK_SIZE,
         use_lock_race_condition_fix_v2=True,
         coalesce_shim_dma=bool(COALESCE),
@@ -5181,7 +5240,10 @@ def run():
         f"8 cascade pairs, NPH={NPH} dests={DEMUX}"
     )
     art = backend.compile(module, output_binary_name="decode", insts="decode.insts.bin")
-    print(f"[q4nx_decode] emitted {art.output_binary} + {art.insts}")
+    print(
+        f"[q4nx_decode] emitted {art.output_binary} + {art.insts} "
+        f"(kernel {art.kernel!r})"
+    )
     return 0
 
 

--- a/programming_examples/fused_decode/fused_decode.py
+++ b/programming_examples/fused_decode/fused_decode.py
@@ -955,6 +955,20 @@ def _dynseq_knob(name, default):
 # block loop stays a compile-time ATTN_ROUNDS and the far blocks are skipped by
 # masking (DYNSEQ_TRIP off) -- which is what the shipping xclbin design already
 # does, and it keeps the shim's push count fixed and agreeing with the cores.
+# The overrides only narrow what DECODE_DYNSEQ turned on; they cannot turn it
+# on. DYNSEQ is what appends the context length as a trailing scalar operand,
+# so with it off there is no operand for these paths to read -- L_rt and
+# _seg_L are None and the first arithmetic on one raises deep inside codegen,
+# a long way from the environment variable that caused it. Fail here instead.
+if not DYNSEQ:
+    for _k in ("RB", "APPEND", "RTP", "MEM", "TRIP"):
+        if _dynseq_knob("DECODE_DYNSEQ_" + _k, False):
+            raise SystemExit(
+                f"DECODE_DYNSEQ_{_k}=1 needs DECODE_DYNSEQ=1: the context length "
+                "is only a runtime operand when DYNSEQ is on, and these knobs "
+                "select which parts of the sequence follow it."
+            )
+
 DYNSEQ_RB = _dynseq_knob("DECODE_DYNSEQ_RB", DYNSEQ_RB)
 DYNSEQ_APPEND = _dynseq_knob("DECODE_DYNSEQ_APPEND", DYNSEQ_APPEND)
 DYNSEQ_RTP = _dynseq_knob("DECODE_DYNSEQ_RTP", DYNSEQ_RTP)
@@ -3909,13 +3923,21 @@ def build_module():
                                     _reblock_dec()
 
                                 def _core_rounds(Lh):
-                                    """ceil(Lh/16) as a core-side loop bound.
+                                    """The core-side attention loop bound.
 
-                                    Lh is the RTP-L herd block-arg, so this is opaque to
-                                    folding and survives to core codegen as a real runtime
-                                    trip count -- the same count the shim's readback BD
-                                    pushes, which is what keeps the core off a channel get
-                                    that never arrives.
+                                    With DYNSEQ_TRIP this is ceil(Lh/16) built from the
+                                    RTP-L herd block-arg, so it is opaque to folding and
+                                    survives to core codegen as a real runtime trip count
+                                    -- the same count the shim's readback BD pushes, which
+                                    is what keeps the core off a channel get that never
+                                    arrives.
+
+                                    Without it the bound is the compile-time ATTN_ROUNDS
+                                    and the far blocks are skipped by masking instead. A
+                                    static TXN binary (--output-format=elf) has no
+                                    representation for a runtime trip count, so that is
+                                    the only form the full-ELF path can build; the shim's
+                                    push count is then fixed and agrees by construction.
                                     """
                                     if not DYNSEQ_TRIP:
                                         return idx(ATTN_ROUNDS)
@@ -5240,10 +5262,10 @@ def run():
         f"8 cascade pairs, NPH={NPH} dests={DEMUX}"
     )
     art = backend.compile(module, output_binary_name="decode", insts="decode.insts.bin")
-    print(
-        f"[q4nx_decode] emitted {art.output_binary} + {art.insts} "
-        f"(kernel {art.kernel!r})"
-    )
+    # An ELF embeds its instruction stream, so no insts.bin is written and
+    # naming one here would send a reader looking for a file that is not there.
+    _insts = f" + {art.insts}" if out_fmt != "elf" else ""
+    print(f"[q4nx_decode] emitted {art.output_binary}{_insts} (kernel {art.kernel!r})")
     return 0
 
 


### PR DESCRIPTION
`programming_examples/fused_decode` could only be built as an xclbin, and its
context length was one switch over four independent things. This adds an ELF
target and separates the knobs.

Independent of #(the scratchpad PR) — nothing here needs a compiler change.

### `DECODE_OUTPUT_FORMAT=elf`

Upstream hardcodes `output_format="xclbin"` with no override and the Makefile
has no ELF target, so the q4nx fused decode had almost certainly never been
built through the full-ELF path. Doing so surfaced two mlir-aie bugs, fixed in
Xilinx/mlir-aie#3679 (merged) — this needs that.

The one subtlety is `instance_name`. XRT resolves an ELF kernel as
`main:<instance_name>`, and that has to be the **outer** runtime sequence: the
one holding `aiex.configure @seg`, which lowers to the `load_pdi` that
configures locks, BDs, routing and core enable. The ELF also exports the inner
`@seg_sequence`, which is shim DMAs with no tile configuration — dispatching
it does not fault, it *hangs*. That trap already cost an issue once (#1557),
so the name is derived from the module rather than hardcoded.

### Splitting `DECODE_DYNSEQ`

`DYNSEQ_RTP` bundled two things that a static instruction stream treats very
differently:

- the mask threshold `L_c` — a runtime **value**, which a static stream can
  carry (given a scratchpad parameter);
- the attention trip count `ceil(Lh/16)` — a runtime **loop bound**, which it
  cannot, since a static TXN is a flat list of literal words.

`DECODE_DYNSEQ_TRIP` separates them, defaulting to the existing coupling so
nothing changes unless asked. Per-knob `DECODE_DYNSEQ_{RB,APPEND,RTP,MEM}`
overrides come along with it.

### `DECODE_ATTN_L`

Sets the context length without the golden harness. That is what a build used
purely as a *reference* for another build wants — two same-`ATTN_MAXL` builds
to calibrate an instruction slope, or a static build to check a runtime-L one
against. Only `DECODE_GOLDEN_L` could do this before, and it drags in the real
weights and a different norm configuration. It defers to `DECODE_GOLDEN_L`
when both are set, so the golden path keeps one source of truth.

### Testing

`black` clean. Built and run on NPU2 (Strix): `DECODE_OUTPUT_FORMAT=elf`
produces an ELF whose logits are bitwise identical to the xclbin built from
the same `build_module()`, and `DECODE_ATTN_L=32` reproduces the default build
byte for byte.

One thing worth knowing, found while testing and **not** fixed here: the
*default* configuration (16 layers + LM head, `POST_RMS` off) produces all-NaN
logits at `ATTN_ROUNDS >= 3`, on the xclbin path as much as the ELF one. The
Makefile's `DECODE_ENV` (`NLAYERS=1 LM_HEAD=0 DECODE_GOLDEN=1 ...`) is fine at
128 rounds. So the config `fused_decode.py` produces with no environment set
is not one that works past L=32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
