### PR TITLE
[ci] Only publish benchmark results from main

### DIFF
--- a/.github/workflows/nightlyPerfBenchmark.yml
+++ b/.github/workflows/nightlyPerfBenchmark.yml
@@ -41,6 +41,14 @@ on:
           run is ~7h, sweep alone well under an hour, prefill-sweep ~2.7h. A
           narrowed run does NOT publish (see below), because its perf.json is
           partial by construction.
+
+          Neither does a run on any ref other than main, whatever the suite list:
+          publishing is gated on the ref as well. A dispatch from a PR branch with
+          the default (all four) suites used to satisfy the gate and append to the
+          durable perf-history branch. That is how a gemma4_e2b_q4nx verify=fail
+          row from a PR branch reached the published page and then STUCK there --
+          the model did not exist on main, so no later nightly could ever produce
+          a row to supersede it.
         default: verify,profile,sweep,prefill-sweep
         type: string
 
@@ -586,7 +594,7 @@ jobs:
         # run cancelled mid-profile appended rows with null metrics but
         # verify_status "pass". A *failed* run must still publish -- its other
         # models' rows are good.
-        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep') }}
+        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep')) }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -671,7 +679,7 @@ jobs:
       # for `if:`. A cancelled full run is partial at an arbitrary point, so it
       # must land under the non-publishable name like a narrowed run does.
       - name: Upload perf artifact
-        if: ${{ !cancelled() && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep') }}
+        if: ${{ !cancelled() && (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep')) }}
         uses: actions/upload-artifact@v4
         with:
           name: perf-${{ github.run_id }}
@@ -684,7 +692,7 @@ jobs:
 
       # Same payload, name the publisher ignores: still there to download.
       - name: Upload perf artifact (partial run)
-        if: ${{ cancelled() || !(github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep') }}
+        if: ${{ cancelled() || !(github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep')) }}
         uses: actions/upload-artifact@v4
         with:
           name: perf-partial-${{ github.run_id }}
@@ -707,7 +715,7 @@ jobs:
         # Full, non-cancelled runs only -- same reasoning as the history append.
         # Note this gate alone never protected the page: the artifact naming
         # above is what actually decides, because generateDocs runs on push too.
-        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep') }}
+        if: ${{ !cancelled() && hashFiles('perf.json') != '' && (github.ref == 'refs/heads/main' && (github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep')) }}
         continue-on-error: true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The nightly's four publish steps — `perf.json` to the pages branch, the
`perf-history` append, and the `generateDocs` dispatch — gate on the suite list
alone:

```
github.event_name == 'schedule' || github.event.inputs.suites == 'verify,profile,sweep,prefill-sweep'
```

A `workflow_dispatch` from **any** ref satisfies that, because the default suite
list is exactly those four. So dispatching the nightly on a PR branch publishes
to the shared page and writes the durable history branch.

That is not hypothetical. A dispatch on the `gemma4_e2b_q4nx` PR branch appended

```
2026-09-05T00:35:53Z  gemma4_e2b_q4nx  verify=fail
```

to `perf-history:history.ndjson`. The published page has rendered that row ever
since — including on builds from `main`, where the model did not exist until
#1982 — and **nothing could clear it**: a row is only superseded by a newer row
for the same model, and no run on `main` could produce one.

This adds the ref to the gate, so the failure mode becomes impossible rather
than unlikely. A branch run still does all the work and still uploads its
artifact for inspection; it just cannot write shared state.

The `else` branch that explains why a run did not publish is updated in step, so
it still fires exactly when the publish steps do not.

Also documents the rule in the `suites` input description, with the incident as
the reason, so the next person narrowing a suite list understands the ref matters
too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)