### PR TITLE
[AIRToAIE][AIRRtToNpu] Runtime herd scalars and BD offsets via mlir-aie scratchpad parameters

### DIFF
--- a/mlir/include/air/Conversion/Passes.td
+++ b/mlir/include/air/Conversion/Passes.td
@@ -198,6 +198,14 @@ def AIRToAIE : Pass<"air-to-aie", "ModuleOp"> {
            /*default=*/"false",
            "Choose whether to lower data movement ops to aie.objectFifo, or "
            "directly to aie.locks.">,
+    Option<"clOutputElf", "output-elf", "bool",
+           /*default=*/"false",
+           "Target a static TXN binary (full ELF). A herd's runtime scalar "
+           "operands then go through mlir-aie scratchpad parameters rather "
+           "than a control-plane RTP write, which a static TXN cannot encode. "
+           "Off by default: the RTP path is correct everywhere else, and the "
+           "host contract differs -- an unwritten scratchpad parameter reads "
+           "as zero instead of failing.">,
     Option<"clGenerateShimDMA", "generate-shim-dma", "bool",
            /*default=*/"false",
            "Choose whether to schedule shim data movement via generating AIE "

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -1277,10 +1277,16 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
         Operation *anchor = op;
         while (anchor && anchor->getParentOp() != seq.getOperation())
           anchor = anchor->getParentOp();
+        // Only a marker that is already a *direct* child counts as done:
+        // --aie-lower-scratchpad-parameters expands those and ignores any
+        // other, so treating a nested one as "already marked" would leave the
+        // sequence with no preamble at all.
         bool alreadyMarked = false;
-        seq.walk([&](AIEX::SyncScratchpadParametersFromHostOp) {
-          alreadyMarked = true;
-        });
+        for (Operation &o : seq.getBody().front())
+          if (isa<AIEX::SyncScratchpadParametersFromHostOp>(o)) {
+            alreadyMarked = true;
+            break;
+          }
         if (anchor && !alreadyMarked) {
           OpBuilder::InsertionGuard g(rewriter);
           rewriter.setInsertionPoint(anchor);
@@ -1300,19 +1306,29 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
 
         // Only generate RTP writes if the RTP buffer was actually created.
         bool rtpBufferExists = false;
+        // The device that actually owns this tile's RTP buffer. Without it
+        // there is no core to ask which slots AIRToAIE moved to the
+        // scratchpad, and every slot would get an RTP write -- including the
+        // runtime ones, which is exactly the non-constant write32 a static TXN
+        // cannot encode. So the fallback has to resolve the device too, not
+        // just answer whether the buffer exists somewhere.
+        AIE::DeviceOp owningDevice = device;
         if (device) {
           rtpBufferExists =
               static_cast<bool>(device.lookupSymbol<AIE::BufferOp>(name));
         } else {
           // Fallback for IR without segment_name: search all AIE::DeviceOp's.
           module.walk([&](AIE::DeviceOp d) {
-            if (!rtpBufferExists && d.lookupSymbol<AIE::BufferOp>(name))
+            if (!rtpBufferExists && d.lookupSymbol<AIE::BufferOp>(name)) {
               rtpBufferExists = true;
+              owningDevice = d;
+            }
           });
         }
 
         xilinx::AIE::CoreOp coreOp =
-            device ? getCoreAt(device, phys_x, phys_y) : xilinx::AIE::CoreOp();
+            owningDevice ? getCoreAt(owningDevice, phys_x, phys_y)
+                         : xilinx::AIE::CoreOp();
         if (rtpBufferExists) {
           unsigned rtp_slot = 0;
           for (int i = 0, e = op.getNumOperands(); i < e; i++) {
@@ -3007,8 +3023,14 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
       // Hoist within every block instead.
       SmallVector<Block *> blocks;
       seq.getBody().walk([&](Block *b) { blocks.push_back(b); });
+      // A sync marker is only honoured as a direct child of the sequence, so
+      // it may be reordered within the entry block but never moved or cloned
+      // into a nested one -- there the lowering would ignore it and the arm
+      // would run with whatever the parameter buffers last held.
+      Block *seqEntry = &seq.getBody().front();
       for (Block *blkPtr : blocks) {
         Block &blk = *blkPtr;
+        const bool syncsAllowed = blkPtr == seqEntry;
         // Snapshot the op order; the delimiters never move, and RTP/set_lock
         // ops only move within their own region, so region membership computed
         // from this snapshot stays valid across the moves below.
@@ -3084,13 +3106,14 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
             continue;
           // An arm that reloads its PDI has lost the parameter buffers the
           // earlier sync wrote, so give it its own.
-          if (anySync && g.syncs.empty() && g.afterLoadPdi &&
+          if (syncsAllowed && anySync && g.syncs.empty() && g.afterLoadPdi &&
               !g.locks.empty()) {
             OpBuilder b(g.anchor);
             g.syncs.push_back(b.clone(*anySync));
           }
-          for (auto *sy : g.syncs)
-            sy->moveBefore(g.anchor);
+          if (syncsAllowed)
+            for (auto *sy : g.syncs)
+              sy->moveBefore(g.anchor);
           for (auto *rtp : g.rtps)
             moveRtpBefore(rtp, g.anchor);
           for (auto *lk : g.locks)

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -374,8 +374,7 @@ static Value peelStaticAddends(Value v, OpBuilder &builder, Location loc,
   for (Value s : staticSides) {
     if (residual && residual.getType() != s.getType())
       return nullptr;
-    residual = residual ? arith::AddIOp::create(builder, loc, residual, s)
-                        : s;
+    residual = residual ? arith::AddIOp::create(builder, loc, residual, s) : s;
   }
   return v;
 }
@@ -442,8 +441,7 @@ static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
                                                  Value &residual) {
   if (!module)
     return nullptr;
-  Value dynamic =
-      peelStaticAddends(offset, builder, offset.getLoc(), residual);
+  Value dynamic = peelStaticAddends(offset, builder, offset.getLoc(), residual);
   if (!dynamic)
     return nullptr;
   int64_t scale, addend;
@@ -465,8 +463,7 @@ static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointToStart(module.getBody());
     xilinx::AIEX::ScratchpadParameterOp::create(
-        builder, module.getLoc(), name,
-        TypeAttr::get(builder.getI32Type()),
+        builder, module.getLoc(), name, TypeAttr::get(builder.getI32Type()),
         /*state_table_idx=*/nullptr, /*kind=*/nullptr);
   }
   return name;
@@ -1124,11 +1121,11 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
       // instruction stream constant. Same mechanism as a herd's runtime
       // scalar, in its `addr` flavour.
       Value offsetResidual;
-      StringAttr paramName =
-          outputElf ? declareBlockArgOffsetParameter(
-                        op->getParentOfType<ModuleOp>(), dynOffsetI32,
-                        rewriter, offsetResidual)
-                    : nullptr;
+      StringAttr paramName = outputElf
+                                 ? declareBlockArgOffsetParameter(
+                                       op->getParentOfType<ModuleOp>(),
+                                       dynOffsetI32, rewriter, offsetResidual)
+                                 : nullptr;
       if (paramName) {
         bd.setOffsetParameterAttr(FlatSymbolRefAttr::get(paramName));
         // The base keeps its ordinary place on the BD; the parameter is added
@@ -3042,12 +3039,21 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
           Operation *anchor = nullptr;
           SmallVector<Operation *> rtps;
           SmallVector<Operation *> locks;
+          // The scratchpad sync has to lead its arm for the same reason the
+          // RTP writes do, and more strictly: it is what puts a herd's runtime
+          // scalar in place, and the set_locks below it are what let the cores
+          // read that scalar.
+          SmallVector<Operation *> syncs;
+          // A PDI reload rewrites tile memory, so the per-core parameter
+          // buffers the sync populated are gone and the arm needs its own.
+          bool afterLoadPdi = false;
         };
         SmallVector<ArmGroup> groups(1);
         std::optional<int64_t> curWave;
         for (Operation *o : ops) {
           if (isa<AIEX::NpuLoadPdiOp>(o)) {
             groups.emplace_back();
+            groups.back().afterLoadPdi = true;
             curWave.reset();
             continue;
           }
@@ -3059,14 +3065,32 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
           ArmGroup &g = groups.back();
           if (isa<AIEX::NpuWriteRTPOp>(o))
             g.rtps.push_back(o);
+          else if (isa<AIEX::SyncScratchpadParametersFromHostOp>(o))
+            g.syncs.push_back(o);
           else if (isa<AIEX::SetLockOp>(o))
             g.locks.push_back(o);
           else if (!o->hasAttr(air::attrs::RuntimeHoist) && !g.anchor)
             g.anchor = o;
         }
+        // Each move inserts immediately before the anchor, so the order these
+        // run in is the order they end up in: sync, then RTP writes, then the
+        // releases that let the cores read both.
+        Operation *anySync = nullptr;
+        for (auto &g : groups)
+          if (!g.syncs.empty() && !anySync)
+            anySync = g.syncs.front();
         for (auto &g : groups) {
           if (!g.anchor)
             continue;
+          // An arm that reloads its PDI has lost the parameter buffers the
+          // earlier sync wrote, so give it its own.
+          if (anySync && g.syncs.empty() && g.afterLoadPdi &&
+              !g.locks.empty()) {
+            OpBuilder b(g.anchor);
+            g.syncs.push_back(b.clone(*anySync));
+          }
+          for (auto *sy : g.syncs)
+            sy->moveBefore(g.anchor);
           for (auto *rtp : g.rtps)
             moveRtpBefore(rtp, g.anchor);
           for (auto *lk : g.locks)

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -336,56 +336,85 @@ static bool reachesSequenceArg(Value v) {
                          blockArg.getOwner()->getParentOp());
 }
 
-// On success, `residual` is the part of the offset the parameter does *not*
-// cover -- the loop-varying base -- which the caller leaves on the BD as its
-// ordinary offset. mlir-aie applies the parameter additively
-// ("update_from_scratchpad to add the runtime offset to the BD address
-// register", AIEDmaToNpu.cpp), so base and delta compose rather than compete,
-// and the base folds to a constant when the enclosing loop unrolls.
-static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
-                                                 OpBuilder &builder,
-                                                 Value &residual) {
-  if (!module)
-    return nullptr;
-  // Walk back through the address arithmetic AIR builds around a scalar --
-  // casts, and adds/multiplies against constants -- to whatever ultimately
-  // varies. Stopping at the first arith op (the earlier version did) means
-  // never recognising an offset like `(L-1) * stride`, which is exactly the
-  // shape a KV append has.
-  Value v = offset;
+// Peel the offset's top-level additive chain into the part that varies per
+// dispatch and the part that does not. Every addend that does not reach the
+// sequence argument is static -- a loop-varying base, a constant, or both --
+// and stays on the BD as its ordinary offset, which `offset_parameter` is
+// added to rather than replacing ("update_from_scratchpad to add the runtime
+// offset to the BD address register", AIEDmaToNpu.cpp). Returns the remaining
+// per-dispatch term, or null when an add has runtime on both sides (no single
+// parameter can stand for it).
+//
+// Dropping a constant addend here instead of banking it is a silent
+// miscompile, not a missed optimisation: the KV append's V transfer is
+// `base + KV_HALF + f(L)` against the K transfer's `base + f(L)`, so losing
+// KV_HALF lands both on the same slot.
+static Value peelStaticAddends(Value v, OpBuilder &builder, Location loc,
+                               Value &residual) {
+  SmallVector<Value> staticSides;
+  while (Operation *def = v.getDefiningOp()) {
+    // AIR wraps the offset in width adjustments on the way to the BD
+    // (index -> i64 -> i32); the addends sit underneath them. Narrowing
+    // distributes over the add for the ranges a BD offset can hold.
+    if (llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
+                  arith::ExtSIOp, arith::BitcastOp>(def)) {
+      v = def->getOperand(0);
+      continue;
+    }
+    auto add = llvm::dyn_cast<arith::AddIOp>(def);
+    if (!add)
+      break;
+    Value lhs = add.getLhs(), rhs = add.getRhs();
+    bool lhsRuntime = reachesSequenceArg(lhs);
+    if (lhsRuntime == reachesSequenceArg(rhs))
+      break;
+    staticSides.push_back(lhsRuntime ? rhs : lhs);
+    v = lhsRuntime ? lhs : rhs;
+  }
+  for (Value s : staticSides) {
+    if (residual && residual.getType() != s.getType())
+      return nullptr;
+    residual = residual ? arith::AddIOp::create(builder, loc, residual, s)
+                        : s;
+  }
+  return v;
+}
+
+// Reduce a per-dispatch term to `arg * scale + addend`, walking outside in.
+// Two BDs may share one parameter only if they need the same number written,
+// so these coefficients identify the parameter alongside the argument number.
+// Returns the sequence argument, or null if the term is not affine in one.
+static BlockArgument affineInSequenceArg(Value v, int64_t &scale,
+                                         int64_t &addend) {
+  scale = 1;
+  addend = 0;
   while (Operation *def = v.getDefiningOp()) {
     if (llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
                   arith::ExtSIOp, arith::BitcastOp>(def)) {
       v = def->getOperand(0);
       continue;
     }
-    if (llvm::isa<arith::AddIOp, arith::SubIOp, arith::MulIOp>(def)) {
-      // Follow the one varying side; if both vary this is not a single
-      // parameter and the caller keeps the SSA offset.
-      Value lhs = def->getOperand(0), rhs = def->getOperand(1);
-      bool lhsConst = matchPattern(lhs, m_Constant());
-      bool rhsConst = matchPattern(rhs, m_Constant());
-      if (lhsConst != rhsConst) {
-        v = lhsConst ? rhs : lhs;
-        continue;
-      }
-      // Neither side is constant. An add of two varying terms is still
-      // separable when exactly one of them reaches the sequence argument --
-      // that is the KV append's shape, a per-iteration base plus a
-      // per-dispatch delta. Split it: follow the runtime side and give the
-      // other back as the residual. Anything else (a product of two varying
-      // terms, both sides runtime) genuinely has no single parameter.
-      if (!llvm::isa<arith::AddIOp>(def) || residual)
-        return nullptr;
-      bool lhsRuntime = reachesSequenceArg(lhs);
-      bool rhsRuntime = reachesSequenceArg(rhs);
-      if (lhsRuntime == rhsRuntime)
-        return nullptr;
-      residual = lhsRuntime ? rhs : lhs;
-      v = lhsRuntime ? lhs : rhs;
-      continue;
+    if (!llvm::isa<arith::AddIOp, arith::SubIOp, arith::MulIOp>(def))
+      return nullptr;
+    Value lhs = def->getOperand(0), rhs = def->getOperand(1);
+    IntegerAttr c;
+    bool constOnRight = matchPattern(rhs, m_Constant(&c));
+    if (!constOnRight && !matchPattern(lhs, m_Constant(&c)))
+      return nullptr;
+    int64_t k = c.getInt();
+    Value inner = constOnRight ? lhs : rhs;
+    // f is what has been applied so far; compose the new innermost op into it.
+    if (llvm::isa<arith::MulIOp>(def)) {
+      scale *= k; // f(k*x) = scale*k*x + addend
+    } else if (llvm::isa<arith::AddIOp>(def)) {
+      addend += scale * k; // f(x+k)
+    } else if (constOnRight) {
+      addend -= scale * k; // f(x-k)
+    } else {
+      addend += scale * k; // f(k-x)
+      scale = -scale;
     }
-    return nullptr;
+    v = inner;
   }
   auto blockArg = llvm::dyn_cast<BlockArgument>(v);
   if (!blockArg)
@@ -397,8 +426,41 @@ static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
   if (!llvm::isa<xilinx::AIE::RuntimeSequenceOp>(
           blockArg.getOwner()->getParentOp()))
     return nullptr;
-  auto name = builder.getStringAttr("__air_param_argoff_" +
-                                    std::to_string(blockArg.getArgNumber()));
+  return blockArg;
+}
+
+// A BD offset that traces back to the runtime sequence's own operand is
+// unknowable at compile time and belongs in the scratchpad. Anything else --
+// a constant, or an offset computed from constants -- stays on the normal
+// path, so this only fires where the static encoding was impossible anyway.
+// Returns the parameter's name, or null if the offset is not separable.
+//
+// On success, `residual` is the part of the offset the parameter does *not*
+// cover, which the caller leaves on the BD.
+static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
+                                                 OpBuilder &builder,
+                                                 Value &residual) {
+  if (!module)
+    return nullptr;
+  Value dynamic =
+      peelStaticAddends(offset, builder, offset.getLoc(), residual);
+  if (!dynamic)
+    return nullptr;
+  int64_t scale, addend;
+  BlockArgument blockArg = affineInSequenceArg(dynamic, scale, addend);
+  if (!blockArg)
+    return nullptr;
+  // The host writes the whole affine value, so the coefficients are part of
+  // the parameter's identity: BDs needing `(L-1)*256` and `L*256` are two
+  // parameters, not one shared entry that would be right for one of them.
+  std::string suffix;
+  if (scale != 1 || addend != 0) {
+    suffix = "_x" + std::to_string(scale);
+    suffix += (addend < 0 ? "_m" : "_p") +
+              std::to_string(addend < 0 ? -addend : addend);
+  }
+  auto name = builder.getStringAttr(
+      "__air_param_argoff_" + std::to_string(blockArg.getArgNumber()) + suffix);
   if (!module.lookupSymbol(name)) {
     OpBuilder::InsertionGuard g(builder);
     builder.setInsertionPointToStart(module.getBody());

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -270,6 +270,146 @@ static void markDevicesNeedingLockReset(mlir::ModuleOp module) {
 
 namespace {
 
+// The core placed at (x, y) in this device, or null. AIRToAIE stamps each core
+// with `air.herd_name`, which is how the herd a tile belongs to is recovered
+// here without rebuilding a tile-to-herd map.
+static xilinx::AIE::CoreOp getCoreAt(xilinx::AIE::DeviceOp device, int x,
+                                     int y) {
+  xilinx::AIE::CoreOp found = nullptr;
+  device.walk([&](xilinx::AIE::CoreOp core) {
+    if (found)
+      return;
+    auto tile = core.getTileOp();
+    if (tile.getCol() == x && tile.getRow() == y)
+      found = core;
+  });
+  return found;
+}
+
+// True when AIRToAIE routed this herd slot through the scratchpad rather than
+// the RTP buffer. The declaration it emits at module scope is the contract
+// between the two passes; see the comment on isRuntimeHerdOperand in
+// AIRToAIEPass.cpp for why the decision is recorded rather than recomputed.
+static bool isScratchpadParameterSlot(ModuleOp module,
+                                      xilinx::AIE::CoreOp coreOp,
+                                      unsigned slot) {
+  if (!coreOp)
+    return false;
+  auto herdName = coreOp->getAttrOfType<StringAttr>("air.herd_name");
+  if (!herdName)
+    return false;
+  std::string name =
+      "__air_param_" + herdName.getValue().str() + "_" + std::to_string(slot);
+  return static_cast<bool>(
+      module.lookupSymbol<xilinx::AIEX::ScratchpadParameterOp>(name));
+}
+
+// A BD offset that traces back to the runtime sequence's own operand is
+// unknowable at compile time and belongs in the scratchpad. Anything else --
+// a constant, or an offset computed from constants -- stays on the normal
+// path, so this only fires where the static encoding was impossible anyway.
+// Returns the parameter's name, or null if the offset is not a block argument.
+//
+// The name is keyed on the argument number rather than on the transfer, so
+// that every BD driven by the same operand (a KV append writes one chunk per
+// group) shares one parameter and one state-table entry.
+// Does this value reach the runtime sequence's own argument? Pure predicate --
+// no declaration, no IR change -- used to decide which side of an add is the
+// per-dispatch one.
+static bool reachesSequenceArg(Value v) {
+  while (Operation *def = v.getDefiningOp()) {
+    if (llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
+                  arith::ExtSIOp, arith::BitcastOp>(def)) {
+      v = def->getOperand(0);
+      continue;
+    }
+    if (llvm::isa<arith::AddIOp, arith::SubIOp, arith::MulIOp>(def)) {
+      if (reachesSequenceArg(def->getOperand(0)))
+        return true;
+      v = def->getOperand(1);
+      continue;
+    }
+    return false;
+  }
+  auto blockArg = llvm::dyn_cast<BlockArgument>(v);
+  return blockArg && llvm::isa<xilinx::AIE::RuntimeSequenceOp>(
+                         blockArg.getOwner()->getParentOp());
+}
+
+// On success, `residual` is the part of the offset the parameter does *not*
+// cover -- the loop-varying base -- which the caller leaves on the BD as its
+// ordinary offset. mlir-aie applies the parameter additively
+// ("update_from_scratchpad to add the runtime offset to the BD address
+// register", AIEDmaToNpu.cpp), so base and delta compose rather than compete,
+// and the base folds to a constant when the enclosing loop unrolls.
+static StringAttr declareBlockArgOffsetParameter(ModuleOp module, Value offset,
+                                                 OpBuilder &builder,
+                                                 Value &residual) {
+  if (!module)
+    return nullptr;
+  // Walk back through the address arithmetic AIR builds around a scalar --
+  // casts, and adds/multiplies against constants -- to whatever ultimately
+  // varies. Stopping at the first arith op (the earlier version did) means
+  // never recognising an offset like `(L-1) * stride`, which is exactly the
+  // shape a KV append has.
+  Value v = offset;
+  while (Operation *def = v.getDefiningOp()) {
+    if (llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
+                  arith::ExtSIOp, arith::BitcastOp>(def)) {
+      v = def->getOperand(0);
+      continue;
+    }
+    if (llvm::isa<arith::AddIOp, arith::SubIOp, arith::MulIOp>(def)) {
+      // Follow the one varying side; if both vary this is not a single
+      // parameter and the caller keeps the SSA offset.
+      Value lhs = def->getOperand(0), rhs = def->getOperand(1);
+      bool lhsConst = matchPattern(lhs, m_Constant());
+      bool rhsConst = matchPattern(rhs, m_Constant());
+      if (lhsConst != rhsConst) {
+        v = lhsConst ? rhs : lhs;
+        continue;
+      }
+      // Neither side is constant. An add of two varying terms is still
+      // separable when exactly one of them reaches the sequence argument --
+      // that is the KV append's shape, a per-iteration base plus a
+      // per-dispatch delta. Split it: follow the runtime side and give the
+      // other back as the residual. Anything else (a product of two varying
+      // terms, both sides runtime) genuinely has no single parameter.
+      if (!llvm::isa<arith::AddIOp>(def) || residual)
+        return nullptr;
+      bool lhsRuntime = reachesSequenceArg(lhs);
+      bool rhsRuntime = reachesSequenceArg(rhs);
+      if (lhsRuntime == rhsRuntime)
+        return nullptr;
+      residual = lhsRuntime ? rhs : lhs;
+      v = lhsRuntime ? lhs : rhs;
+      continue;
+    }
+    return nullptr;
+  }
+  auto blockArg = llvm::dyn_cast<BlockArgument>(v);
+  if (!blockArg)
+    return nullptr;
+  // Only the runtime sequence's own argument is a per-dispatch value. A loop
+  // induction variable is also a block argument but varies per iteration, and
+  // the scratchpad holds one value per dispatch -- those offsets are folded
+  // by unrolling further down the pipeline instead.
+  if (!llvm::isa<xilinx::AIE::RuntimeSequenceOp>(
+          blockArg.getOwner()->getParentOp()))
+    return nullptr;
+  auto name = builder.getStringAttr("__air_param_argoff_" +
+                                    std::to_string(blockArg.getArgNumber()));
+  if (!module.lookupSymbol(name)) {
+    OpBuilder::InsertionGuard g(builder);
+    builder.setInsertionPointToStart(module.getBody());
+    xilinx::AIEX::ScratchpadParameterOp::create(
+        builder, module.getLoc(), name,
+        TypeAttr::get(builder.getI32Type()),
+        /*state_table_idx=*/nullptr, /*kind=*/nullptr);
+  }
+  return name;
+}
+
 // Helper function to check if a value is a memref on host memory (space 0)
 static bool isHostMemory(Value val) {
   if (auto memrefType = dyn_cast_if_present<BaseMemRefType>(val.getType()))
@@ -904,8 +1044,34 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
                      : AIE::DMABDOp::create(rewriter, op.getLoc(), memref, 0,
                                             static_cast<int>(transferLen),
                                             dimsAttr));
-      bd.getOffsetMutable().assign(dynOffsetI32);
-      bd.removeStaticOffsetAttr();
+      // A runtime offset carried as an SSA operand becomes a BD word computed
+      // at dispatch, which only the C++ TXN target can encode -- a static TXN,
+      // and therefore the full-ELF output, cannot. When the offset is
+      // genuinely the sequence's own operand, hand it to the scratchpad
+      // instead: `offset_parameter` names a parameter the host writes per
+      // dispatch and firmware folds into the BD address, leaving the
+      // instruction stream constant. Same mechanism as a herd's runtime
+      // scalar, in its `addr` flavour.
+      Value offsetResidual;
+      if (StringAttr paramName = declareBlockArgOffsetParameter(
+              op->getParentOfType<ModuleOp>(), dynOffsetI32, rewriter,
+              offsetResidual)) {
+        bd.setOffsetParameterAttr(FlatSymbolRefAttr::get(paramName));
+        // The base keeps its ordinary place on the BD; the parameter is added
+        // to it at dispatch.
+        if (offsetResidual) {
+          // The BD's offset operand is i32; the residual is whatever type the
+          // address arithmetic left it in (index, here).
+          if (!offsetResidual.getType().isInteger(32))
+            offsetResidual = arith::IndexCastOp::create(
+                rewriter, op.getLoc(), rewriter.getI32Type(), offsetResidual);
+          bd.getOffsetMutable().assign(offsetResidual);
+          bd.removeStaticOffsetAttr();
+        }
+      } else {
+        bd.getOffsetMutable().assign(dynOffsetI32);
+        bd.removeStaticOffsetAttr();
+      }
     } else if (dimLayouts.empty() && !pktAttr) {
       AIE::DMABDOp::create(rewriter, op.getLoc(), memref,
                            static_cast<int>(totalOffset),
@@ -1024,6 +1190,35 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
     // and set_locks so the per-wave hoist groups this arm by its iteration.
     auto waveAttr = op->getAttr(air::attrs::LaunchWave);
 
+    // Any herd scalar that AIRToAIE routed through the scratchpad has to be
+    // in place before a core is let past its herd lock, so the sync goes ahead
+    // of the whole arm. One per sequence is enough -- it syncs the table, not
+    // an individual parameter -- and AIR's own herd lock is what orders the
+    // cores against it, which is why the pass's built-in preamble is off.
+    if (!module.getOps<AIEX::ScratchpadParameterOp>().empty()) {
+      if (auto seq = op->getParentOfType<AIE::RuntimeSequenceOp>()) {
+        // The marker is what --aie-lower-scratchpad-parameters expands into
+        // the real preamble, and it must be a *direct* child of the sequence
+        // (HasParent), while this pattern may be rewriting several regions
+        // deep. Walk out to the ancestor that does sit at sequence level and
+        // put the marker in front of it, which keeps it ahead of this herd's
+        // set_locks without hoisting it past unrelated work.
+        Operation *anchor = op;
+        while (anchor && anchor->getParentOp() != seq.getOperation())
+          anchor = anchor->getParentOp();
+        bool alreadyMarked = false;
+        seq.walk([&](AIEX::SyncScratchpadParametersFromHostOp) {
+          alreadyMarked = true;
+        });
+        if (anchor && !alreadyMarked) {
+          OpBuilder::InsertionGuard g(rewriter);
+          rewriter.setInsertionPoint(anchor);
+          AIEX::SyncScratchpadParametersFromHostOp::create(rewriter,
+                                                           op.getLoc());
+        }
+      }
+    }
+
     // for each herd core, emit write_rtp ops for every herd operand
     // followed by a write32 to the herd lock, setting it to 1.
     for (int phys_x = loc_x; phys_x < size_x + loc_x; phys_x++) {
@@ -1045,6 +1240,8 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
           });
         }
 
+        xilinx::AIE::CoreOp coreOp =
+            device ? getCoreAt(device, phys_x, phys_y) : xilinx::AIE::CoreOp();
         if (rtpBufferExists) {
           unsigned rtp_slot = 0;
           for (int i = 0, e = op.getNumOperands(); i < e; i++) {
@@ -1078,6 +1275,19 @@ struct HerdLoadToNpuPattern : public OpConversionPattern<airrt::HerdLoadOp> {
                 vVal =
                     arith::ExtUIOp::create(rewriter, op.getLoc(), i32Ty, oper);
               }
+            }
+            // AIRToAIE routes a herd's *runtime* scalars through the
+            // scratchpad instead of this buffer, so that the value never has
+            // to be encoded into a static instruction stream (see
+            // isRuntimeHerdOperand there). It signals that by declaring
+            // `__air_param_<herd>_<slot>` at module scope; the host writes
+            // that parameter per dispatch and the core reads it directly, so
+            // there is nothing to write here. The symbol is the contract
+            // between the two passes -- re-deciding "is this constant?" here
+            // would risk the two disagreeing after canonicalization.
+            if (isScratchpadParameterSlot(module, coreOp, rtp_slot)) {
+              rtp_slot++;
+              continue;
             }
             if (vVal) {
               auto rtpOp = AIEX::NpuWriteRTPOp::create(rewriter, op.getLoc(),

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -756,8 +756,17 @@ struct FoldConstIndexSwitchPattern
 struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
   using OpConversionPattern<airrt::DmaMemcpyNdOp>::OpConversionPattern;
 
-  DmaToNpuPattern(MLIRContext *context, PatternBenefit benefit = 1)
-      : OpConversionPattern<airrt::DmaMemcpyNdOp>(context, benefit) {}
+  // Only the static-TXN (full ELF) output cannot encode a runtime BD offset.
+  // Everywhere else the SSA offset is a legal BD word, and rerouting it to the
+  // scratchpad would silently change the host contract: an unwritten parameter
+  // reads as zero, so an existing design would keep running and transfer from
+  // the wrong address.
+  bool outputElf = false;
+
+  DmaToNpuPattern(MLIRContext *context, bool outputElf = false,
+                  PatternBenefit benefit = 1)
+      : OpConversionPattern<airrt::DmaMemcpyNdOp>(context, benefit),
+        outputElf(outputElf) {}
 
   LogicalResult
   matchAndRewrite(airrt::DmaMemcpyNdOp op, OpAdaptor adaptor,
@@ -1115,9 +1124,12 @@ struct DmaToNpuPattern : public OpConversionPattern<airrt::DmaMemcpyNdOp> {
       // instruction stream constant. Same mechanism as a herd's runtime
       // scalar, in its `addr` flavour.
       Value offsetResidual;
-      if (StringAttr paramName = declareBlockArgOffsetParameter(
-              op->getParentOfType<ModuleOp>(), dynOffsetI32, rewriter,
-              offsetResidual)) {
+      StringAttr paramName =
+          outputElf ? declareBlockArgOffsetParameter(
+                        op->getParentOfType<ModuleOp>(), dynOffsetI32,
+                        rewriter, offsetResidual)
+                    : nullptr;
+      if (paramName) {
         bd.setOffsetParameterAttr(FlatSymbolRefAttr::get(paramName));
         // The base keeps its ordinary place on the BD; the parameter is added
         // to it at dispatch.
@@ -2869,10 +2881,11 @@ struct AIRRtToNpuPass : public impl::AIRRtToNpuBase<AIRRtToNpuPass> {
     }
 
     RewritePatternSet patterns(ctx);
-    patterns.add<DmaToNpuPattern, HerdLoadToNpuPattern, SegmentLoadToNpuPattern,
+    patterns.add<HerdLoadToNpuPattern, SegmentLoadToNpuPattern,
                  ModuleMetadataToNpuPattern, L1MemRefStoreOpConversion,
                  L1AffineStoreOpConversion, HostMemRefCopyOpConversion,
                  AIRRtAllocOpConversion, AIRRtDeallocOpConversion>(ctx);
+    patterns.add<DmaToNpuPattern>(ctx, clOutputElf);
     patterns.add<AIRRtWaitAllOpConversion>(ctx, clOutputElf);
 
     if (failed(applyPartialConversion(module, target, std::move(patterns))))

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -111,16 +111,40 @@ struct AIRToAIEConversionOptions {
 // that built correctly before. The value has to be genuinely unknowable at
 // compile time, which means it traces back to a block argument (the runtime
 // sequence's own operand) rather than to any computation on constants.
+// Not every block argument qualifies. The scratchpad holds ONE value per
+// dispatch, so a value that varies within a dispatch cannot live there: an
+// scf.for induction variable is a block argument too, and routing it to the
+// scratchpad would freeze it at whatever the host last wrote. The operand has
+// to reach the enclosing function's own argument, which is the only thing that
+// is fixed for a dispatch and supplied by the host.
+//
+// Herd operands normally arrive through air.launch/segment/herd nesting rather
+// than directly, so the walk resolves each hierarchy block argument to the
+// operand it is tied to and keeps going.
 static bool isRuntimeHerdOperand(Value koperand) {
   Value v = koperand;
-  // Look through the width/type adjustments AIR inserts around scalars.
-  while (Operation *def = v.getDefiningOp()) {
-    if (!llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
-                   arith::ExtSIOp, arith::BitcastOp>(def))
+  while (true) {
+    // Look through the width/type adjustments AIR inserts around scalars.
+    while (Operation *def = v.getDefiningOp()) {
+      if (!llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
+                     arith::ExtSIOp, arith::BitcastOp>(def))
+        return false;
+      v = def->getOperand(0);
+    }
+    auto blockArg = llvm::dyn_cast<BlockArgument>(v);
+    if (!blockArg)
       return false;
-    v = def->getOperand(0);
+    Operation *owner = blockArg.getOwner()->getParentOp();
+    if (llvm::isa<func::FuncOp>(owner))
+      return true;
+    auto hier = llvm::dyn_cast<air::HierarchyInterface>(owner);
+    if (!hier)
+      return false; // a loop IV, or any other region we cannot see through
+    Value tied = hier.getTiedKernelOperand(blockArg);
+    if (!tied) // an induction variable of the hierarchy op itself
+      return false;
+    v = tied;
   }
-  return llvm::isa<BlockArgument>(v);
 }
 
 // The name both halves of the lowering agree on. AIRRtToNpu re-derives it to

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -80,6 +80,75 @@ struct AIRToAIEConversionOptions {
   unsigned stack_size;
 };
 
+// --- Runtime herd parameters via the scratchpad ---------------------------
+//
+// A herd's scalar operands reach its cores through the `__air_herd_rtp` buffer,
+// which the runtime sequence fills with `aiex.npu.write32`. That works only
+// when the value is a compile-time constant: a static TXN binary -- what the
+// full-ELF output format emits -- has nowhere to put a value the host has not
+// supplied yet, and rejects the write with
+//
+//   'aiex.npu.write32' op Cannot translate write32 with non-constant address
+//   or value to a static TXN binary
+//
+// mlir-aie's scratchpad parameters are the data-plane alternative: the core
+// reads the value from a firmware scratchpad the host writes per dispatch, so
+// the instruction stream stays constant. Only *runtime* operands are routed
+// this way; a constant keeps the existing RTP path, which costs no state-table
+// entry (there are 32 for the whole module) and leaves every existing design
+// lowering exactly as before.
+//
+// The slot numbering is deliberately left alone -- a runtime operand still
+// consumes its `__air_herd_rtp` word, it just goes unread. Keeping the two
+// sides' slot arithmetic identical is worth one wasted word per parameter.
+// "Not an arith.constant" is too weak a test here: this pass runs long before
+// the canonicalization that folds an index_cast of a constant, so it would
+// classify values that do end up constant as runtime, move them to the
+// scratchpad, and leave nobody to write them -- silently changing a design
+// that built correctly before. The value has to be genuinely unknowable at
+// compile time, which means it traces back to a block argument (the runtime
+// sequence's own operand) rather than to any computation on constants.
+static bool isRuntimeHerdOperand(Value koperand) {
+  Value v = koperand;
+  // Look through the width/type adjustments AIR inserts around scalars.
+  while (Operation *def = v.getDefiningOp()) {
+    if (!llvm::isa<arith::IndexCastOp, arith::TruncIOp, arith::ExtUIOp,
+                   arith::ExtSIOp, arith::BitcastOp>(def))
+      return false;
+    v = def->getOperand(0);
+  }
+  return llvm::isa<BlockArgument>(v);
+}
+
+// The name both halves of the lowering agree on. AIRRtToNpu re-derives it to
+// decide whether to skip a write, so this must stay a pure function of the
+// herd's symbol and the slot. Herds without a symbol keep the RTP path: there
+// would be no stable name to agree on.
+static std::string getHerdParamName(air::HerdOp h, unsigned slot) {
+  auto sym = h->getAttrOfType<StringAttr>(SymbolTable::getSymbolAttrName());
+  if (!sym)
+    return "";
+  return "__air_param_" + sym.getValue().str() + "_" + std::to_string(slot);
+}
+
+// Declare the parameter at module scope, once. The scratchpad is one hardware
+// resource shared by every PDI a runtime sequence loads, so the declaration is
+// global and every core of the herd refers to the same one -- which is also
+// why a herd spanning N cores costs one state-table entry per slot rather than
+// N.
+static void declareHerdScratchpadParameter(air::HerdOp h, StringRef name,
+                                           Type type) {
+  auto module = h->getParentOfType<ModuleOp>();
+  if (!module || module.lookupSymbol(name))
+    return;
+  OpBuilder b(module.getBodyRegion());
+  b.setInsertionPointToStart(module.getBody());
+  AIEX::ScratchpadParameterOp::create(b, h.getLoc(), b.getStringAttr(name),
+                                      TypeAttr::get(type),
+                                      /*state_table_idx=*/nullptr,
+                                      /*kind=*/nullptr);
+}
+
 // Breakpoint stages for debugging with --test-patterns
 // Each stage represents a point in the pipeline where execution can stop
 // for debugging purposes.
@@ -467,12 +536,32 @@ LogicalResult outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
         // rtp buffer and remap uses of the kernel operand to the loaded value.
         if (llvm::isa<IntegerType, IndexType, FloatType>(karg.getType())) {
 
-          // load from rtp buffer
-          SmallVector<Value> offsets{
-              arith::ConstantIndexOp::create(core_builder, hloc, rtp_slot)};
-          auto load = memref::LoadOp::create(core_builder, hloc,
-                                             IntegerType::get(ctx, 32),
-                                             rtp_buffer, offsets);
+          // A runtime operand is read from the scratchpad instead of the RTP
+          // buffer, so that nothing downstream has to encode its value into a
+          // static instruction stream. Both reads produce an i32 that the
+          // conversion below treats identically.
+          std::string paramName = getHerdParamName(h, rtp_slot);
+          Value load;
+          if (!paramName.empty() && isRuntimeHerdOperand(koperand)) {
+            declareHerdScratchpadParameter(h, paramName,
+                                           IntegerType::get(ctx, 32));
+            load = AIEX::ReadScratchpadParameterOp::create(
+                core_builder, hloc, IntegerType::get(ctx, 32),
+                FlatSymbolRefAttr::get(ctx, paramName),
+                /*buffer=*/nullptr);
+            // AIR already gates the core on its herd lock, which the runtime
+            // sequence releases only after the parameters are synced. Letting
+            // --aie-lower-scratchpad-parameters add its own lock as well would
+            // put two independent protocols on the same core.
+            core->setAttr("emit_parameter_sync_preamble",
+                          core_builder.getBoolAttr(false));
+          } else {
+            SmallVector<Value> offsets{
+                arith::ConstantIndexOp::create(core_builder, hloc, rtp_slot)};
+            load = memref::LoadOp::create(core_builder, hloc,
+                                          IntegerType::get(ctx, 32), rtp_buffer,
+                                          offsets);
+          }
 
           // truncate, extend or bitcast the value to the correct type
           Value rtp = nullptr;

--- a/mlir/lib/Conversion/AIRToAIEPass.cpp
+++ b/mlir/lib/Conversion/AIRToAIEPass.cpp
@@ -76,6 +76,9 @@ struct AIRToAIEConversionOptions {
   // forming a strict producer-ordering chain, eliminating concurrent-
   // access races on the memtile DMA. Mutually exclusive with v1.
   bool use_lock_race_condition_fix_v2;
+  // Target a static TXN binary (full ELF). Only then does a herd's runtime
+  // scalar have to leave the control plane for a scratchpad parameter.
+  bool output_elf;
   AIE::AIEDevice device;
   unsigned stack_size;
 };
@@ -542,7 +545,8 @@ LogicalResult outlineAIECores(OpBuilder &builder, AIE::DeviceOp aie_device,
           // conversion below treats identically.
           std::string paramName = getHerdParamName(h, rtp_slot);
           Value load;
-          if (!paramName.empty() && isRuntimeHerdOperand(koperand)) {
+          if (options.output_elf && !paramName.empty() &&
+              isRuntimeHerdOperand(koperand)) {
             declareHerdScratchpadParameter(h, paramName,
                                            IntegerType::get(ctx, 32));
             load = AIEX::ReadScratchpadParameterOp::create(
@@ -7942,6 +7946,7 @@ public:
           /*.insert_trace_packet_flow = */ clInsertTracePacketFlow,
           /*.use_lock_race_condition_fix = */ clUseLockRaceConditionFix,
           /*.use_lock_race_condition_fix_v2 = */ clUseLockRaceConditionFixV2,
+          /*.output_elf = */ clOutputElf,
           /*.device = */ *device,
           /*.stack_size = */ clStackSize};
 
@@ -8074,6 +8079,7 @@ public:
         /* .insert_trace_packet_flow = */ clInsertTracePacketFlow,
         /* .use_lock_race_condition_fix = */ clUseLockRaceConditionFix,
         /* .use_lock_race_condition_fix_v2 = */ clUseLockRaceConditionFixV2,
+        /* .output_elf = */ clOutputElf,
         /* .device = */ *device,
         /* .stack_size = */ clStackSize};
     if (failed(createAIEModulesAndOutlineCores(module, aie_devices, options))) {
@@ -8629,6 +8635,7 @@ FailureOr<ModuleOp> convertAIRToAIE(mlir::RewriterBase &rewriter,
       /* .insert_trace_packet_flow = */ false,
       /* .use_lock_race_condition_fix = */ true,
       /* .use_lock_race_condition_fix_v2 = */ false,
+      /* .output_elf = */ false,
       /* .device = */ *device};
   std::vector<std::pair<ModuleOp, air::HerdOp>> aie_modules;
   p.walk([&](air::HerdOp h) { aie_modules.push_back({aie_module, h}); });

--- a/mlir/test/Conversion/AIRRtToNpu/dma_offset_scratchpad.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/dma_offset_scratchpad.mlir
@@ -1,0 +1,151 @@
+//===- dma_offset_scratchpad.mlir -------------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu="output-elf=true" -canonicalize --split-input-file %s | FileCheck %s --check-prefix=ELF
+// RUN: air-opt -airrt-to-npu -canonicalize --split-input-file %s | FileCheck %s --check-prefix=SSA
+
+// A BD offset that is only known at dispatch becomes a runtime BD word, which
+// only the C++ TXN target can encode. For a static TXN (full ELF) the offset
+// moves to an mlir-aie scratchpad parameter instead: firmware adds
+// StateTable[idx] * element_size to the BD address register at dispatch, so
+// the instruction stream stays constant.
+//
+// Everywhere else the SSA offset is a perfectly good BD operand, and rerouting
+// it would silently change the host contract -- an unwritten parameter reads
+// as zero, so the transfer would quietly move to the wrong address instead of
+// failing. Hence the gate.
+
+// -----
+
+// The plain case: the offset IS the sequence argument. No static part, so the
+// BD keeps offset 0 and the parameter carries everything.
+
+// ELF-LABEL: aie.runtime_sequence @seg_plain_sequence
+// ELF:         aie.dma_bd(%{{.*}} offset = 0 {{.*}}) {offset_parameter = @__air_param_argoff_1}
+
+// SSA-LABEL: aie.runtime_sequence @plain
+// SSA-NOT:     offset_parameter
+// SSA:         aie.dma_bd(%{{.*}} offset = %{{.*}})
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId2(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "seg_plain"}
+  func.func @plain(%arg0: memref<1048576xbf16>, %off: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %p = airrt.segment_load "seg_plain" : i64
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %off], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<1048576xbf16>)
+    return
+  }
+}
+
+// -----
+
+// The KV append's real shape, and the bug that reached hardware. K writes at
+// `base + f(L)` and V at `base + KV_HALF + f(L)`. Following only the varying
+// side of the add and DROPPING the constant put both BDs on the same slot, so
+// half the cache was never written -- and it still built, still ran, and only
+// showed up as diverging logits.
+//
+// Every addend that does not reach the sequence argument is static and belongs
+// on the BD, where it folds once the enclosing loop unrolls. The two BDs share
+// one parameter because they need the same number written; they differ in
+// their own offsets.
+
+// ELF-LABEL: aie.runtime_sequence @seg_kv_sequence
+// ELF:         aie.dma_bd(%{{.*}} offset = 4096 {{.*}}) {offset_parameter = @__air_param_argoff_1_x256_m256}
+// ELF:         aie.dma_bd(%{{.*}} offset = 20480 {{.*}}) {offset_parameter = @__air_param_argoff_1_x256_m256}
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @appendK(%shim_noc_tile_0_0, S2MM, 0)
+    %shim_noc_tile_1_0 = aie.tile(1, 0)
+    aie.shim_dma_allocation @appendV(%shim_noc_tile_1_0, S2MM, 0)
+  } {sym_name = "seg_kv"}
+  func.func @kv_append(%arg0: memref<1048576xbf16>, %L: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %c16384_i64 = arith.constant 16384 : i64
+    %p = airrt.segment_load "seg_kv" : i64
+    // f(L) = (L - 1) * 256, the slot this token appends at.
+    %lm1 = arith.subi %L, %c1_i64 : i64
+    %delta = arith.muli %lm1, %c256_i64 : i64
+    // K goes at base + delta, V one KV_HALF further along.
+    %koff = arith.addi %c4096_i64, %delta : i64
+    %vhalf = arith.addi %c4096_i64, %c16384_i64 : i64
+    %voff = arith.addi %vhalf, %delta : i64
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %koff], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @appendK} : (i32, i64, i64, memref<1048576xbf16>)
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %voff], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @appendV} : (i32, i64, i64, memref<1048576xbf16>)
+    return
+  }
+}
+
+// -----
+
+// Two BDs needing DIFFERENT affine functions of the same argument get
+// DIFFERENT parameters. The host writes one number per parameter, so sharing
+// an entry here would be right for one BD and wrong for the other. The
+// coefficients are part of the name, which is also how a host can derive the
+// value from params.txt without knowing the design.
+
+// ELF-LABEL: aie.runtime_sequence @seg_two_sequence
+// ELF-DAG:     {offset_parameter = @__air_param_argoff_1_x256_m256}
+// ELF-DAG:     {offset_parameter = @__air_param_argoff_1_x512_p0}
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @outA(%shim_noc_tile_0_0, S2MM, 0)
+    %shim_noc_tile_1_0 = aie.tile(1, 0)
+    aie.shim_dma_allocation @outB(%shim_noc_tile_1_0, S2MM, 0)
+  } {sym_name = "seg_two"}
+  func.func @two_formulas(%arg0: memref<1048576xbf16>, %L: i64) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c512_i64 = arith.constant 512 : i64
+    %p = airrt.segment_load "seg_two" : i64
+    %lm1 = arith.subi %L, %c1_i64 : i64
+    %offA = arith.muli %lm1, %c256_i64 : i64
+    %offB = arith.muli %L, %c512_i64 : i64
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %offA], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outA} : (i32, i64, i64, memref<1048576xbf16>)
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %offB], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @outB} : (i32, i64, i64, memref<1048576xbf16>)
+    return
+  }
+}
+
+// -----
+
+// A constant offset is not a parameter, even under output-elf. State-table
+// entries are a module-wide resource of 32, and a value the compiler already
+// knows costs nothing to encode.
+
+// ELF-LABEL: aie.runtime_sequence @seg_const_sequence
+// ELF-NOT:     offset_parameter
+// ELF:         aie.dma_bd(%{{.*}} offset = 4096
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId2(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "seg_const"}
+  func.func @constant_offset(%arg0: memref<1048576xbf16>) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2_i32 = arith.constant 2 : i32
+    %c256_i64 = arith.constant 256 : i64
+    %c4096_i64 = arith.constant 4096 : i64
+    %p = airrt.segment_load "seg_const" : i64
+    airrt.dma_memcpy_nd(%c2_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c4096_i64], [%c1_i64, %c1_i64, %c1_i64, %c256_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId2} : (i32, i64, i64, memref<1048576xbf16>)
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/herd_rtp_scratchpad_skip.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/herd_rtp_scratchpad_skip.mlir
@@ -1,0 +1,143 @@
+//===- herd_rtp_scratchpad_skip.mlir ----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt -airrt-to-npu -canonicalize --split-input-file %s | FileCheck %s
+
+// When AIRToAIE routes a herd slot through an mlir-aie scratchpad parameter,
+// the core reads the parameter directly and there is nothing for this pass to
+// write into the RTP buffer.
+//
+// The DECLARATION is the contract between the two passes, not a re-run of the
+// classifier. Re-deciding "is this operand constant?" here would let the two
+// disagree after any canonicalization that runs between them -- and they must
+// not, because the core loads whichever source AIRToAIE picked.
+
+// -----
+
+// The parameter exists for slot 0, so slot 0 gets no rtp_write. The sync
+// marker goes ahead of the herd's set_lock: the parameter has to be in place
+// before a core is let past its herd lock, and one marker per sequence is
+// enough because it syncs the whole table.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl
+// CHECK:         aiex.sync_scratchpad_parameters_from_host
+// CHECK-NOT:     aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0
+// CHECK:         aiex.set_lock(%{{.*}}, 1)
+module {
+  aiex.scratchpad_parameter @__air_param_herd_0_0 : i32
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<1xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {air.herd_name = "herd_0", link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl(%arg0: memref<64xi32>, %L: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %h0 = airrt.herd_load "herd_0" (%L) {segment_name = "seg"} : (i32) -> i64
+    airrt.wait_all %f0 {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}
+
+// -----
+
+// A parameter for a DIFFERENT herd must not suppress this one's write. The
+// name carries the herd symbol, so the lookup is per (herd, slot).
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl_other
+// CHECK-SAME:    %{{.*}}: memref<64xi32>, %[[L:[a-zA-Z0-9_]+]]: i32
+// CHECK:         aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0, %[[L]]) : i32
+module {
+  aiex.scratchpad_parameter @__air_param_someotherherd_0 : i32
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<1xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {air.herd_name = "herd_0", link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl_other(%arg0: memref<64xi32>, %L: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %h0 = airrt.herd_load "herd_0" (%L) {segment_name = "seg"} : (i32) -> i64
+    airrt.wait_all %f0 {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}
+
+// -----
+
+// Two slots, only the first parameterised: slot 1 still gets its write, and it
+// keeps index 1. The slot counter advances for a skipped slot too, so the two
+// passes' arithmetic stays aligned -- compacting here would make the core read
+// the wrong word.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl_two
+// CHECK-SAME:    %{{.*}}: memref<64xi32>, %{{.*}}: i32, %[[M:[a-zA-Z0-9_]+]]: i32
+// CHECK-NOT:     aiex.npu.rtp_write(@__air_herd_rtp_0_2, 0
+// CHECK:         aiex.npu.rtp_write(@__air_herd_rtp_0_2, 1, %[[M]]) : i32
+module {
+  aiex.scratchpad_parameter @__air_param_herd_0_0 : i32
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<2xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {air.herd_name = "herd_0", link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl_two(%arg0: memref<64xi32>, %L: i32, %M: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %h0 = airrt.herd_load "herd_0" (%L, %M) {segment_name = "seg"} : (i32, i32) -> i64
+    airrt.wait_all %f0 {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRRtToNpu/herd_rtp_scratchpad_skip.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/herd_rtp_scratchpad_skip.mlir
@@ -141,3 +141,102 @@ module {
     return
   }
 }
+
+// -----
+
+// No `segment_name`: the pass falls back to searching every device for the RTP
+// buffer, and has to resolve the owning device while it is there. Answering
+// only "does the buffer exist somewhere" leaves no core to ask which slots
+// AIRToAIE moved, so every slot gets a write -- including the runtime one,
+// which is the non-constant write32 a static TXN cannot encode.
+
+// (This path emits no herd-lock releases either -- that lookup is also keyed
+// on segment_name -- so the check is on the writes.)
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl_no_segname
+// CHECK:         aiex.sync_scratchpad_parameters_from_host
+// CHECK-NOT:     aiex.npu.rtp_write
+module {
+  aiex.scratchpad_parameter @__air_param_herd_0_0 : i32
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<1xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {air.herd_name = "herd_0", link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl_no_segname(%arg0: memref<64xi32>, %L: i32) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+    %h0 = airrt.herd_load "herd_0" (%L) : (i32) -> i64
+    airrt.wait_all %f0 {"air.launch_end"}
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}
+
+// -----
+
+// The marker has to stay a DIRECT child of the sequence: that is what
+// --aie-lower-scratchpad-parameters expands, and it ignores any other, so a
+// marker that drifts into a loop body leaves the arm running on whatever the
+// parameter buffers last held. Nothing about that failure is loud.
+//
+// A herd armed inside a loop is where that can happen, because the emission
+// point is the herd_load. This pins the walk back out to sequence level, and
+// pins that one marker serves the whole loop rather than one per iteration.
+
+// CHECK-LABEL: aie.runtime_sequence @ctrl_looped
+// CHECK:         aiex.sync_scratchpad_parameters_from_host
+// CHECK:         scf.for
+// CHECK-NOT:       aiex.sync_scratchpad_parameters_from_host
+// CHECK:         }
+module {
+  aiex.scratchpad_parameter @__air_param_herd_0_0 : i32
+  aie.device(npu2) @seg {
+    %tile_0_0 = aie.tile(0, 0)
+    %tile_0_2 = aie.tile(0, 2)
+    %__air_herd_lock_0_2 = aie.lock(%tile_0_2, 0) {init = 0 : i32, sym_name = "__air_herd_lock_0_2"}
+    %__air_herd_rtp_0_2 = aie.buffer(%tile_0_2) {sym_name = "__air_herd_rtp_0_2"} : memref<2xi32>
+    aie.shim_dma_allocation @feedIn(%tile_0_0, MM2S, 0)
+    %core_0_2 = aie.core(%tile_0_2) {
+      aie.end
+    } {air.herd_name = "herd_0", link_with = "kernel.o"}
+  } {sym_name = "seg"}
+
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "seg"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 2 : i64, sym_name = "herd_0"}
+    }
+  }
+
+  func.func @ctrl_looped(%arg0: memref<64xi32>, %L: i32, %M: i32) {
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %c4 = arith.constant 4 : index
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c64_i64 = arith.constant 64 : i64
+    %feed = arith.constant 4 : i32
+    scf.for %i = %c0 to %c4 step %c1 {
+      %f0 = airrt.dma_memcpy_nd(%feed, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %c0_i64], [%c1_i64, %c1_i64, %c1_i64, %c64_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @feedIn} : (i32, i64, i64, memref<64xi32>) : !airrt.event
+      %h0 = airrt.herd_load "herd_0" (%L, %M) {segment_name = "seg"} : (i32, i32) -> i64
+      airrt.wait_all %f0 {"air.launch_end"}
+    }
+    %p = airrt.segment_load "seg" : i64
+    return
+  }
+}

--- a/mlir/test/Conversion/AIRToAIE/air_herd_rtp_scratchpad.mlir
+++ b/mlir/test/Conversion/AIRToAIE/air_herd_rtp_scratchpad.mlir
@@ -1,0 +1,139 @@
+//===- air_herd_rtp_scratchpad.mlir -----------------------------*- MLIR -*-===//
+//
+// Copyright (C) 2026, Advanced Micro Devices, Inc. All rights reserved.
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: air-opt %s --split-input-file -air-to-aie="output-elf=true" | FileCheck %s --check-prefix=ELF
+// RUN: air-opt %s --split-input-file -air-to-aie | FileCheck %s --check-prefix=RTP
+
+// A herd's runtime scalar reaches the core through the RTP buffer, which
+// AIRRtToNpu writes with a control-plane write32. A static TXN binary (the
+// full-ELF output) cannot encode a write32 whose value is not known at compile
+// time, so on that target the operand goes through an mlir-aie scratchpad
+// parameter instead: declared at module scope, read by the core, written by
+// the host per dispatch.
+//
+// This is gated because the two have different host contracts. An unwritten
+// scratchpad parameter reads as zero rather than failing, so turning it on
+// everywhere would leave existing designs running with a silently wrong value.
+
+// -----
+
+// The operand is the function's own argument: unknowable at compile time, so
+// under output-elf it becomes a parameter and the core reads it directly. The
+// core also opts out of the lowering's own sync preamble -- AIR's herd lock
+// already orders the cores against the parameter write, and a second protocol
+// would only give the two a way to disagree.
+
+// ELF: aiex.scratchpad_parameter @__air_param_rtherd_0 : i32
+// ELF-LABEL: aie.device
+// ELF: aie.core
+// ELF: aiex.read_scratchpad_parameter @__air_param_rtherd_0 : i32
+// ELF-NOT: memref.load %{{.*}}[%c0] : memref<1xi32>
+// ELF: emit_parameter_sync_preamble = false
+
+// RTP-NOT: aiex.scratchpad_parameter
+// RTP-LABEL: aie.device
+// RTP: %[[BUF:.*]] = aie.buffer(%{{.*}}) {{{.*}}sym_name = "__air_herd_rtp_
+// RTP: aie.core
+// RTP: memref.load %[[BUF]][%c0] : memref<1xi32>
+func.func @runtime_scalar(%L: i32) {
+  %c1 = arith.constant 1 : index
+  air.herd @rtherd tile(%tx, %ty) in (%sx = %c1, %sy = %c1) args(%a = %L) : i32 {
+    %buf = memref.alloc() : memref<1xi32, 2>
+    %zero = arith.constant 0 : index
+    %0 = memref.load %buf[%zero] : memref<1xi32, 2>
+    %1 = arith.addi %0, %a : i32
+    memref.store %1, %buf[%zero] : memref<1xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+
+// -----
+
+// A constant operand keeps the RTP path even under output-elf. "Not an
+// arith.constant" would be too weak a test to rely on -- this pass runs long
+// before the canonicalization that folds an index_cast of a constant -- so the
+// classifier requires the operand to trace to a block argument. Getting this
+// wrong moves a value to the scratchpad with nobody to write it.
+
+// ELF-NOT: aiex.scratchpad_parameter
+// ELF-LABEL: aie.device
+// ELF: %[[BUF:.*]] = aie.buffer(%{{.*}}) {{{.*}}sym_name = "__air_herd_rtp_
+// ELF: aie.core
+// ELF: memref.load %[[BUF]][%c0] : memref<1xi32>
+func.func @constant_scalar() {
+  %c1 = arith.constant 1 : index
+  %c42 = arith.constant 42 : i32
+  air.herd @cherd tile(%tx, %ty) in (%sx = %c1, %sy = %c1) args(%a = %c42) : i32 {
+    %buf = memref.alloc() : memref<1xi32, 2>
+    %zero = arith.constant 0 : index
+    %0 = memref.load %buf[%zero] : memref<1xi32, 2>
+    %1 = arith.addi %0, %a : i32
+    memref.store %1, %buf[%zero] : memref<1xi32, 2>
+    air.herd_terminator
+  }
+  return
+}
+
+// -----
+
+// An induction variable is a block argument too, but it varies WITHIN a
+// dispatch while the scratchpad holds one value per dispatch. Routing it there
+// would freeze it at whatever the host last wrote. It stays on the RTP path,
+// which is rewritten per iteration.
+
+// ELF-NOT: aiex.scratchpad_parameter
+// ELF-LABEL: aie.device
+// ELF: %[[BUF:.*]] = aie.buffer(%{{.*}}) {{{.*}}sym_name = "__air_herd_rtp_
+// ELF: aie.core
+// ELF: memref.load %[[BUF]][%c0] : memref<1xi32>
+func.func @loop_varying_scalar() {
+  %c0 = arith.constant 0 : index
+  %c1 = arith.constant 1 : index
+  %c4 = arith.constant 4 : index
+  scf.for %iv = %c0 to %c4 step %c1 {
+    %ivi = arith.index_cast %iv : index to i32
+    air.herd @lherd tile(%tx, %ty) in (%sx = %c1, %sy = %c1) args(%a = %ivi) : i32 {
+      %buf = memref.alloc() : memref<1xi32, 2>
+      %zero = arith.constant 0 : index
+      %0 = memref.load %buf[%zero] : memref<1xi32, 2>
+      %1 = arith.addi %0, %a : i32
+      memref.store %1, %buf[%zero] : memref<1xi32, 2>
+      air.herd_terminator
+    }
+  }
+  return
+}
+
+// -----
+
+// Mixed operands: the runtime one moves to the scratchpad, the constant one
+// stays. The slot numbering is deliberately NOT compacted -- a runtime operand
+// still consumes its RTP word, it just goes unread -- so that this pass and
+// AIRRtToNpu cannot drift on which slot is which. Here that shows as the
+// constant keeping slot 1 in a 2-element buffer.
+
+// ELF: aiex.scratchpad_parameter @__air_param_mherd_0 : i32
+// ELF-LABEL: aie.device
+// ELF: %[[BUF:.*]] = aie.buffer(%{{.*}}) {{{.*}}sym_name = "__air_herd_rtp_{{.*}}} : memref<2xi32>
+// ELF: aie.core
+// ELF-DAG: aiex.read_scratchpad_parameter @__air_param_mherd_0 : i32
+// ELF-DAG: memref.load %[[BUF]][%c1] : memref<2xi32>
+func.func @mixed_scalars(%L: i32) {
+  %c1 = arith.constant 1 : index
+  %c42 = arith.constant 42 : i32
+  air.herd @mherd tile(%tx, %ty) in (%sx = %c1, %sy = %c1) args(%a = %L, %b = %c42) : i32, i32 {
+    %buf = memref.alloc() : memref<1xi32, 2>
+    %zero = arith.constant 0 : index
+    %0 = memref.load %buf[%zero] : memref<1xi32, 2>
+    %1 = arith.addi %0, %a : i32
+    %2 = arith.addi %1, %b : i32
+    memref.store %2, %buf[%zero] : memref<1xi32, 2>
+    air.herd_terminator
+  }
+  return
+}

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1390,6 +1390,12 @@ static LogicalResult runAieCompilation() {
       aieccCmd.push_back("--get-full-elf");
       aieccCmd.push_back("--expand-load-pdis");
       aieccCmd.push_back("--full-elf-name=" + elfName.getValue());
+      // The scratchpad-parameter lowering runs unconditionally in aiecc; this
+      // only asks it to also write the layout out. Without params.txt the host
+      // has no way to name a runtime parameter -- ParameterScratchpad indexes
+      // the state table by the names in that file -- so an ELF carrying a
+      // runtime herd scalar would be unusable.
+      aieccCmd.push_back("--get-scratchpad-parameters");
     } else if (outputFormat == OF_xclbin) {
       aieccCmd.push_back("--get-xclbin");
       aieccCmd.push_back("--xclbin-name=" + xclbinFile);

--- a/tools/aircc/aircc.cpp
+++ b/tools/aircc/aircc.cpp
@@ -1241,6 +1241,10 @@ static LogicalResult runAieCompilation() {
        << (useLockRaceConditionFix ? "true" : "false");
     os << " use-lock-race-condition-fix-v2="
        << (useLockRaceConditionFixV2 ? "true" : "false");
+    // The full-ELF output is a static TXN, which cannot hold a runtime herd
+    // scalar; only there does AIRToAIE route one through a scratchpad
+    // parameter instead of the RTP control-plane write.
+    os << " output-elf=" << (outputFormat == OF_elf ? "true" : "false");
     if (stackSize.getNumOccurrences() > 0)
       os << " stack-size=" << stackSize.getValue();
     os << "}";


### PR DESCRIPTION
A herd's runtime scalar reaches its core through `aiex.npu.rtp_write`, which
lowers to a control-plane `write32`. The full-ELF output is a static TXN
binary, and that cannot encode a `write32` whose value is not known at compile
time:

```
error: 'aiex.npu.write32' op Cannot translate write32 with non-constant
       address or value to a static TXN binary
```

Correctly so — a static TXN is a byte array with nowhere to put a value the
host has not supplied yet. The xclbin path works because the instruction
stream is a BO the host patches.

**mlir-aie already has the mechanism and mlir-air does not use it.** Scratchpad
parameters (Xilinx/mlir-aie#3061) are exactly this feature: the lowering emits
a *constant* placeholder `write32` plus an `update_from_scratchpad`, and
firmware substitutes the real value from a 32-entry state table at dispatch.
The host reaches that table through `xrt::run::get_ctrl_scratchpad_bo()`, so
no extra kernel argument is needed. There is no reference to
`scratchpad_parameter` anywhere in `mlir/`, and `AIRRtToNpuPass.cpp` builds
its BDs with `/*offset_parameter=*/nullptr` hardcoded.

This PR routes both kinds through it:

| quantity | mechanism |
|---|---|
| a herd's runtime scalar | `aiex.scratchpad_parameter` + `read_scratchpad_parameter` (`core` kind) |
| a runtime BD offset | `offset_parameter` on `aie.dma_bd` (`addr` kind) |

`aircc` passes `--get-scratchpad-parameters` so `params.txt` is emitted;
without it the host has no name to write the parameter by.

### Gated on `output-elf`, deliberately

Only a static TXN needs this. Everywhere else the RTP write and the SSA BD
offset are legal, and rerouting them changes the host contract **silently** —
an unwritten scratchpad parameter reads as *zero*, so an existing xclbin
design would keep running and transfer from the wrong address rather than
fail. `AIRRtToNpu` already had an `output-elf` option; `AIRToAIE` gains one,
and `aircc` sets both from the output format.

`Conversion/AIRRtToNpu/runtime_valued_size.mlir` is what caught this: an
earlier revision was replacing a legitimate runtime BD offset with `offset = 0`
plus a parameter no host was going to write.

### Two subtleties worth reviewer attention

**Slot numbering is not compacted.** A runtime operand still consumes its
`__air_herd_rtp` word, it just goes unread. Keeping both passes' slot
arithmetic identical is worth one wasted word per parameter — the declaration
is the contract between them, and re-deciding "is this constant?" in the
second pass would let the two disagree after any intervening canonicalization.

**The affine coefficients are part of the parameter name.** The host writes one
number per parameter, so two BDs may share an entry only if they need the same
number. `__air_param_argoff_5_x256_m256` means `L*256 - 256`. This also lets a
host derive the value from `params.txt` without knowing the design. I am not
attached to encoding it in the symbol — extra columns in `params.txt` would be
cleaner, but that needs an mlir-aie change. **Happy to redo this if you prefer
that shape.**

### Tests

Three new lit files, and every case is mutation-checked — reverting the
behaviour it describes makes it fail:

| mutation | caught by |
|---|---|
| drop a constant addend instead of banking it | `dma_offset_scratchpad` |
| ignore the affine coefficients when naming | `dma_offset_scratchpad` |
| remove the `output-elf` gate on BD offsets | `runtime_valued_size` (existing) |
| do not hoist the sync ahead of the lock releases | `herd_rtp_scratchpad_skip` |
| skip the RTP write regardless of the symbol | `herd_rtp_scratchpad_skip` |
| remove the `output-elf` gate on herd scalars | `air_herd_rtp_scratchpad` |
| treat any block argument as runtime | `air_herd_rtp_scratchpad` |

Writing them found two real bugs, both fixed here:

- **The sync marker landed after the herd-lock releases.** A later hoist moves
  RTP writes and set_locks to the front of their arm; the marker was not part
  of it, so cores were released before their parameter was in place. It looked
  correct in the design I was developing against only because its herd is
  nested, which put the marker ahead of the whole arm by accident. Any
  sequence with the `herd_load` at sequence level got it wrong. An arm that
  reloads its PDI now gets its own sync: the reload rewrites tile memory, so
  the parameter buffers an earlier sync populated are gone.
- **`isRuntimeHerdOperand` accepted any block argument**, including an
  `scf.for` induction variable — which varies *within* a dispatch while the
  scratchpad holds one value *per* dispatch, so it would have frozen at
  whatever the host last wrote. It now resolves hierarchy block arguments
  through `getTiedKernelOperand` and requires the enclosing function's own
  argument.

553/553 lit tests pass. `clang-format` clean on the changed C++.

### Hardware

Depends on Xilinx/mlir-aie#3679 (merged) for any AIR design whose segment
sequence contains an `scf.for`.

On NPU2 (Strix), with `programming_examples/fused_decode` at
`ATTN_MAXL=2048`, one runtime-L ELF against four separately compiled builds:

```
L=   64  vs a DECODE_ATTN_L=64   build: logits identical, kv-pos 63
L=  512  vs a DECODE_ATTN_L=512  build: logits identical, kv-pos 511
L= 1024  vs a DECODE_ATTN_L=1024 build: logits identical, kv-pos 1023
L= 2048  vs a DECODE_ATTN_L=2048 build: logits identical, kv-pos 2047
```

Bitwise identical across a 32x range of context length, with the KV append
landing at position L-1 each time — one binary reproducing what four builds
produce. The static path is unaffected: byte-identical ELF, zero parameters
emitted, and a `DECODE_DYNSEQ` xclbin is back to 35 `rtp_write`s and zero
parameters.

(The `DECODE_ATTN_L` knob those reference builds use is in #1978, which is
otherwise independent of this PR.)

### Known limitation, upstream of here

`AIEX::emitUpdateBdAddressFromOffsetParameter` emits a read-modify-write of a
single 32-bit BD address register, so an offset carrying out of the low word
never reaches the high word. Bounded — it needs a buffer placed within the
delta of a 4 GiB boundary — but silent. Worth an mlir-aie issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
