### PR TITLE
[air.api][AIRRtToNpu] Surface for a temporally dispatched design, and the shim coalescer bug porting it found

### DIFF
--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -2315,13 +2315,43 @@ struct PeeledOffset {
   const void *shape;
 };
 
-// Split an affine result expression into its constant term and the rest.
-static std::pair<AffineExpr, int64_t> splitAffineConstant(AffineExpr expr) {
-  if (auto add = dyn_cast<AffineBinaryOpExpr>(expr))
-    if (add.getKind() == AffineExprKind::Add)
-      if (auto c = dyn_cast<AffineConstantExpr>(add.getRHS()))
-        return {add.getLHS(), c.getValue()};
-  return {expr, 0};
+// Split an affine result expression into its whole constant term and the rest.
+// The rest is null when the expression was entirely constant.
+//
+// Simplify first. AffineExpr's own construction already folds successive
+// constants and moves a constant to the RHS of an add, so `4 + s0 * 8` and
+// `s0 * 8 + 4 + 16` cannot reach here unsimplified -- but it does NOT
+// distribute a product, so `(s0 + 2) * 8` keeps its constant buried where a
+// top-level scan cannot see it. simplifyAffineExpr expands that to
+// `s0 * 8 + 16`, and the 16 then reaches the addend where it belongs. Without
+// this, two feeds at `(s0 + 2) * 8` and `(s0 + 4) * 8` -- a contiguous run --
+// land in different groups and do not coalesce.
+//
+// The loop that follows is defensive rather than load-bearing, for expressions
+// built outside that canonicalisation.
+static std::pair<AffineExpr, int64_t>
+splitAffineConstant(AffineExpr expr, unsigned numDims, unsigned numSymbols) {
+  expr = simplifyAffineExpr(expr, numDims, numSymbols);
+  int64_t constant = 0;
+  while (true) {
+    if (auto c = dyn_cast<AffineConstantExpr>(expr))
+      return {AffineExpr(), constant + c.getValue()};
+    auto add = dyn_cast<AffineBinaryOpExpr>(expr);
+    if (!add || add.getKind() != AffineExprKind::Add)
+      break;
+    if (auto c = dyn_cast<AffineConstantExpr>(add.getRHS())) {
+      constant += c.getValue();
+      expr = add.getLHS();
+      continue;
+    }
+    if (auto c = dyn_cast<AffineConstantExpr>(add.getLHS())) {
+      constant += c.getValue();
+      expr = add.getRHS();
+      continue;
+    }
+    break;
+  }
+  return {expr, constant};
 }
 
 static PeeledOffset peelOffset(Value v) {
@@ -2354,7 +2384,13 @@ static PeeledOffset peelOffset(Value v) {
     if (auto apply = dyn_cast_if_present<affine::AffineApplyOp>(def)) {
       AffineMap map = apply.getAffineMap();
       if (map.getNumResults() == 1 && apply.getMapOperands().size() == 1) {
-        auto [rest, constant] = splitAffineConstant(map.getResult(0));
+        auto [rest, constant] = splitAffineConstant(
+            map.getResult(0), map.getNumDims(), map.getNumSymbols());
+        // A map that simplified to a bare constant addresses a fixed offset,
+        // so it has no base at all -- the straight-line case, which groups
+        // with the other constant-offset feeds rather than against itself.
+        if (!rest)
+          return {nullptr, addend + constant, nullptr};
         return {apply.getMapOperands().front(), addend + constant,
                 rest.getAsOpaquePointer()};
       }

--- a/mlir/lib/Conversion/AIRRtToNpuPass.cpp
+++ b/mlir/lib/Conversion/AIRRtToNpuPass.cpp
@@ -2298,15 +2298,37 @@ LogicalResult tileIllegalWrapDim(airrt::DmaMemcpyNdOp memcpy_op) {
 // channel's transfers ahead of the sibling-channel round-major interleave; that
 // reorder is numerically equivalent to the fragmented feed (verified
 // output-identical on an exercising design).
-// Peel an offset into (base, constant addend): a rolled body's offsets are
-// `addi(loop-derived base, const)`, so two feeds are contiguous when they
-// share a base and their addends are. A constant offset has a null base,
+// Peel an offset into (base, constant addend, shape): a rolled body's offsets
+// are a loop-derived base plus a constant, so two feeds are contiguous when
+// they share a base and their addends are. A constant offset has a null base,
 // which is the straight-line case.
-static std::pair<Value, int64_t> peelOffset(Value v) {
+//
+// `shape` distinguishes two offsets that peel to the same base Value but scale
+// it differently. It is null for the arith spelling, where peeling only ever
+// strips additive constants, and carries the affine.apply's non-constant
+// sub-expression otherwise. Without it, `apply(s0 * 8 + 4)` and
+// `apply(s0 * 64 + 4)` would both report base s0 and addend 4, and be merged as
+// if they addressed the same run.
+struct PeeledOffset {
+  Value base;
+  int64_t addend;
+  const void *shape;
+};
+
+// Split an affine result expression into its constant term and the rest.
+static std::pair<AffineExpr, int64_t> splitAffineConstant(AffineExpr expr) {
+  if (auto add = dyn_cast<AffineBinaryOpExpr>(expr))
+    if (add.getKind() == AffineExprKind::Add)
+      if (auto c = dyn_cast<AffineConstantExpr>(add.getRHS()))
+        return {add.getLHS(), c.getValue()};
+  return {expr, 0};
+}
+
+static PeeledOffset peelOffset(Value v) {
   int64_t addend = 0;
   while (v) {
     if (auto c = getConstantIntValue(v))
-      return {nullptr, addend + *c};
+      return {nullptr, addend + *c, nullptr};
     Operation *def = v.getDefiningOp();
     if (auto cast = dyn_cast_if_present<arith::IndexCastOp>(def)) {
       v = cast.getIn();
@@ -2324,9 +2346,22 @@ static std::pair<Value, int64_t> peelOffset(Value v) {
         continue;
       }
     }
+    // The same address written as one affine.apply rather than an arith chain.
+    // A frontend that folds index arithmetic into a single map -- which AIR's
+    // own dependency analysis and DMA specialisation prefer -- otherwise loses
+    // shim coalescing entirely, silently: the feed still runs, in twice as many
+    // BDs.
+    if (auto apply = dyn_cast_if_present<affine::AffineApplyOp>(def)) {
+      AffineMap map = apply.getAffineMap();
+      if (map.getNumResults() == 1 && apply.getMapOperands().size() == 1) {
+        auto [rest, constant] = splitAffineConstant(map.getResult(0));
+        return {apply.getMapOperands().front(), addend + constant,
+                rest.getAsOpaquePointer()};
+      }
+    }
     break;
   }
-  return {v, addend};
+  return {v, addend, nullptr};
 }
 
 static void coalesceShimDmaOrder(ModuleOp module) {
@@ -2338,6 +2373,7 @@ static void coalesceShimDmaOrder(ModuleOp module) {
   // multi-dim wrap, or non-unit inner stride).
   struct Desc {
     Value base;
+    const void *shape;
     int64_t offset;
     int64_t len;
   };
@@ -2359,6 +2395,7 @@ static void coalesceShimDmaOrder(ModuleOp module) {
         (*strides)[3] != 1)
       return std::nullopt;
     Value base = nullptr;
+    const void *shape = nullptr;
     int64_t totalOffset = 0;
     for (auto [off, str] : llvm::zip_equal(d.getMixedOffsets(), *strides)) {
       if (auto c = getConstantIntValue(off)) {
@@ -2368,13 +2405,14 @@ static void coalesceShimDmaOrder(ModuleOp module) {
       // One dynamic offset, on the unit-stride innermost dim.
       if (base || str != 1)
         return std::nullopt;
-      auto [b, addend] = peelOffset(cast<Value>(off));
-      if (!b)
+      auto peeled = peelOffset(cast<Value>(off));
+      if (!peeled.base)
         return std::nullopt;
-      base = b;
-      totalOffset += addend;
+      base = peeled.base;
+      shape = peeled.shape;
+      totalOffset += peeled.addend;
     }
-    return Desc{base, totalOffset, (*lengths)[3]};
+    return Desc{base, shape, totalOffset, (*lengths)[3]};
   };
 
   for (auto f : funcOps) {
@@ -2400,8 +2438,9 @@ static void coalesceShimDmaOrder(ModuleOp module) {
     };
     // The base joins the key: feeds off different bases are never contiguous,
     // and for a rolled body the base is what distinguishes one wave's slice.
-    llvm::MapVector<std::tuple<int64_t, StringRef, void *, void *>,
-                    SmallVector<Entry>>
+    llvm::MapVector<
+        std::tuple<int64_t, StringRef, void *, void *, const void *>,
+        SmallVector<Entry>>
         groups;
     for (auto d : paced) {
       auto desc = describe(d);
@@ -2414,7 +2453,7 @@ static void coalesceShimDmaOrder(ModuleOp module) {
       if (auto w = d->getAttrOfType<IntegerAttr>(air::attrs::LaunchWave))
         wave = w.getInt();
       groups[{wave, md.getValue(), d.getMemref().getAsOpaquePointer(),
-              desc->base.getAsOpaquePointer()}]
+              desc->base.getAsOpaquePointer(), desc->shape}]
           .push_back({d, desc->offset, desc->len});
     }
 

--- a/mlir/lib/Util/Dependency.cpp
+++ b/mlir/lib/Util/Dependency.cpp
@@ -8,6 +8,7 @@
 
 #include "air/Util/Dependency.h"
 #include "air/Util/Util.h"
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
 #include "mlir/Dialect/SCF/Utils/Utils.h"
 #include "mlir/IR/Iterators.h"
@@ -1279,13 +1280,26 @@ bool isTripCountDivisibleByFactor(scf::ForOp forOp, uint64_t factor) {
   auto step = getConstantIntValue(forOp.getStep());
   if (!lb || *lb != 0 || !step || *step != 1)
     return false;
-  auto mul = forOp.getUpperBound().getDefiningOp<arith::MulIOp>();
-  if (!mul)
+  if (auto mul = forOp.getUpperBound().getDefiningOp<arith::MulIOp>()) {
+    for (Value operand : {mul.getLhs(), mul.getRhs()})
+      if (auto c = getConstantIntValue(operand))
+        if (*c != 0 && (*c % (int64_t)factor) == 0)
+          return true;
     return false;
-  for (Value operand : {mul.getLhs(), mul.getRhs()})
-    if (auto c = getConstantIntValue(operand))
-      if (*c != 0 && (*c % (int64_t)factor) == 0)
-        return true;
+  }
+  // The same bound written as one affine map rather than an arith chain. A
+  // frontend that folds index arithmetic into affine.apply -- which AIR's own
+  // dependency analysis and DMA specialisation prefer -- would otherwise lose
+  // this, and lose it silently: the loop still unrolls, with a dead runtime
+  // epilogue whose never-filled DMA BD ring slots corrupt the count-free ring
+  // locks. getLargestKnownDivisor answers exactly the question asked here.
+  if (auto apply =
+          forOp.getUpperBound().getDefiningOp<affine::AffineApplyOp>()) {
+    AffineMap map = apply.getAffineMap();
+    if (map.getNumResults() != 1)
+      return false;
+    return (map.getResult(0).getLargestKnownDivisor() % (int64_t)factor) == 0;
+  }
   return false;
 }
 

--- a/mlir/test/Conversion/AIRRtToNpu/coalesce_shim_dma.mlir
+++ b/mlir/test/Conversion/AIRRtToNpu/coalesce_shim_dma.mlir
@@ -335,3 +335,86 @@ module {
     return
   }
 }
+
+// -----
+
+// An offset spelled as ONE affine.apply rather than an arith chain still
+// coalesces. A frontend that folds index arithmetic into a single map -- which
+// AIR's own dependency analysis and DMA specialisation prefer -- otherwise
+// loses coalescing silently: the feed still runs, in twice the BDs. Two paced
+// feeds at `s0 * 4096` and `s0 * 4096 + 2048`, each len 2048, are one
+// contiguous run and merge into a single len-4096 BD at a dynamic offset.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<16384xbf16> offset = %{{.*}} len = 4096 sizes = [4096] strides = [1])
+// CHECK-NOT: len = 2048
+
+// NOCOAL-LABEL: aie.device(npu2)
+// NOCOAL: aie.dma_bd(%arg0 : memref<16384xbf16> offset = %{{.*}} len = 2048 sizes = [2048] strides = [1])
+// NOCOAL: aie.dma_bd(%arg0 : memref<16384xbf16> offset = %{{.*}} len = 2048 sizes = [2048] strides = [1])
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<16384xbf16>, %wave: index) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %a0 = affine.apply affine_map<()[s0] -> (s0 * 4096)>()[%wave]
+    %o0 = arith.index_cast %a0 : index to i64
+    %a1 = affine.apply affine_map<()[s0] -> (s0 * 4096 + 2048)>()[%wave]
+    %o1 = arith.index_cast %a1 : index to i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %o0], [%c1_i64, %c1_i64, %c1_i64, %c2048_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4, air.preserve_shim_dma_order} : (i32, i64, i64, memref<16384xbf16>) : !airrt.event
+    %1 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %o1], [%c1_i64, %c1_i64, %c1_i64, %c2048_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4, air.preserve_shim_dma_order} : (i32, i64, i64, memref<16384xbf16>) : !airrt.event
+    return
+  }
+}
+
+// -----
+
+// Two affine offsets that peel to the SAME base value but scale it differently
+// are NOT one run and must not merge. `s0 * 2048` and `s0 * 4096 + 2048` have
+// constant terms 0 and 2048, so on the addends alone they look contiguous --
+// they are only distinguished by the map's non-constant sub-expression, which
+// joins the group key. Neutering that key merges these into one len-4096 BD,
+// which is what this case guards.
+
+// CHECK-LABEL: aie.device(npu2)
+// CHECK: aie.dma_bd(%arg0 : memref<16384xbf16> offset = %{{.*}} len = 2048 sizes = [2048] strides = [1])
+// CHECK: aie.dma_bd(%arg0 : memref<16384xbf16> offset = %{{.*}} len = 2048 sizes = [2048] strides = [1])
+// CHECK-NOT: len = 4096
+
+module {
+  aie.device(npu2) {
+    %shim_noc_tile_0_0 = aie.tile(0, 0)
+    aie.shim_dma_allocation @airMemcpyId4(%shim_noc_tile_0_0, MM2S, 0)
+  } {sym_name = "forward_0"}
+  airrt.module_metadata {
+    airrt.segment_metadata attributes {sym_name = "forward_0"} {
+      airrt.herd_metadata {size_x = 1 : i64, size_y = 1 : i64, loc_x = 0 : i64, loc_y = 0 : i64, sym_name = "herd_0"}
+    }
+  }
+  func.func @forward(%arg0: memref<16384xbf16>, %wave: index) {
+    %c0_i64 = arith.constant 0 : i64
+    %c1_i64 = arith.constant 1 : i64
+    %c2048_i64 = arith.constant 2048 : i64
+    %c4_i32 = arith.constant 4 : i32
+    %p = airrt.segment_load "forward_0" : i64
+    %a0 = affine.apply affine_map<()[s0] -> (s0 * 2048)>()[%wave]
+    %o0 = arith.index_cast %a0 : index to i64
+    %a1 = affine.apply affine_map<()[s0] -> (s0 * 4096 + 2048)>()[%wave]
+    %o1 = arith.index_cast %a1 : index to i64
+    %0 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %o0], [%c1_i64, %c1_i64, %c1_i64, %c2048_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4, air.preserve_shim_dma_order} : (i32, i64, i64, memref<16384xbf16>) : !airrt.event
+    %1 = airrt.dma_memcpy_nd(%c4_i32, %c0_i64, %c0_i64, %arg0[%c0_i64, %c0_i64, %c0_i64, %o1], [%c1_i64, %c1_i64, %c1_i64, %c2048_i64], [%c0_i64, %c0_i64, %c0_i64, %c1_i64]) {metadata = @airMemcpyId4, air.preserve_shim_dma_order} : (i32, i64, i64, memref<16384xbf16>) : !airrt.event
+    return
+  }
+}

--- a/python/air/api/__init__.py
+++ b/python/air/api/__init__.py
@@ -93,6 +93,23 @@ statements -- which is what a channel put or a DMA has to be. They are the two
 halves of if-conversion. Reaching for either with the other's condition raises
 and the message names the one you wanted; ``_cond.py`` has the full table.
 
+``ops.switch`` is ``scf.index_switch``, in two forms. **With values** it is an
+expression that picks a number, and it has two consumers: the elementwise
+emitter, which types its arms as *buffer elements*, and ``coerce_index``, which
+types them as ``index`` -- so a switch can be an ``air.sequential`` bound or a
+region offset as well as a scalar in an expression (``as_index()`` is only
+needed to do arithmetic on one). **Without values** it is a region, run unless
+the key is zero, taking the same conditions ``ops.branch`` does.
+
+The region form exists because the op a position needs is not always the op its
+control flow suggests. An N-way statement *is* nested branches, which is why it
+was first routed there -- but that makes the emitted op an ``scf.if``, and a
+region that has to be an ``scf.index_switch`` then cannot be written at all.
+The ``with`` body is the *default* region and ``otherwise()`` fills ``case 0``,
+which ``__enter__`` builds either way -- so a two-armed switch is one case
+region, and there is no spelling for a second. That is deliberate: a second
+case region breaks ``air-to-aie``'s L2 receiver allocation.
+
 ``ops.branch`` has to be a region rather than a Python ``if`` because the herd
 body is traced once for the whole herd: a comparison against a coordinate has no
 value at trace time, so ``bool()`` on one raises rather than picking a branch for
@@ -113,6 +130,8 @@ from ._compile import CompiledKernel, LaunchContext, compile, launch
 from ._extern import ExternKernel, extern
 from ._loop import parallel, sequential
 from ._trace import (
+    RuntimeParam,
+    rtp,
     HerdContext,
     Scope,
     SegmentContext,

--- a/python/air/api/_channel.py
+++ b/python/air/api/_channel.py
@@ -91,10 +91,24 @@ def _reset_declaration_order():
 class Channel:
     """A named channel; ``put`` and ``get`` move data through it."""
 
-    __slots__ = ("name", "size", "broadcast_shape", "channel_type", "_declared", "_seq")
+    __slots__ = (
+        "name",
+        "size",
+        "broadcast_shape",
+        "channel_type",
+        "attrs",
+        "_declared",
+        "_seq",
+    )
 
     def __init__(
-        self, name, size=None, broadcast_shape=None, channel_type=None, **unsupported
+        self,
+        name,
+        size=None,
+        broadcast_shape=None,
+        channel_type=None,
+        attrs=None,
+        **unsupported,
     ):
         if not isinstance(name, str) or not name:
             raise TypeError(
@@ -162,6 +176,12 @@ class Channel:
                 "-- a packet broadcast is a genuine one-to-many fan-out."
             )
         self.channel_type = channel_type
+        # Unit attributes on the air.channel symbol. air.shared_resident_ring is
+        # the one in use: it tells air-ping-pong-transform that two sibling get
+        # loops re-reading this stream are one resident ring, not two -- without
+        # it air-to-aie fuses them into a single interleaved ring of twice the
+        # depth, which covers the wrong blocks.
+        self.attrs = tuple(attrs or ())
         self._declared = False
         self._seq = _NEXT_SEQ[0]
         _NEXT_SEQ[0] += 1
@@ -232,7 +252,27 @@ class Channel:
             # is a next sibling to insert before.
             ip = InsertionPoint(ops[channels[-1][0] + 1])
         else:
-            ip = InsertionPoint.at_block_begin(trace.module.body)
+            # No channel emitted yet. Anchor after the private kernel
+            # declarations rather than at block begin: air.extern's lazy path
+            # prepends its decls, so block begin is right for it either way,
+            # but a decl emitted eagerly (air.extern(signature=...)) is already
+            # in place and a channel put above it would invert the order the
+            # hand-written builders emit -- kernels first, then channels.
+            last_decl = None
+            for op in ops:
+                if op.operation.name == "func.func" and (
+                    "sym_visibility" in op.operation.attributes
+                ):
+                    last_decl = op
+            if last_decl is None:
+                ip = InsertionPoint.at_block_begin(trace.module.body)
+            else:
+                nxt = ops.index(last_decl) + 1
+                ip = (
+                    InsertionPoint(ops[nxt])
+                    if nxt < len(ops)
+                    else InsertionPoint(trace.module.body)
+                )
         with ip:
             if self.channel_type is None:
                 ChannelOp(
@@ -259,6 +299,18 @@ class Channel:
                 op.operation.attributes["channel_type"] = StringAttr.get(
                     self.channel_type
                 )
+            if self.attrs:
+                from air.ir import UnitAttr
+
+                decl = list(trace.module.body.operations)
+                op = next(
+                    d
+                    for d in reversed(decl)
+                    if d.operation.name == "air.channel"
+                    and d.operation.attributes["sym_name"].value == self.name
+                )
+                for attr in self.attrs:
+                    op.operation.attributes[attr] = UnitAttr.get()
         _DECLARED_SEQ[self.name] = self._seq
         self._declared = True
 
@@ -319,7 +371,7 @@ class Channel:
             out.append(value)
         return out
 
-    def _emit(self, obj, indices, dependency, direction):
+    def _emit(self, obj, indices, dependency, direction, dest=None):
         from ._trace import current_herd, current_launch, current_segment
         from ._value import Tensor, TensorSlice
         from .ops import _check_dependency, _endpoint
@@ -388,6 +440,23 @@ class Channel:
             # value defined outside the region".
             endpoint = _endpoint(obj, f"channel.{direction}", "argument")
             offsets, sizes, strides = endpoint.pattern or ([], [], [])
+            extra = {}
+            if dest is not None:
+                from ._index import coerce_index
+
+                if self.channel_type != "npu_dma_packet":
+                    raise ValueError(
+                        f"air.channel {self.name!r}: dest= names a destination "
+                        "of a packet-switched channel, but this one is "
+                        + (
+                            f"channel_type={self.channel_type!r}"
+                            if self.channel_type
+                            else "the default circuit-switched stream"
+                        )
+                        + ". A circuit-switched put reaches its one consumer "
+                        "with no routing header, so there is nothing to select."
+                    )
+                extra["dest"] = coerce_index(dest).materialize()
             return op(
                 self.name,
                 endpoint.value,
@@ -395,6 +464,7 @@ class Channel:
                 sizes=sizes,
                 strides=strides,
                 indices=self._indices(indices, direction),
+                **extra,
             )
 
         if tensor is None:
@@ -438,10 +508,18 @@ class Channel:
 
     # -- public ------------------------------------------------------------
 
-    def put(self, obj, indices=None, dependency=None, **unsupported):
-        """Send a tensor, a buffer, or a region of either into the channel."""
+    def put(self, obj, indices=None, dependency=None, dest=None, **unsupported):
+        """Send a tensor, a buffer, or a region of either into the channel.
+
+        ``dest`` names which *destination* of a packet-switched channel this put
+        is for, as an ordinal -- the same index the receiving get sits at. It is
+        not a packet id: air-annotate-packet-ids allocates the ids and rewrites
+        these, so the wire number lives in one place instead of being written
+        here, written again on the channel, and hoped to agree. Only meaningful
+        on a channel_type="npu_dma_packet" channel with several consumers.
+        """
         _reject_unsupported(unsupported)
-        return self._emit(obj, indices, dependency, "put")
+        return self._emit(obj, indices, dependency, "put", dest=dest)
 
     def get(self, obj, indices=None, dependency=None, **unsupported):
         """Receive the channel's next chunk into a tensor, buffer, or region."""
@@ -500,12 +578,20 @@ def _reject_unsupported(kwargs):
         raise NotImplementedError(f"air.api does not implement {key}=: {what}")
 
 
-def channel(name, size=None, broadcast_shape=None, channel_type=None, **unsupported):
+def channel(
+    name,
+    size=None,
+    broadcast_shape=None,
+    channel_type=None,
+    attrs=None,
+    **unsupported,
+):
     """Declare a named channel; ``put`` into it and ``get`` out of it."""
     return Channel(
         name,
         size=size,
         broadcast_shape=broadcast_shape,
         channel_type=channel_type,
+        attrs=attrs,
         **unsupported,
     )

--- a/python/air/api/_compile.py
+++ b/python/air/api/_compile.py
@@ -42,7 +42,7 @@ __all__ = ["LaunchContext", "CompiledKernel", "launch", "compile"]
 class LaunchContext:
     """A traced kernel: an interface, a body, and a compiler entry point."""
 
-    def __init__(self, grid=None, name="kernel", target=None):
+    def __init__(self, grid=None, name="kernel", target=None, repeat=None, attrs=None):
         # This launch's own iteration space -- air.launch's `sizes`. One point
         # is one replay of everything inside, so outer tiling belongs here:
         # a segment's L2 staging is refilled per point. air.segment and
@@ -54,6 +54,15 @@ class LaunchContext:
         self.dims = parse_grid(grid) if grid is not None else ()
         self.grid = tuple(d.count for d in self.dims)
         self.tile_sizes = tuple(d.step for d in self.dims)
+        # An scf.for around air.launch: this launch is *dispatched* `repeat`
+        # times, its index handed to the body after the grid coordinates. int n
+        # means range(n); a range carries its own start and step.
+        self.repeat = _parse_repeat(repeat)
+        # Unit attributes on air.launch. air.preserve_shim_dma_order is the one
+        # in use: it opts out of air-opt-shim-dma-bds' per-channel BD
+        # regrouping, which a design whose weight feeds are coupled by an X
+        # broadcast multicast needs, since round-major put order is load-bearing.
+        self.attrs = tuple(attrs or ())
         self.name = name
         self.target = target or DEFAULT_TARGET
         self.tensors = list(PENDING_TENSORS)
@@ -178,7 +187,7 @@ class LaunchContext:
         kernel that stages nothing at the plain `func` + `air.herd` shape its
         hand-written predecessor had.
         """
-        n_expected = len(self.dims)
+        n_expected = len(self.dims) + (1 if self.repeat is not None else 0)
         if _positional_arity(self._body) != n_expected:
             raise TypeError(
                 f"launch body takes {_positional_arity(self._body)} coordinate "
@@ -189,8 +198,14 @@ class LaunchContext:
                     if n_expected == 0
                     else ""
                 )
+                + (
+                    " plus the dispatch index of repeat="
+                    f"{self.repeat[0]}:{self.repeat[1]}:{self.repeat[2]}"
+                    if self.repeat is not None
+                    else ""
+                )
             )
-        if not self.dims:
+        if not self.dims and self.repeat is None:
             self._body()
             return
         # air.launch takes as many sizes as it is given, and a 1-D grid pads to
@@ -200,18 +215,23 @@ class LaunchContext:
         # launch rather than a loop around a 2-D one.
         counts = list(self.grid) + [1] * max(0, 2 - len(self.grid))
         open_launch_region(
-            state, self.tensors, counts, lambda: self._body(*state.coords)
+            state,
+            self.tensors,
+            counts,
+            lambda: self._body(*state.coords, *([state.wave] if state.wave else [])),
+            repeat=self.repeat,
+            attrs=self.attrs,
         )
 
     def _check_interface(self):
-        outputs = self.outputs
+        outputs = [t for t in self.outputs if not t.inout]
         if not outputs:
             raise RuntimeError(
                 "kernel writes no output; at least one air.api.ops.store(...) "
                 "into a tensor is required"
             )
         first_output = self.tensors.index(outputs[0])
-        if any(not t.is_output for t in self.tensors[first_output:]):
+        if any(not t.is_output and not t.inout for t in self.tensors[first_output:]):
             raise RuntimeError(
                 "output tensors must be declared after all input tensors; the "
                 "interface order is "
@@ -330,16 +350,51 @@ class CompiledKernel:
         self.backend.unload()
 
 
-def launch(grid=None, name="kernel", target=None):
+def launch(grid=None, name="kernel", target=None, repeat=None, attrs=None):
     """Open a launch; claims every tensor declared since the last launch.
 
     `grid` is the launch's own iteration space -- one point is one replay of
     everything inside, with a segment's L2 staging refilled each time, so outer
     tiling goes here. `air.segment` and `air.herd` each take their own.
 
+    `repeat` dispatches this launch that many times: an `scf.for` **around**
+    `air.launch`, with the dispatch index handed to the body after the grid
+    coordinates. It is not a grid. A grid is spatial, so every point carries its
+    own segment -- multiplying segment symbols, locks and packet ids, which the
+    5-bit `dma_bd` Packet ID field caps at about four launches. `repeat` is
+    temporal: one device, driven N times, which is how a per-wave decode
+    dispatch is written. Pass an int for `range(n)`, or a `range`.
+
+    `attrs` are unit attributes on `air.launch`.
+
     `target` names an NPU generation, or "auto"/None to use the installed one.
     """
-    return LaunchContext(grid=grid, name=name, target=target)
+    return LaunchContext(
+        grid=grid, name=name, target=target, repeat=repeat, attrs=attrs
+    )
+
+
+def _parse_repeat(repeat):
+    """Normalise `repeat` to (lo, hi, step), or None."""
+    if repeat is None:
+        return None
+    if isinstance(repeat, range):
+        lo, hi, step = repeat.start, repeat.stop, repeat.step
+    elif isinstance(repeat, int) and not isinstance(repeat, bool):
+        lo, hi, step = 0, repeat, 1
+    else:
+        raise TypeError(
+            f"air.launch(repeat=...) takes an int or a range, got {repeat!r} "
+            f"({type(repeat).__name__})"
+        )
+    if step <= 0:
+        raise ValueError(f"air.launch(repeat=...) needs a positive step, got {step}")
+    if hi <= lo:
+        raise ValueError(
+            f"air.launch(repeat=range({lo}, {hi})) dispatches nothing; a launch "
+            "that never runs is a kernel with no body"
+        )
+    return (lo, hi, step)
 
 
 def compile(launch_ctx, **kwargs):

--- a/python/air/api/_cond.py
+++ b/python/air/api/_cond.py
@@ -70,7 +70,7 @@ the region structure.
 # dealloc would not be dominated by its alloc. See air.alloc's guard.
 from ._loop import enter_region, exit_region
 
-__all__ = ["Condition", "Branch", "branch"]
+__all__ = ["Condition", "Branch", "branch", "SwitchRegion", "switch_region"]
 
 
 class Condition:
@@ -254,9 +254,10 @@ class _Region:
     it instead.
     """
 
-    def __init__(self, at, terminate, arm=None):
+    def __init__(self, at, terminate, arm=None, what="ops.branch"):
         self._at = at
         self._terminate = terminate
+        self._what = what
         # (branch, index) while this region is open, so air.alloc can tell a
         # buffer in the then arm from one in the else arm.
         self._arm = arm
@@ -284,7 +285,7 @@ class _Region:
         self.open = False
         if self._arm is not None:
             _ARM_PATH.pop()
-        exit_region(aborted=exc_type is not None, what="ops.branch")
+        exit_region(aborted=exc_type is not None, what=self._what)
         if self._terminate:
             yield_([])
         self._ip.__exit__(exc_type, exc, tb)
@@ -374,6 +375,142 @@ class Branch:
         return _Region(
             InsertionPoint(self._else_terminator), terminate=False, arm=(self, 1)
         )
+
+
+class SwitchRegion:
+    """``ops.switch``'s statement form: a region, run unless the key is zero.
+
+    ``ops.switch`` with values is an expression and picks a number;
+    ``ops.switch`` without them is this, and runs statements. One op, two
+    forms, rather than a second construct that looks like a third conditional.
+
+    The ``with`` body is the **default** region -- what runs unless the key is
+    zero -- and ``otherwise()`` fills the *existing* ``case 0``. That is one
+    case region plus a default, never two: an ``scf.index_switch`` with a
+    second case region breaks ``air-to-aie``'s L2 receiver allocation, which
+    then reports the failure on the far side of the flow as
+    ``'air.channel.put' op failed to get S2MM tile for L3 allocation`` -- on a
+    shim put that is itself fine. There is no way to ask for a second one, so
+    that stays unrepresentable rather than merely documented.
+    """
+
+    def __init__(self, key):
+        self._key = key
+        self._op = None
+        self._body = None
+        self._case_terminator = None
+        self._otherwise_taken = False
+
+    def _switch_operand(self):
+        """The index the switch keys on, as an index-typed Value.
+
+        A :class:`Condition` becomes ``select(pred, 1, 0)`` then an
+        ``index_cast``, rather than feeding the ``i1`` somewhere it does not
+        belong. That is not a detour: an i32 operand survives
+        ``cloneL2AndL3MemcpysToDeviceOp``, which pins INDEX-typed segment
+        arguments to constant 0 -- so a gate whose key were built as an index
+        inside a segment would fold to one arm and erase every other branch.
+        """
+        from air.dialects import arith
+        from ._index import materialize_index
+
+        if isinstance(self._key, (Condition, ValueCondition)):
+            one = arith.ConstantOp(_i32(), 1).result
+            zero = arith.ConstantOp(_i32(), 0).result
+            picked = arith.select(self._key.materialize(), one, zero)
+            return arith.index_cast(_index_type(), picked)
+        key = materialize_index(self._key)
+        if isinstance(key, int):
+            # A constant key needs no switch, but folding it here would silently
+            # drop the region for key 0 and inline it otherwise -- a structural
+            # change the caller cannot see. Emit the constant and let the switch
+            # stand; canonicalisation folds it with the whole design in view.
+            return arith.ConstantOp.create_index(key).result
+        return key
+
+    def __enter__(self):
+        from air.dialects.scf import IndexSwitchOp, yield_
+        from air.ir import InsertionPoint
+
+        if self._op is not None:
+            raise RuntimeError("ops.switch region entered twice")
+        self._op = IndexSwitchOp(results=[], arg=self._switch_operand(), cases=[0])
+        # Terminate case 0 now, whether or not otherwise() will claim it. It is
+        # the idle arm by default, and a block with no terminator turns a
+        # diagnosable error into a verifier crash somewhere unrelated.
+        with InsertionPoint(self._op.case_block(0)):
+            self._case_terminator = yield_([])
+        self._body = _Region(
+            self._op.default_block, terminate=True, arm=(self, 0), what="ops.switch"
+        )
+        self._body.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return self._body.__exit__(exc_type, exc, tb)
+
+    def otherwise(self):
+        """The ``case 0`` region, as a second ``with`` block.
+
+        Not a second case region -- ``case 0`` is built by ``__enter__`` either
+        way, and this fills it instead of leaving it idle.
+        """
+        from air.ir import InsertionPoint
+
+        if self._op is None:
+            raise RuntimeError(
+                "otherwise() on an ops.switch whose region was never opened; "
+                "the spelling is `with ops.switch(...) as arm:` followed by "
+                "`with arm.otherwise():`"
+            )
+        if self._body.open:
+            raise RuntimeError(
+                "otherwise() inside the body of an ops.switch region; close "
+                "the first `with` block before opening the second"
+            )
+        if self._otherwise_taken:
+            raise RuntimeError("this ops.switch region already has an otherwise()")
+        self._otherwise_taken = True
+        return _Region(
+            InsertionPoint(self._case_terminator),
+            terminate=False,
+            arm=(self, 1),
+            what="ops.switch",
+        )
+
+
+def _i32():
+    from air.ir import IntegerType
+
+    return IntegerType.get_signless(32)
+
+
+def _index_type():
+    from air.ir import IndexType
+
+    return IndexType.get()
+
+
+def switch_region(key):
+    """Build :class:`SwitchRegion`; ``ops.switch`` calls this when given no values.
+
+    ``key`` is what ``ops.branch`` takes -- a comparison between index
+    expressions -- or a bare index. A comparison reaches the switch as
+    ``select(pred, 1, 0)`` then an ``index_cast`` rather than as a raw ``i1``.
+    """
+    key = _as_condition(key)
+    if isinstance(key, (Condition, ValueCondition)):
+        return SwitchRegion(key)
+    from ._index import coerce_index
+
+    try:
+        return SwitchRegion(coerce_index(key))
+    except TypeError:
+        raise TypeError(
+            "ops.switch's region form takes a comparison between index "
+            f"expressions (`wave < n`) or an index, got {key!r} "
+            f"({type(key).__name__}). " + _why_not_a_branch(key)
+        ) from None
 
 
 def branch(condition):

--- a/python/air/api/_extern.py
+++ b/python/air/api/_extern.py
@@ -46,7 +46,15 @@ __all__ = ["ExternKernel", "extern"]
 class ExternKernel:
     """A private ``func.func`` in an object file, callable from a herd body."""
 
-    def __init__(self, name, link_with=None, scalars=()):
+    def __init__(
+        self,
+        name,
+        link_with=None,
+        scalars=(),
+        signature=None,
+        emit_c_interface=True,
+        link_with_mode=None,
+    ):
         if not isinstance(name, str) or not name:
             raise TypeError("air.extern(name) takes the kernel's C symbol name")
         if not link_with:
@@ -76,10 +84,60 @@ class ExternKernel:
         self.name = name
         self.link_with = link_with
         self.scalars = list(scalars)
+        self.signature = signature
+        # A kernel whose C entry point is called directly, not through MLIR's
+        # C-interface wrapper, carries no llvm.emit_c_interface. Every kernel
+        # reached this way so far wanted the wrapper, so it stays the default.
+        self.emit_c_interface = emit_c_interface
+        # link_with_mode = "merge" links the kernel's LLVM IR into the core
+        # module rather than linking an object beside it, which is what a .ll
+        # kernel needs.
+        self.link_with_mode = link_with_mode
         # The declaration, materialised at the first call from the call's own
-        # argument types, and reused after that.
+        # argument types, and reused after that -- unless `signature` was given,
+        # in which case it is emitted eagerly, below.
         self._decl = None
         self._arg_types = None
+        if signature is not None:
+            # A signature already states every argument type, scalars included,
+            # so restating them in scalars= would be a second source of truth
+            # for the same fact -- and the two disagreeing is a wrong constant
+            # in a kernel call, which nothing downstream can catch.
+            derived = [_scalar_dtype(t) for t in signature if not _is_memref_type(t)]
+            if scalars and [s.name for s in scalars] != [d.name for d in derived]:
+                raise TypeError(
+                    f"air.extern({name!r}) was given both signature= and "
+                    f"scalars=, and they disagree: the signature's scalar "
+                    f"arguments are {[d.name for d in derived]} but scalars= "
+                    f"says {[s.name for s in scalars]}. Give one or the other."
+                )
+            self.scalars = derived
+            self._declare_now(signature)
+
+    def _declare_now(self, signature):
+        """Emit the declaration at construction, in source order.
+
+        The lazy path inserts each declaration with ``at_block_begin``, so the
+        module lists them in *reverse* order of first call. That is settled IR
+        for every kernel already written this way, so it is left alone; a caller
+        that needs source order says so by giving the signature, which is also
+        the only way to know the argument types before the first call.
+        """
+        from air.ir import InsertionPoint, StringAttr, UnitAttr
+        from air.dialects.func import FuncOp
+
+        from ._trace import active_trace
+
+        types = [_declared_type(t) for t in signature]
+        trace = active_trace()
+        with _after_declarations(trace.module):
+            decl = FuncOp(self.name, (types, []), visibility="private")
+            decl.attributes["link_with"] = StringAttr.get(self.link_with)
+            if self.link_with_mode is not None:
+                decl.attributes["link_with_mode"] = StringAttr.get(self.link_with_mode)
+            if self.emit_c_interface:
+                decl.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+        self._decl, self._arg_types = decl, types
 
     def __repr__(self):
         return f"air.api.extern({self.name!r}, link_with={self.link_with!r})"
@@ -123,7 +181,12 @@ class ExternKernel:
             with InsertionPoint.at_block_begin(trace.module.body):
                 decl = FuncOp(self.name, (types, []), visibility="private")
                 decl.attributes["link_with"] = StringAttr.get(self.link_with)
-                decl.attributes["llvm.emit_c_interface"] = UnitAttr.get()
+                if self.link_with_mode is not None:
+                    decl.attributes["link_with_mode"] = StringAttr.get(
+                        self.link_with_mode
+                    )
+                if self.emit_c_interface:
+                    decl.attributes["llvm.emit_c_interface"] = UnitAttr.get()
             self._decl, self._arg_types = decl, types
         elif [str(t) for t in types] != [str(t) for t in self._arg_types]:
             raise TypeError(
@@ -134,8 +197,15 @@ class ExternKernel:
                 "kernel, or make the buffer shapes agree."
             )
 
-        # aircc links one object per herd, so the attribute is a single string.
-        herd.require_object(self.link_with, self.name)
+        # aircc links one object per herd, so the attribute is a single string
+        # -- but only for an object that is *linked*. A kernel declared
+        # link_with_mode = "merge" has its LLVM IR merged into whichever core
+        # calls it, per core, straight from the declaration; the herd attribute
+        # plays no part. fused_decode's attention block herd is the case: eight
+        # cores in one herd, attn_qk.ll on the qk rows and attn_kv.ll on the kv
+        # rows, and no herd link_with at all.
+        if self.link_with_mode != "merge":
+            herd.require_object(self.link_with, self.name)
         return CallOp(self._decl, values)
 
 
@@ -323,6 +393,21 @@ def _core_slab(buffer):
 def _scalar_value(arg, dtype, name, pos, arith):
     """Materialise a non-buffer argument as ``dtype``."""
     from ._value import BufferExpr, BufferSlice
+    from ._trace import RuntimeParam
+
+    if isinstance(arg, RuntimeParam):
+        # Already an i32 in this region -- the herd operand air.rtp threaded in.
+        # Passing it on is the point: fused_decode's rope and rms kernels take
+        # the layer-type arm as their last argument, the same value ops.switch
+        # gates on.
+        from .types import i32
+
+        if dtype is not i32:
+            raise TypeError(
+                f"{name}: argument {pos} is an air.rtp parameter, which crosses "
+                f"a region boundary as i32, but the kernel declares it {dtype}"
+            )
+        return arg.value
 
     if isinstance(arg, (BufferExpr, BufferSlice)):
         # A value read out of a buffer. The counter tile the flash-attention
@@ -343,6 +428,23 @@ def _scalar_value(arg, dtype, name, pos, arith):
 
         require_signless(dtype, "an air.extern scalar argument")
         return emit_scalar_value(expr, dtype)
+
+    from ._cond import Condition, ValueCondition
+
+    if isinstance(arg, (Condition, ValueCondition)):
+        # A comparison as a 0/1 integer flag. Kernels take these: fused_decode's
+        # cached-reduction accumulator is told to *fill* rather than accumulate
+        # on the first row-block of a projection, and "first" is `v1 == 0`.
+        # arith.extui, not a select of two constants -- one op, and the same
+        # shape the hand-written builders emit.
+        from air.dialects import arith as _arith
+
+        if dtype.is_float:
+            raise TypeError(
+                f"{name}: argument {pos} is a comparison, which is a 0/1 flag, "
+                f"but was declared {dtype}"
+            )
+        return _arith.extui(dtype.mlir(), arg.materialize())
 
     if isinstance(arg, IndexExpr):
         # A loop induction variable or tile coordinate. It folds to a Python int
@@ -380,6 +482,84 @@ def _scalar_value(arg, dtype, name, pos, arith):
     return arith.ConstantOp(dtype.mlir(), int(arg)).result
 
 
-def extern(name, link_with=None, scalars=()):
-    """Declare a hand-written kernel from ``link_with``; call it in a herd."""
-    return ExternKernel(name, link_with=link_with, scalars=scalars)
+def extern(
+    name,
+    link_with=None,
+    scalars=(),
+    signature=None,
+    emit_c_interface=True,
+    link_with_mode=None,
+):
+    """Declare a hand-written kernel from ``link_with``; call it in a herd.
+
+    ``signature`` states the argument types up front -- MLIR types, or air.api
+    element types for scalars -- which emits the declaration here, in source
+    order, rather than at the first call in reverse order of it.
+    ``emit_c_interface=False`` drops ``llvm.emit_c_interface``, and
+    ``link_with_mode="merge"`` links the kernel's IR into the core module.
+    """
+    return ExternKernel(
+        name,
+        link_with=link_with,
+        scalars=scalars,
+        signature=signature,
+        emit_c_interface=emit_c_interface,
+        link_with_mode=link_with_mode,
+    )
+
+
+def _declared_type(t):
+    """An entry of ``signature=`` as an MLIR type."""
+    from .types import DType
+
+    return t.mlir() if isinstance(t, DType) else t
+
+
+def _is_memref_type(t):
+    from .types import DType
+
+    if isinstance(t, DType):
+        return False
+    from air.ir import MemRefType
+
+    return isinstance(t, MemRefType) or str(t).startswith("memref<")
+
+
+def _scalar_dtype(t):
+    """A scalar entry of ``signature=`` as one of this package's element types.
+
+    The declaration only needs the MLIR type, but the *call* needs the DType:
+    that is what turns a Python ``1`` at the call site into an ``i32`` constant
+    rather than a guess.
+    """
+    from .types import DType, SCALAR_TYPES
+
+    if isinstance(t, DType):
+        return t
+    for dtype in SCALAR_TYPES:
+        if str(dtype.mlir()) == str(t):
+            return dtype
+    raise TypeError(
+        f"air.extern(signature=...) has a scalar argument of type {t}, which "
+        f"air.api has no element type for. Declare it as one of "
+        f"{', '.join(d.name for d in SCALAR_TYPES)}."
+    )
+
+
+def _after_declarations(module):
+    """Insert point after the private declarations already in ``module``."""
+    from air.ir import InsertionPoint
+    from air.dialects.func import FuncOp
+
+    last = None
+    for op in module.body.operations:
+        if isinstance(op, FuncOp) or op.operation.name == "func.func":
+            if "sym_visibility" in op.operation.attributes:
+                last = op
+    if last is None:
+        return InsertionPoint.at_block_begin(module.body)
+    ops = list(module.body.operations)
+    nxt = ops.index(last) + 1
+    # Before whatever follows the last declaration, or at the end of the module
+    # if nothing does -- InsertionPoint(block) appends.
+    return InsertionPoint(ops[nxt]) if nxt < len(ops) else InsertionPoint(module.body)

--- a/python/air/api/_index.py
+++ b/python/air/api/_index.py
@@ -342,6 +342,15 @@ def coerce_index(value):
         raise TypeError("bool is not a valid index")
     if isinstance(value, int):
         return IndexExpr.constant(value)
+    # A switch chosen at runtime: an scf.index_switch yielding an index, which
+    # is a leaf like any other SSA index. Emitted once and memoised on the
+    # switch, so using one as a loop bound and again as an offset inside that
+    # loop is one op, not two.
+    from .ops import _Switch
+    from ._trace import RuntimeParam
+
+    if isinstance(value, (_Switch, RuntimeParam)):
+        return value.as_index()
     # Symbol and anything else exposing __index__ resolves to its current value.
     if hasattr(value, "__index__"):
         return IndexExpr.constant(int(value))

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -79,7 +79,15 @@ def sequential(start, stop=None, step=None, name=None):
     if step is None:
         step = 1
 
-    from ._index import IndexExpr as _IndexExpr
+    from ._index import IndexExpr as _IndexExpr, coerce_index as _coerce
+    from .ops import _Switch
+
+    # A bound picked at runtime by ops.switch is an index like any other; coerce
+    # it here so the dynamic path below sees an IndexExpr rather than refusing a
+    # type it has no opinion about.
+    start, stop, step = (
+        _coerce(v) if isinstance(v, _Switch) else v for v in (start, stop, step)
+    )
 
     # A bound may be an index expression -- a coordinate, or an enclosing loop's
     # variable. scf.for takes SSA bounds, so nothing here has to fold: what it

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -18,9 +18,29 @@ inside the loop end up stranded between the unrolled copies, and the kernel
 computes with stale operands. A reduction that reuses a buffer across trips --
 which is to say, every reduction -- has to reach the compiler as a loop.
 
-Bounds must be Python integers. A dynamic trip count would need the bound to be
-an SSA value, and nothing in the DSL produces one; accepting an ``IndexExpr``
-here would only defer the failure into the IR.
+This always emits ``scf.for`` -- there is one loop op here and no other. What
+varies is the *bound operand*. A bound whose value is known while tracing (a
+Python integer, an ``air.symbol``) becomes a constant operand, and the trip
+count can be checked here: that the step tiles the extent exactly, that the
+range does not run backwards. A bound that is only known at run time becomes an
+SSA operand instead, computed by the ops immediately above the loop, and those
+checks are skipped because there is nothing yet to check::
+
+    %2 = arith.index_cast %arg : i32 to index    # an air.rtp parameter
+    %3 = affine.apply #map()[%2]
+    scf.for %i = %c0 to %3 step %c1 { ... }
+
+Three things produce such a bound: an enclosing loop's induction variable, an
+``ops.switch`` (which emits an ``scf.index_switch`` yielding an index), and an
+``air.rtp`` parameter (an i32 the instruction stream writes per dispatch). All
+three arrive as an :class:`IndexExpr` and are told apart from a constant by
+``as_const()``.
+
+A bound built from a *tile coordinate* is refused, and that is not the same
+question. The herd body is traced once and stands for every core, so a
+coordinate-dependent trip count would give each core a different one, and
+anything with a channel operation in it would deadlock on the cores that run
+fewer trips. A loop variable is uniform across cores and is allowed.
 """
 
 from ._index import IndexExpr

--- a/python/air/api/_loop.py
+++ b/python/air/api/_loop.py
@@ -80,13 +80,20 @@ def sequential(start, stop=None, step=None, name=None):
         step = 1
 
     from ._index import IndexExpr as _IndexExpr, coerce_index as _coerce
+    from ._trace import RuntimeParam
     from .ops import _Switch
 
-    # A bound picked at runtime by ops.switch is an index like any other; coerce
-    # it here so the dynamic path below sees an IndexExpr rather than refusing a
-    # type it has no opinion about.
+    # A bound decided at runtime -- picked by ops.switch, or read from an
+    # air.rtp parameter -- is an index like any other; coerce it here so the
+    # dynamic path below sees an IndexExpr rather than refusing a type it has no
+    # opinion about. Both, not just the switch: coerce_index handles the two
+    # together, and a bound is exactly where a runtime parameter turns up. A
+    # per-dispatch context length driving a herd's block loop is the case --
+    # fused_decode's attention cores loop ceil(L/16) times, with L an i32 RTP
+    # the instruction stream writes.
     start, stop, step = (
-        _coerce(v) if isinstance(v, _Switch) else v for v in (start, stop, step)
+        _coerce(v) if isinstance(v, (_Switch, RuntimeParam)) else v
+        for v in (start, stop, step)
     )
 
     # A bound may be an index expression -- a coordinate, or an enclosing loop's
@@ -312,9 +319,22 @@ def _parallel_grid(grid, name):
 
 def _as_bound(value, which, what="sequential"):
     if isinstance(value, bool) or not hasattr(value, "__index__"):
+        # Say what was rejected, not why it might have been built. This used to
+        # assert "a bound computed from a tile coordinate is not supported" for
+        # every type it turned away, which named a cause that is usually not the
+        # one -- and is not even a general truth any more: air.sequential does
+        # take a runtime bound, and only a *spatial* coordinate is refused, by
+        # the check that can actually tell.
+        extra = ""
+        if what == "parallel":
+            extra = (
+                " air.parallel's bounds are resolved at trace time even where "
+                "air.sequential's are not: its index is a channel bundle slot, "
+                "which air-to-aie unrolls spatially and cannot do for a count "
+                "it does not know."
+            )
         raise TypeError(
             f"air.{what}({which}=...) takes a Python integer (or an air.symbol), "
-            f"got {type(value).__name__} {value!r}. Loop bounds are resolved at "
-            "trace time; a bound computed from a tile coordinate is not supported."
+            f"got {type(value).__name__} {value!r}." + extra
         )
     return int(value)

--- a/python/air/api/_trace.py
+++ b/python/air/api/_trace.py
@@ -128,6 +128,11 @@ class Trace:
         # Peak declared L1 bytes across the trace, used to explain an
         # out-of-memory failure from the AIE placer in DSL terms.
         self.l1_peak = 0
+        # Runtime parameters (air.rtp): scalars computed once and carried into
+        # IsolatedFromAbove regions. Threaded into every herd, referenced or
+        # not, then dropped by prune_unused_operands -- the same policy as
+        # tensors and staged L2 buffers, and for the same reason.
+        self.rtps = []
 
 
 def set_active_trace(trace):
@@ -211,7 +216,7 @@ class LaunchState:
     at the plain `func` + `air.herd` shape its hand-written predecessors have.
     """
 
-    __slots__ = ("ctx", "opened", "coords", "leaves", "reentry")
+    __slots__ = ("ctx", "opened", "coords", "leaves", "reentry", "wave")
 
     def __init__(self, ctx):
         self.ctx = ctx
@@ -229,6 +234,85 @@ class LaunchState:
         # leaf's .value to its own block argument.
         self.coords = []
         self.leaves = []
+        # The dispatch index of a repeated launch: an scf.for around air.launch,
+        # its induction variable threaded in as the last launch operand. Not
+        # spatial -- every core of every segment sees the same wave -- which is
+        # what makes it usable as a loop bound and as an ops.switch key, where a
+        # tile coordinate is refused.
+        self.wave = None
+
+
+class RuntimeParam:
+    """A scalar computed once and carried into IsolatedFromAbove regions.
+
+    ``air.rtp(wave < n)`` evaluates the condition where it is written and hands
+    the result to every herd as an **i32** operand, to be read back inside with
+    ``ops.switch``. i32 rather than index is the whole point:
+    ``cloneL2AndL3MemcpysToDeviceOp`` pins INDEX-typed segment arguments to the
+    constant 0, so an index-typed parameter folds to one arm and every other
+    branch is erased -- in cores as much as in memtiles. An i32 operand is left
+    alone and survives as a real per-dispatch parameter.
+
+    Threaded into every herd whether referenced or not, then dropped by
+    ``prune_unused_operands``: the tracer cannot know what a body touches until
+    it has run it, which is the policy tensors and L2 buffers already follow.
+    """
+
+    __slots__ = ("value", "_name")
+
+    def __init__(self, value, name):
+        self.value = value
+        self._name = name
+
+    def rebind(self, value):
+        self.value = value
+
+    def __repr__(self):
+        return f"air.rtp({self._name})"
+
+    def as_index(self):
+        """Read the parameter back as an index, in the current region."""
+        from air.dialects import arith
+        from air.ir import IndexType
+
+        return IndexExpr.leaf(arith.index_cast(IndexType.get(), self.value), "rtp")
+
+
+def rtp(source):
+    """A runtime parameter: evaluate ``source`` here, read it inside a herd.
+
+        arm = air.rtp(wave < n_decode)     # once, at segment scope
+        with air.herd(...) as h:
+            @h.body
+            def _(tx, ty):
+                with ops.switch(arm):      # the i32 crosses the boundary
+                    ...
+
+    ``source`` is a comparison between index expressions, or an index. A
+    comparison becomes 1 or 0; an index is cast. Either way the value that
+    crosses a region boundary is i32 -- see :class:`RuntimeParam` for why that
+    is not incidental.
+    """
+    from air.dialects import arith
+    from air.ir import IntegerType
+    from ._cond import Condition, ValueCondition, _as_condition
+    from ._index import coerce_index, materialize_index
+
+    i32 = IntegerType.get_signless(32)
+    source = _as_condition(source)
+    if isinstance(source, (Condition, ValueCondition)):
+        one = arith.ConstantOp(i32, 1).result
+        zero = arith.ConstantOp(i32, 0).result
+        value = arith.select(source.materialize(), one, zero)
+    else:
+        index = materialize_index(coerce_index(source))
+        if isinstance(index, int):
+            value = arith.ConstantOp(i32, index).result
+        else:
+            value = arith.index_cast(i32, index)
+    param = RuntimeParam(value, repr(source))
+    active_trace().rtps.append(param)
+    return param
 
 
 def set_launch(state):
@@ -245,19 +329,49 @@ def current_launch():
     return _CURRENT_LAUNCH
 
 
-def open_launch_region(launch, tensors, counts, body):
+def open_launch_region(launch, tensors, counts, body, repeat=None, attrs=None):
     """Emit air.launch with ``counts`` as its sizes and run ``body`` inside.
 
     Block arguments are ids + sizes + operands, so the operands start after two
     entries per axis -- four for the 2-D launch that was the only kind when this
     was written, six for a 3-D one.
+
+    ``repeat`` is ``(lo, hi, step)``: an ``scf.for`` **around** air.launch, its
+    induction variable threaded in as the last launch operand. A launch is not
+    obliged to be the outermost op -- ``scf.for { air.launch }`` is ordinary AIR
+    and is how a per-wave dispatch is written, one device driven N times. That
+    is not a grid, which is spatial: every grid point carries its own segment,
+    multiplying segment symbols, locks and packet ids, and the 5-bit ``dma_bd``
+    Packet ID field caps that at about four launches. The DSL treated the launch
+    as the top level because nothing had needed otherwise, not because the
+    dialect says so.
     """
-    from air.dialects.air import launch as launch_region
-    from air.ir import InsertionPoint
-
     closed = []
+    operands = [t.value for t in tensors]
 
-    @launch_region(sizes=counts, operands=[t.value for t in tensors])
+    if repeat is None:
+        _emit_launch(launch, tensors, counts, body, operands, attrs, closed)
+    else:
+        from air.dialects import arith
+        from air.dialects.scf import for_ as scf_for, yield_
+
+        bounds = [arith.ConstantOp.create_index(v).result for v in repeat]
+        for _iv in scf_for(*bounds):
+            _emit_launch(launch, tensors, counts, body, operands + [_iv], attrs, closed)
+            yield_([])
+
+    if closed:
+        launch.reentry = closed[0]
+
+
+def _emit_launch(launch, tensors, counts, body, operands, attrs, closed):
+    """One air.launch, with ``operands`` bound into its region."""
+    from air.dialects.air import launch as launch_region
+    from air.ir import InsertionPoint, UnitAttr
+
+    attributes = {name: UnitAttr.get() for name in (attrs or ())}
+
+    @launch_region(sizes=counts, operands=operands, attributes=attributes)
     def launch_body(*largs):
         launch.opened = True
         launch.leaves = [
@@ -266,21 +380,21 @@ def open_launch_region(launch, tensors, counts, body):
         ]
         launch.coords = [IndexExpr({leaf: 1}, 0) for leaf in launch.leaves]
         first_operand = 2 * len(counts)
+        bound = largs[first_operand : first_operand + len(tensors)]
+        extra = largs[first_operand + len(tensors) :]
+        launch.wave = IndexExpr.leaf(extra[0], "w") if extra else None
         saved = [t.value for t in tensors]
-        for t, v in zip(tensors, largs[first_operand:]):
+        for t, v in zip(tensors, bound):
             t.value = v
         # Captured here, published only once this region closes: while it is
         # open the ordinary insertion point is already right, and the block has
         # no terminator to insert ahead of yet.
-        closed.append((InsertionPoint.current.block, list(largs[first_operand:])))
+        closed.append((InsertionPoint.current.block, list(bound)))
         try:
             body()
         finally:
             for t, v in zip(tensors, saved):
                 t.value = v
-
-    if closed:
-        launch.reentry = closed[0]
 
 
 def in_launch_body(emit):
@@ -1031,7 +1145,13 @@ class SegmentContext:
         # air.segment is IsolatedFromAbove, so a launch coordinate used in this
         # body cannot simply be referenced -- it is threaded in as an operand
         # ahead of the tensors, and rebound to the block argument inside.
-        outer_leaves = launch.leaves
+        # The launch's grid coordinates, and -- for a repeated launch -- its
+        # dispatch index, which is a leaf of the same kind and has to cross the
+        # IsolatedFromAbove boundary the same way. Without it, a body that gates
+        # on the wave would reference a value from outside the region.
+        outer_leaves = list(launch.leaves)
+        if launch.wave is not None:
+            outer_leaves += [leaf for leaf in launch.wave.leaves()]
         operands = [leaf.value for leaf in outer_leaves] + [t.value for t in tensors]
         sizes = list(self.grid) + [1] * (2 - len(self.grid)) if self.grid else []
 
@@ -1153,7 +1273,14 @@ class HerdContext:
     _what = "air.herd"
 
     def __init__(
-        self, iterable, name=None, shape=None, target=None, link_with=None, at=None
+        self,
+        iterable,
+        name=None,
+        shape=None,
+        target=None,
+        link_with=None,
+        at=None,
+        params=None,
     ):
         self.dims = parse_grid(iterable)
         if len(self.dims) > 2:
@@ -1162,6 +1289,7 @@ class HerdContext:
             )
         self.name = name or "herd_0"
         self.at = _parse_herd_anchor(at)
+        self.params = _parse_herd_params(params, self.name)
         self.target = resolve_target(target) if target else current_target()
         self.grid = tuple(d.count for d in self.dims)
         self.tile_sizes = tuple(d.step for d in self.dims)
@@ -1390,10 +1518,31 @@ class HerdContext:
         # nothing to do with each other.
         outer = list(current_launch().leaves)
         outer += list(enclosing.leaves) if enclosing is not None else []
+        # Runtime parameters, unlike tensors and L2 buffers, are NOT safe to
+        # thread wholesale. They are the one operand kind whose *order* is part
+        # of the herd's interface, and a design with several of them wants a
+        # different subset in each herd -- fused_decode's attention herd reads
+        # the context length and the layer-type arm, its rope herd only the arm.
+        # Passing every live one to every herd would put the wrong value in the
+        # wrong position. So: one live parameter threads implicitly (the common
+        # case, and unambiguous), and more than one has to be named.
+        if self.params is not None:
+            rtps = list(self.params)
+        elif len(trace.rtps) > 1:
+            raise RuntimeError(
+                f"air.herd {self.name!r}: {len(trace.rtps)} air.rtp parameters "
+                "are live, so which ones this herd reads -- and in what order "
+                "-- is ambiguous. Name them: "
+                "air.herd(..., params=[length, arm]). They become herd "
+                "operands in the order given."
+            )
+        else:
+            rtps = list(trace.rtps)
         operands = (
             [leaf.value for leaf in outer]
             + [t.value for t in tensors]
             + [b.value for b in staged]
+            + [r.value for r in rtps]
         )
         # air.herd is always 2-D. A 1-D grid is laid out along x -- [P, 1], the
         # orientation the hand-written eltwise_add kernel uses for its 8-core
@@ -1415,13 +1564,18 @@ class HerdContext:
             saved = [t.value for t in tensors]
             saved_staged = [b.value for b in staged]
             saved_outer = [leaf.value for leaf in outer]
+            saved_rtps = [r.value for r in rtps]
             n_outer = len(outer)
+            n_staged = len(staged)
             for leaf, v in zip(outer, inner[:n_outer]):
                 leaf.value = v
-            for t, v in zip(tensors, inner[n_outer : n_outer + len(tensors)]):
+            base = n_outer + len(tensors)
+            for t, v in zip(tensors, inner[n_outer:base]):
                 t.value = v
-            for b, v in zip(staged, inner[n_outer + len(tensors) :]):
+            for b, v in zip(staged, inner[base : base + n_staged]):
                 b.value = v
+            for r, v in zip(rtps, inner[base + n_staged :]):
+                r.rebind(v)
             previous, _CURRENT_HERD = _CURRENT_HERD, herd_self
 
             phys_coords = coords if two_d else coords[:1]
@@ -1468,6 +1622,8 @@ class HerdContext:
                     t.value = v
                 for b, v in zip(staged, saved_staged):
                     b.value = v
+                for r, v in zip(rtps, saved_rtps):
+                    r.rebind(v)
                 for leaf, v in zip(outer, saved_outer):
                     leaf.value = v
                 _CURRENT_HERD = previous
@@ -1539,6 +1695,30 @@ def run_strip_mined(run, repeats, range_, yield_):
 # ---------------------------------------------------------------------------
 
 
+def _parse_herd_params(params, name):
+    """Validate ``air.herd(params=[...])`` into a tuple of RuntimeParams, or None.
+
+    ``None`` means "thread whatever single parameter is live", which is what a
+    design with one of them wants and what every herd got before this existed.
+    An empty list is not the same thing: it says this herd reads none.
+    """
+    if params is None:
+        return None
+    if isinstance(params, RuntimeParam):
+        params = [params]
+    out = []
+    for p in params:
+        if not isinstance(p, RuntimeParam):
+            raise TypeError(
+                f"air.herd {name!r}: params= takes values from air.rtp(), got "
+                f"{p!r} ({type(p).__name__}). A herd operand that is a buffer "
+                "is passed by using it in the body; params= is only for the "
+                "scalars air.rtp builds."
+            )
+        out.append(p)
+    return tuple(out)
+
+
 def _parse_herd_anchor(at):
     """Validate ``air.herd(at=(col, row))`` into a pair of ints, or None.
 
@@ -1577,7 +1757,9 @@ def _parse_herd_anchor(at):
     return tuple(out)
 
 
-def herd(iterable, name=None, shape=None, target=None, link_with=None, at=None):
+def herd(
+    iterable, name=None, shape=None, target=None, link_with=None, at=None, params=None
+):
     """A herd of cores over ``iterable``, strip-mined onto the physical array.
 
     ``link_with=`` names the object file to stamp on the herd, for a lowering
@@ -1596,7 +1778,13 @@ def herd(iterable, name=None, shape=None, target=None, link_with=None, at=None):
     1x1 LA herds pinned along row 4, with LGU and LD on rows 2 and 3.
     """
     return HerdContext(
-        iterable, name=name, shape=shape, target=target, link_with=link_with, at=at
+        iterable,
+        name=name,
+        shape=shape,
+        target=target,
+        link_with=link_with,
+        at=at,
+        params=params,
     )
 
 
@@ -1612,10 +1800,18 @@ def _require_allocatable(dtype, what):
     )
 
 
-def tensor(shape, dtype, name=None):
-    """Declare a host-visible L3 array; becomes a kernel argument."""
+def tensor(shape, dtype, name=None, inout=False):
+    """Declare a host-visible L3 array; becomes a kernel argument.
+
+    ``inout=True`` marks a buffer the kernel both reads and writes in place. It
+    is exempt from the inputs-then-outputs ordering rule, which exists because
+    the XRT invocation passes inputs first and then outputs -- a distinction an
+    in-place buffer does not have. It also does not, on its own, satisfy the
+    requirement that a kernel write *some* output.
+    """
     _require_allocatable(dtype, "air.tensor")
     t = Tensor(shape, dtype, name=name or infer_name(f"t{len(PENDING_TENSORS)}"))
+    t.inout = inout
     PENDING_TENSORS.append(t)
     return t
 

--- a/python/air/api/_value.py
+++ b/python/air/api/_value.py
@@ -374,6 +374,11 @@ class Tensor(_Reshapable):
         self.value = None
         # Set when this tensor is the destination of an ops.store().
         self.is_output = False
+        # Declared in-place: read *and* written, so it is neither an input nor
+        # an output but both, and the inputs-then-outputs ordering rule does not
+        # apply to it. A residual stream chained through the same L3 buffer
+        # every layer is the case -- see fused_decode's x.
+        self.inout = False
 
     def __getitem__(self, key):
         key = _normalize_key(key, len(self.shape), "tensor")

--- a/python/air/api/ops.py
+++ b/python/air/api/ops.py
@@ -37,7 +37,13 @@ plausible-looking placeholder: a DSL that accepts an op it cannot lower
 produces a kernel that runs and is silently wrong.
 """
 
-from ._cond import Branch, Condition, branch  # noqa: F401
+from ._cond import (
+    Branch,
+    Condition,
+    SwitchRegion,
+    branch,
+    switch_region,
+)  # noqa: F401,E501
 from ._value import Buffer, BufferExpr, BufferSlice, Tensor, TensorSlice, Token
 from .types import require_computable, require_signless
 
@@ -988,22 +994,33 @@ def reduce_max(x):
     return _reduce("reduce_max", "max", x)
 
 
-def switch(index, values):
+def switch(index, values=None):
     """Pick one of ``values`` by a runtime ``index``.
 
         addend = air.api.ops.switch(step, [1.0, 10.0])
         acc[:] = acc[:] + addend
 
-    An **expression**, not a statement: it yields the chosen value, the way a
-    Rust ``match`` or a C# switch expression does, and not the way C's statement
-    does. The N-way *statement* -- run one of N bodies for their effects -- is
-    nested ``ops.branch``, which is why this name is not taken by it.
+    With ``values`` it is an **expression**: it yields the chosen value, the way
+    a Rust ``match`` or a C# switch expression does, and not the way C's
+    statement does.
+
+    **Without them it is a region**, run unless the key is zero::
+
+        with air.api.ops.switch(wave < n_decode):
+            ops.load(staged, W[...])
+            ch.put(staged)
+
+    One op, two forms. The region form was originally routed to ``ops.branch``,
+    on the reasoning that an N-way statement is nested branches -- true of the
+    control flow, but it makes the emitted op an ``scf.if``, and a region that
+    has to be an ``scf.index_switch`` then has no spelling at all. Which op a
+    position needs is not something the DSL can infer, so the form that names
+    the op is the one that has to exist.
 
     Against its neighbours: ``ops.switch`` keys on an integer, ``ops.select``
     keys on a per-element mask, and ``ops.branch`` keys on a single condition
-    and runs statements. Both arms of a select are evaluated and one is kept;
-    here exactly one case runs, because it lowers to ``scf.index_switch`` in its
-    value-returning form.
+    and runs statements as an ``scf.if``. Both arms of a select are evaluated
+    and one is kept; here exactly one case runs.
 
     The index is a coordinate or a loop variable, and the values are compile-time
     scalars: the case bodies are constants, so there is nothing to evaluate in
@@ -1018,6 +1035,11 @@ def switch(index, values):
     from ._cond import Condition
     from ._index import coerce_index
     from ._value import Buffer, BufferExpr, BufferSlice
+
+    # No values: the region form. A Condition is legal here and only here --
+    # the expression form keys on an integer, and says so below.
+    if values is None:
+        return switch_region(index)
 
     # Name the neighbour rather than complaining about a type. The three are
     # told apart by what they key on, and handing one the other's key is the
@@ -1042,6 +1064,13 @@ def switch(index, values):
             "choose: use the value itself"
         )
     for v in values:
+        # A callable arm is built inside its own region, and is how a switch
+        # nests: fused_decode's per-phase parameters are a switch over the
+        # decode/lm-head arm whose decode side is itself a switch over the
+        # phase. Only the index form takes one -- an elementwise arm has to be
+        # a constant of the destination's element type.
+        if callable(v):
+            continue
         if not isinstance(v, (int, float)) or isinstance(v, bool):
             raise TypeError(
                 f"air.api.ops.switch takes compile-time scalars to pick from, "
@@ -1051,14 +1080,138 @@ def switch(index, values):
     return _Switch(coerce_index(index), list(values))
 
 
+def _dominates_here(expr):
+    """Is ``expr``'s already-emitted value usable at the current insertion point?
+
+    ``as_index`` memoises, because a switch used as a loop bound and again as an
+    offset inside that loop should be one ``scf.index_switch``, not two. But a
+    switch first read inside one arm of a branch and then inside a *sibling* arm
+    would reuse a value that does not dominate the second use, and the module
+    fails to verify with "operand #0 does not dominate this use" -- naming an
+    affine.apply, several hundred lines from the switch, in a message nothing
+    connects back to the DSL. Re-materialising there is correct and cheap: the
+    arms are constants, so the second switch is pure and identical.
+    """
+    from air.ir import InsertionPoint
+
+    leaves = [leaf for leaf in expr.leaves() if leaf.value is not None]
+    if not leaves:
+        return True
+    here = InsertionPoint.current.block
+    for leaf in leaves:
+        owner = leaf.value.owner
+        block = owner if hasattr(owner, "operations") else owner.parent
+        if block is None:
+            continue
+        seen, cursor = False, here
+        while cursor is not None:
+            if cursor == block:
+                seen = True
+                break
+            parent = cursor.owner  # the op the block belongs to
+            cursor = parent.parent.block if parent is not None else None
+        if not seen:
+            return False
+    return True
+
+
 class _Switch:
     """A pending ops.switch; the dtype comes from the buffer it is used with."""
 
-    __slots__ = ("index", "values")
+    __slots__ = ("index", "values", "_as_index")
 
     def __init__(self, index, values):
         self.index = index
         self.values = values
+        # Memoised, because a switch used as an index is emitted where it is
+        # written and read in several places after -- a loop bound and then the
+        # offsets inside that loop. Re-materialising would put a second,
+        # identical scf.index_switch in the block for every use.
+        self._as_index = None
+
+    # -- the index form -----------------------------------------------------
+
+    def as_index(self):
+        """This switch as an :class:`IndexExpr`, for a bound or an offset.
+
+        The other consumer of a switch is the elementwise emitter, which asks
+        for a *buffer element* type; this one is an ``index``, so it composes
+        with coordinates and loop variables and can be an ``air.sequential``
+        bound or a region offset. ``coerce_index`` calls this, so writing the
+        switch where an index is expected is enough -- ``as_index()`` is only
+        needed to do arithmetic on one.
+        """
+        from ._index import IndexExpr, coerce_index
+
+        if self._as_index is not None and _dominates_here(self._as_index):
+            return self._as_index
+        for v in self.values:
+            if callable(v):
+                continue
+            if isinstance(v, float) and not v.is_integer():
+                raise TypeError(
+                    f"air.api.ops.switch: {v} is not an integer, but this "
+                    "switch is being used as an index (a loop bound, or an "
+                    "offset into a buffer). Index arms have to be whole numbers"
+                )
+        values = [v if callable(v) else int(v) for v in self.values]
+
+        index = self.index.materialize()
+        if isinstance(index, int):
+            # Same rule as the elementwise form: a constant index needs no
+            # switch, and folding it leaves the IR the caller would have written.
+            picked = values[min(index, len(values) - 1)]
+            self._as_index = (
+                coerce_index(picked())
+                if callable(picked)
+                else IndexExpr.constant(picked)
+            )
+            return self._as_index
+
+        from air.ir import IndexType
+        from air.dialects import arith
+        from air.dialects.scf import index_switch, yield_
+
+        def _arm(v):
+            # A callable arm is built *inside* its own region, which is the
+            # point: fused_decode's phase parameters are a switch over the
+            # decode/lm-head arm whose decode side is itself a switch over the
+            # phase. Written as a value that would have to exist before the
+            # outer switch, it would be emitted in the enclosing block and both
+            # arms would compute it.
+            value = coerce_index(v()).materialize() if callable(v) else v
+            if isinstance(value, int):
+                value = arith.ConstantOp.create_index(value).result
+            return yield_([value])
+
+        result = index_switch(
+            [IndexType.get()],
+            index,
+            list(range(len(values) - 1)),
+            case_body_builder=lambda op, i, cv: _arm(values[i]),
+            default_body_builder=lambda op: _arm(values[-1]),
+        )
+        result = result[0] if isinstance(result, (list, tuple)) else result
+        self._as_index = IndexExpr.leaf(result, "switch")
+        return self._as_index
+
+    # Arithmetic means the index form: an element-typed switch is consumed by
+    # the elementwise emitter whole, and there is nothing to add to it there.
+    def __add__(self, other):
+        return self.as_index() + other
+
+    __radd__ = __add__
+
+    def __sub__(self, other):
+        return self.as_index() - other
+
+    def __rsub__(self, other):
+        return other - self.as_index()
+
+    def __mul__(self, other):
+        return self.as_index() * other
+
+    __rmul__ = __mul__
 
     def _typed(self, value, dtype):
         """``value`` in the destination's element type, or a refusal.
@@ -1089,6 +1242,13 @@ class _Switch:
         from air.dialects import arith
         from air.dialects.scf import index_switch, yield_
 
+        if any(callable(v) for v in self.values):
+            raise TypeError(
+                "air.api.ops.switch: a callable arm builds an *index* inside "
+                "its own region, so this switch can be a loop bound or an "
+                "offset, but not a value in an elementwise expression -- there "
+                f"it has to be a constant of the destination's type ({dtype})"
+            )
         values = [self._typed(v, dtype) for v in self.values]
 
         index = self.index.materialize()

--- a/python/air/api/types.py
+++ b/python/air/api/types.py
@@ -219,6 +219,13 @@ ui32 = DType(
 
 _BY_NP = {d.np_dtype: d for d in (bf16, f16, f32, i8, i16, i32, ui8, ui16, ui32)}
 
+# Types a kernel scalar argument can have, for reading one back out of an
+# air.extern(signature=...) entry. Signed before unsigned: MLIR spells
+# signedness in the operation rather than the type, so i32 and ui32 have the
+# same mlir() and the first match wins -- the signed one, which is the only one
+# a scalar constant can be built as anyway.
+SCALAR_TYPES = (bf16, f16, f32, i8, i16, i32)
+
 
 def dtype_of(np_dtype):
     """Map a numpy dtype back onto the API's DType, for error messages.

--- a/python/test/api/switch_region.py
+++ b/python/test/api/switch_region.py
@@ -1,0 +1,179 @@
+# ./python/test/api/switch_region.py -*- Python -*-
+
+# Copyright (C) 2026, Advanced Micro Devices, Inc.
+# SPDX-License-Identifier: MIT
+
+# RUN: %PYTHON %s | FileCheck %s
+
+"""``ops.switch``'s region form, and its index-typed value form.
+
+``switch.py`` covers the expression: ``ops.switch(k, [a, b])`` picks a number.
+This covers the two forms added for the shared ``fused_decode`` builder.
+
+**Region form** -- ``ops.switch(k)`` with no values -- runs statements, and
+lowers to a single-case ``scf.index_switch``. It exists because the op a
+position needs is not always the op its control flow suggests: an N-way
+statement is nested ``ops.branch``, which is where this was first routed, but
+that emits an ``scf.if``, leaving a region that must be an ``scf.index_switch``
+with no spelling.
+
+**Index form** -- the value form typed as ``index`` rather than as a buffer
+element, so a switch can bound an ``air.sequential`` or offset a region.
+
+The shapes checked here are the ones the shared ``fused_decode`` builder emits,
+which is why they are pinned rather than described: ten ``llms/*_q4*`` models
+compile from that one builder.
+"""
+
+from air import api as air
+from air.api import ops
+from air.api.types import bf16
+
+W, NW, UNI_DEC = 256, 4, 2
+
+
+def gated_launch():
+    """A repeated launch, gated by switch regions holding L3 channel traffic.
+
+    The whole shape the shared fused_decode builder uses: an scf.for around
+    air.launch (`repeat=`), a unit attribute on the launch, switch regions
+    gating the L3 puts, and a switch bounding a loop inside the herd.
+    """
+    A = air.tensor([NW * W], bf16)
+    D = air.tensor([NW * W], bf16)
+    ch = air.channel("toc")
+    bk = air.channel("back")
+
+    with air.launch(
+        repeat=NW, name="gated", attrs=["air.preserve_shim_dma_order"]
+    ) as lch:
+
+        @lch.body
+        def _(wave):
+            # Both arms populated: the body is the default, otherwise() fills
+            # the case 0 that __enter__ builds either way. Still one case
+            # region -- there is no way to ask for a second.
+            with ops.switch(wave < UNI_DEC) as arm:
+                ch.put(A[wave * W : wave * W + W])
+            with arm.otherwise():
+                ch.put(A[0:W])
+            with air.segment(name="s") as seg:
+
+                @seg.body
+                def _():
+                    # The gate key, evaluated once here and carried into the
+                    # herd as i32 -- an index-typed one folds to constant 0.
+                    arm = air.rtp(wave < UNI_DEC)
+                    l1 = air.alloc([W], bf16, scope=seg.per_core())
+                    with air.herd([range(1), range(1)], name="h", at=(0, 2)) as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            with ops.switch(arm):
+                                pass
+                            ch.get(l1)
+                            # A runtime trip count: the index form of a switch,
+                            # emitted above the loop it bounds.
+                            for _k in air.sequential(ops.switch(tx, [1, 4])):
+                                l1[:] = l1[:] * 2.0
+                            bk.put(l1)
+
+            with ops.switch(wave < UNI_DEC):
+                bk.get(D[wave * W : wave * W + W])
+
+    return lch.build(target="npu2")
+
+
+# repeat= is an scf.for AROUND air.launch, with the dispatch index threaded in
+# as the last launch operand -- one device driven N times. A grid would be N
+# devices: spatial, one segment per point, and the 5-bit dma_bd Packet ID field
+# caps that at about four launches.
+# CHECK-LABEL: func.func @gated
+# CHECK: scf.for %[[WAVE:.*]] = %{{.*}} to %{{.*}} step
+# CHECK: air.launch {{.*}}%[[ARG:.*]]=%[[WAVE]]) :{{.*}}, index attributes {air.preserve_shim_dma_order}
+#
+# A Condition reaches the switch as select(pred, 1, 0) then an index_cast, not
+# as a raw i1. That is not a detour: cloneL2AndL3MemcpysToDeviceOp pins
+# INDEX-typed segment arguments to constant 0, so a key built as an index inside
+# a segment would fold to one arm and erase every other branch.
+# CHECK: %[[P:.*]] = arith.cmpi slt
+# CHECK: %[[S:.*]] = arith.select %[[P]], %{{.*}}, %{{.*}} : i32
+# CHECK: %[[K:.*]] = arith.index_cast %[[S]] : i32 to index
+# CHECK: scf.index_switch %[[K]]
+# The body is the default; case 0 is otherwise(), or empty if unclaimed. One
+# case region, never two -- see SwitchRegion's docstring.
+# CHECK-NEXT: case 0 {
+# CHECK-NEXT: air.channel.put @toc[] (%{{.*}}[0]
+# CHECK-NEXT: scf.yield
+# CHECK-NEXT: }
+# CHECK-NEXT: default {
+# CHECK: air.channel.put @toc
+# The dispatch index crosses into the segment: air.herd and air.segment are both
+# IsolatedFromAbove, so it is an operand, not a reference.
+# CHECK: air.segment @s {{.*}}args(%{{.*}}=%{{.*}}) : index
+# air.rtp crosses into the herd as i32, and is read back with an index_cast.
+# CHECK: air.herd @h {{.*}}, i32
+# CHECK: %[[K:.*]] = arith.index_cast %{{.*}} : i32 to index
+# The identity affine.apply between the cast and the switch is the DSL's
+# convention for every index it builds, and canonicalises away.
+# CHECK: %[[KB:.*]] = affine.apply {{.*}}[%[[K]]]
+# CHECK: scf.index_switch %[[KB]]
+# The index form yields an index and bounds the loop; the switch sits above the
+# scf.for rather than inside it. The identity affine.apply between the two is
+# the DSL's existing convention for every index it builds, and canonicalises
+# away -- it is not particular to a switch.
+# CHECK: %[[N:.*]] = scf.index_switch %{{.*}} -> index
+# CHECK: %[[NB:.*]] = affine.apply {{.*}}[%[[N]]]
+# CHECK: scf.for %{{.*}} = %{{.*}} to %[[NB]]
+print(gated_launch())
+
+
+def refusals():
+    """The three things the new surface must refuse, and say why."""
+    D = air.tensor([W], bf16)
+
+    with air.launch(grid=[range(NW)], name="refuse") as lch:
+
+        @lch.body
+        def _(wave):
+            with air.segment(name="s") as seg:
+
+                @seg.body
+                def _():
+                    l1 = air.alloc([W], bf16, scope=seg.per_core())
+                    with air.herd([range(1), range(1)], name="h", at=(0, 2)) as h:
+
+                        @h.body
+                        def _(tx, ty):
+                            # otherwise() fills case 0, and there is only one
+                            # of those -- a second case region is what breaks
+                            # air-to-aie's L2 receiver allocation.
+                            g = ops.switch(tx == 0)
+                            with g:
+                                l1[:] = 1.0
+                            with g.otherwise():
+                                l1[:] = 2.0
+                            try:
+                                g.otherwise()
+                            except RuntimeError as e:
+                                print("OTHERWISE:", e)
+                            # An index arm has to be a whole number.
+                            try:
+                                ops.switch(tx, [1.5, 2.5]).as_index()
+                            except TypeError as e:
+                                print("FRACTIONAL:", e)
+                            # The region form still refuses a buffer key.
+                            try:
+                                ops.switch(l1)
+                            except TypeError as e:
+                                print("BUFFER:", type(e).__name__)
+                            ops.store(l1, D[0:W])
+
+    lch.build(target="npu2")
+
+
+# CHECK: OTHERWISE: this ops.switch region already has an otherwise()
+# CHECK: FRACTIONAL: air.api.ops.switch: 1.5 is not an integer
+# CHECK-SAME: used as an index
+# CHECK: BUFFER: TypeError
+refusals()

--- a/python/test/api/switch_region.py
+++ b/python/test/api/switch_region.py
@@ -64,8 +64,19 @@ def gated_launch():
                     # The gate key, evaluated once here and carried into the
                     # herd as i32 -- an index-typed one folds to constant 0.
                     arm = air.rtp(wave < UNI_DEC)
+                    # A second parameter: a per-dispatch trip count, which is
+                    # what an attention block loop over ceil(L/16) needs. Two
+                    # live parameters make the threading ambiguous, so the herd
+                    # has to name them -- and their order here is their operand
+                    # order.
+                    trips = air.rtp(wave + 1)
                     l1 = air.alloc([W], bf16, scope=seg.per_core())
-                    with air.herd([range(1), range(1)], name="h", at=(0, 2)) as h:
+                    with air.herd(
+                        [range(1), range(1)],
+                        name="h",
+                        at=(0, 2),
+                        params=[trips, arm],
+                    ) as h:
 
                         @h.body
                         def _(tx, ty):
@@ -76,6 +87,11 @@ def gated_launch():
                             # emitted above the loop it bounds.
                             for _k in air.sequential(ops.switch(tx, [1, 4])):
                                 l1[:] = l1[:] * 2.0
+                            # And one straight from an air.rtp parameter. The
+                            # bound coercion covers both, so neither needs an
+                            # explicit .as_index() at the call site.
+                            for _k in air.sequential(trips):
+                                l1[:] = l1[:] + 1.0
                             bk.put(l1)
 
             with ops.switch(wave < UNI_DEC):
@@ -112,7 +128,8 @@ def gated_launch():
 # IsolatedFromAbove, so it is an operand, not a reference.
 # CHECK: air.segment @s {{.*}}args(%{{.*}}=%{{.*}}) : index
 # air.rtp crosses into the herd as i32, and is read back with an index_cast.
-# CHECK: air.herd @h {{.*}}, i32
+# Two runtime parameters, in the order params= names them.
+# CHECK: air.herd @h {{.*}}, i32, i32
 # CHECK: %[[K:.*]] = arith.index_cast %{{.*}} : i32 to index
 # The identity affine.apply between the cast and the switch is the DSL's
 # convention for every index it builds, and canonicalises away.
@@ -125,6 +142,12 @@ def gated_launch():
 # CHECK: %[[N:.*]] = scf.index_switch %{{.*}} -> index
 # CHECK: %[[NB:.*]] = affine.apply {{.*}}[%[[N]]]
 # CHECK: scf.for %{{.*}} = %{{.*}} to %[[NB]]
+# An air.rtp parameter bounds a loop the same way, with no .as_index() at the
+# call site: air.sequential coerces whatever coerce_index accepts. Without that
+# the DSL refused the bound outright, and blamed a tile coordinate for it.
+# CHECK: %[[T:.*]] = arith.index_cast %{{.*}} : i32 to index
+# CHECK: %[[TB:.*]] = affine.apply {{.*}}[%[[T]]]
+# CHECK: scf.for %{{.*}} = %{{.*}} to %[[TB]]
 print(gated_launch())
 
 


### PR DESCRIPTION
Two independent changes, from porting `programming_examples/fused_decode` — the per-token decode superkernel shared by all ten `llms/*_q4*` models — onto the `air.api` DSL. **The port itself is not in this PR**; it is incomplete (see below).

## 1. `[AIRRtToNpu]` the shim-DMA coalescer missed affine offsets

`coalesceShimDmaOrder` merges a run of contiguous 1-D shim feeds into one buffer descriptor, finding the run by peeling each offset into `(base, constant)`. `peelOffset` understood only the `arith` spelling — `index_cast`, and `addi` with a constant operand — so an offset folded into a single `affine.apply` stopped the peel and the transfer was dropped from every group.

The failure is silent and expensive: the feed still runs, in twice the BDs. On the decode superkernel with its index arithmetic emitted as affine maps, **40 coalesced feeds became 0, 55 shim DMA tasks became 95, and `insts.bin` grew from 158,032 to 251,184 bytes.**

Now peels `affine.apply` too. The map's non-constant sub-expression joins the group key, so `s0 * 8 + 4` and `s0 * 64 + 4` peel to the same base `Value` without being merged as if they addressed the same run.

`isTripCountDivisibleByFactor` had the same one-spelling blind spot — it proves a dynamic trip count even by matching `arith.muli` against a constant — so it is extended through `AffineExpr::getLargestKnownDivisor`. That guard erases a provably-dead unroll epilogue, whose never-filled DMA ring slots corrupt count-free ring locks. No design in tree reaches it with an affine bound today; it is fixed because it is the same bug.

## 2. `[air.api]` fourteen surface additions

Each is behind a default that reproduces what the DSL emitted before, so the 74 already-converted examples are byte-identical. Each was found by writing the port and hitting a wall, not by surveying the op list.

**Dispatch and gating.** `air.launch(repeat=, attrs=)` puts an `scf.for` *around* `air.launch` and threads the dispatch index in as the last operand — one device driven N times. A launch grid is not the substitute: a grid is spatial, each point carries its own segment, and the 5-bit `dma_bd` Packet ID field caps that at about four.

`ops.switch` grows a region form (`with ops.switch(k):` → a single-case `scf.index_switch`) and an index form whose arms may be thunks built inside their own regions. The region form exists because the op a position needs is not always the op its control flow suggests: an N-way statement *is* nested `ops.branch`, but that emits an `scf.if`, and a region that must be an `index_switch` then has no spelling. `otherwise()` fills the `case 0` that `__enter__` builds either way, so a two-armed switch is still **one** case region — a second one breaks `air-to-aie`'s L2 receiver allocation, and there is deliberately no way to ask for it.

`air.rtp` / `air.herd(params=)` carry a scalar into a herd as **i32, not index**: `cloneL2AndL3MemcpysToDeviceOp` pins INDEX-typed segment arguments to constant 0, so an index-typed parameter folds to one arm and erases every other branch. `params=` names which herd reads which; one live parameter still threads implicitly, more than one must be named, and the ambiguous case raises rather than putting the wrong value in the wrong operand slot.

**Kernels and channels.** `air.extern(signature=, emit_c_interface=, link_with_mode=)` declares eagerly in source order and takes its scalar argument types from the signature rather than a second `scalars=` list that could disagree with it; `link_with_mode="merge"` also skips the one-object-per-herd check, since a `.ll` kernel is merged into whichever core calls it — eight cores in one herd can carry two of them. `air.channel(attrs=)` and `Channel.put(dest=)` add unit attributes and the packet destination ordinal (refused on a circuit-switched channel, where there is nothing to select). `air.tensor(inout=)` marks a buffer read and written in place, exempt from the inputs-then-outputs rule because that rule encodes the XRT calling convention, which an in-place buffer has no place in.

Also: a comparison passed to `air.extern` becomes `arith.extui`, the 0/1 flag spelling kernels take; `air.segment` threads the dispatch index across the IsolatedFromAbove boundary; and the first channel declaration anchors after the private kernel decls rather than at block begin.

`as_index()` now re-materialises when its memoised value does not dominate the insertion point. Not cosmetic: a switch read in one branch arm and then in a sibling produced a module failing to verify with `operand #0 does not dominate this use`, naming an `affine.apply` several hundred lines away and nothing that connects back to the DSL.

## Gates

- **fused_decode artifact sweep, before vs after: 26/26 identical.** All ten `llms/*_q4*` models, both template lengths of each, plus `dynseq` and five staircase windows — byte-identical `insts.bin` and byte-identical per-core ELFs. This is the gate that matters here, because `decode_insts_gen.py` patches context-length-dependent words at located byte offsets in `insts.bin`, so its layout is a functional requirement rather than a nicety.
- `check-air-mlir` 536/550 (7 unsupported, 7 XFAIL), no new failures.
- `check-air-python` api suite 57/57, including the new `python/test/api/switch_region.py`.
- Determinism control re-run and passing: the baseline capture reproduces bit-for-bit on this box.

Correctness on real hardware is what the nightly perf CI on npu2 should decide; the sweep above was compile-only.

## What this PR is *not*

The `fused_decode` port that motivated all of it. It currently emits under **1 of 10** model configurations — the ShortConv mixer herd, Gemma's four-norm rms, the non-paired proj egress, the `W_SPLIT` weight-group switch and the q-pack geometry for other head shapes are unported — and even `llama-3.2-1b` is not yet artifact-identical (19 of 27 core ELFs differ, from a dead ping-pong epilogue that survives because `arith`'s canonicaliser does not fold `remsi` through an affine map, and from an unhoisted loop-invariant flag). `programming_examples/fused_decode/fused_decode.py` is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
