### PR TITLE
[gpu] Fix AIR->GPU conversion passes against current LLVM/AIR APIs

### DIFF
--- a/mlir/lib/Conversion/AIRToROCDLPass.cpp
+++ b/mlir/lib/Conversion/AIRToROCDLPass.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -318,7 +319,7 @@ struct ConvertAIRToROCDLPass
         FunctionType::get(launchOp.getContext(), kernelOperandTypes, {});
     auto outlinedFunc = gpu::GPUFuncOp::create(
         builder, loc, kernelFnName, type,
-        TypeRange(ValueRange(launchOp.getWorkgroupAttributions())),
+        TypeRange(ValueRange(launchOp.getWorkgroupAttributionBBArgs())),
         TypeRange(ValueRange(launchOp.getPrivateAttributions())));
     outlinedFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                           builder.getUnitAttr());
@@ -344,8 +345,8 @@ struct ConvertAIRToROCDLPass
 
     // Map memory attributions from the LaunOp op to the GPUFuncOp attributions.
     for (const auto &[launchArg, funcArg] :
-         llvm::zip(launchOp.getWorkgroupAttributions(),
-                   outlinedFunc.getWorkgroupAttributions()))
+         llvm::zip(launchOp.getWorkgroupAttributionBBArgs(),
+                   outlinedFunc.getWorkgroupAttributionBBArgs()))
       map.map(launchArg, funcArg);
     for (const auto &[launchArg, funcArg] :
          llvm::zip(launchOp.getPrivateAttributions(),
@@ -398,7 +399,7 @@ struct ConvertAIRToROCDLPass
         launchOp.getBlockSizeOperandValues(),
         launchOp.getDynamicSharedMemorySize(), operands,
         asyncToken ? asyncToken.getType() : nullptr,
-        launchOp.getAsyncDependencies(), clusterSize);
+        launchOp.getAsyncDependencies(), /*asyncObject=*/nullptr, clusterSize);
     launchOp.replaceAllUsesWith(launchFunc);
     launchOp.erase();
   }
@@ -818,12 +819,21 @@ struct ConvertAIRToROCDLPass
     Value dstMemref = dmaOp.getDstMemref();
     auto srcType = cast<MemRefType>(srcMemref.getType());
     auto dstType = cast<MemRefType>(dstMemref.getType());
-    SmallVector<Value> srcOffsets(dmaOp.getSrcOffsets());
-    SmallVector<Value> dstOffsets(dmaOp.getDstOffsets());
-    SmallVector<Value> srcSizes(dmaOp.getSrcSizes());
-    SmallVector<Value> dstSizes(dmaOp.getDstSizes());
-    SmallVector<Value> srcStrides(dmaOp.getSrcStrides());
-    SmallVector<Value> dstStrides(dmaOp.getDstStrides());
+    // DmaMemcpyNdOp stores offsets/sizes/strides as mixed static/dynamic
+    // values; materialize each into an index Value (constant for static
+    // entries) so the loop-nest lowering below can consume them uniformly.
+    SmallVector<Value> srcOffsets = getValueOrCreateConstantIndexOp(
+        builder, loc, dmaOp.getMixedSrcOffsets());
+    SmallVector<Value> dstOffsets = getValueOrCreateConstantIndexOp(
+        builder, loc, dmaOp.getMixedDstOffsets());
+    SmallVector<Value> srcSizes =
+        getValueOrCreateConstantIndexOp(builder, loc, dmaOp.getMixedSrcSizes());
+    SmallVector<Value> dstSizes =
+        getValueOrCreateConstantIndexOp(builder, loc, dmaOp.getMixedDstSizes());
+    SmallVector<Value> srcStrides = getValueOrCreateConstantIndexOp(
+        builder, loc, dmaOp.getMixedSrcStrides());
+    SmallVector<Value> dstStrides = getValueOrCreateConstantIndexOp(
+        builder, loc, dmaOp.getMixedDstStrides());
 
     // Determine transfer sizes from whichever side has explicit sizes,
     // or fall back to the smaller memref's static shape.

--- a/mlir/lib/Conversion/GPUKernelOutlinePass.cpp
+++ b/mlir/lib/Conversion/GPUKernelOutlinePass.cpp
@@ -13,6 +13,7 @@
 #include "mlir/Conversion/LLVMCommon/TypeConverter.h"
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/Arith/Utils/Utils.h"
 #include "mlir/Dialect/ControlFlow/IR/ControlFlowOps.h"
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
@@ -333,7 +334,7 @@ struct ConvertGPUKernelOutlinePass
         FunctionType::get(launchOp.getContext(), kernelOperandTypes, {});
     auto outlinedFunc = gpu::GPUFuncOp::create(
         builder, loc, kernelFnName, type,
-        TypeRange(ValueRange(launchOp.getWorkgroupAttributions())),
+        TypeRange(ValueRange(launchOp.getWorkgroupAttributionBBArgs())),
         TypeRange(ValueRange(launchOp.getPrivateAttributions())));
     outlinedFunc->setAttr(gpu::GPUDialect::getKernelFuncAttrName(),
                           builder.getUnitAttr());
@@ -359,8 +360,8 @@ struct ConvertGPUKernelOutlinePass
 
     // Map memory attributions from the LaunOp op to the GPUFuncOp attributions.
     for (const auto &[launchArg, funcArg] :
-         llvm::zip(launchOp.getWorkgroupAttributions(),
-                   outlinedFunc.getWorkgroupAttributions()))
+         llvm::zip(launchOp.getWorkgroupAttributionBBArgs(),
+                   outlinedFunc.getWorkgroupAttributionBBArgs()))
       map.map(launchArg, funcArg);
     for (const auto &[launchArg, funcArg] :
          llvm::zip(launchOp.getPrivateAttributions(),
@@ -425,7 +426,7 @@ struct ConvertGPUKernelOutlinePass
         launchOp.getBlockSizeOperandValues(),
         launchOp.getDynamicSharedMemorySize(), operands,
         asyncToken ? asyncToken.getType() : nullptr,
-        launchOp.getAsyncDependencies(), clusterSize);
+        launchOp.getAsyncDependencies(), /*asyncObject=*/nullptr, clusterSize);
     launchOp.replaceAllUsesWith(launchFunc);
     launchOp.erase();
   }
@@ -622,12 +623,22 @@ struct ConvertGPUKernelOutlinePass
     // Extract the operands (memrefs)
     Value destMemref = dmaMemcpyOp.getDstMemref(); // Destination memref
     Value srcMemref = dmaMemcpyOp.getSrcMemref();  // Source memref
-    SmallVector<Value, 4> src_offsets = dmaMemcpyOp.getSrcOffsets();
-    SmallVector<Value, 4> dst_offsets = dmaMemcpyOp.getDstOffsets();
-    SmallVector<Value, 4> src_sizes = dmaMemcpyOp.getSrcSizes();
-    SmallVector<Value, 4> dst_sizes = dmaMemcpyOp.getDstSizes();
-    SmallVector<Value, 4> src_strides = dmaMemcpyOp.getSrcStrides();
-    SmallVector<Value, 4> dst_strides = dmaMemcpyOp.getDstStrides();
+    // DmaMemcpyNdOp stores offsets/sizes/strides as mixed static/dynamic
+    // values; materialize each into an index Value (constant for static
+    // entries) so the loop-nest lowering below can consume them uniformly.
+    Location dmaLoc = dmaMemcpyOp.getLoc();
+    SmallVector<Value> src_offsets = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedSrcOffsets());
+    SmallVector<Value> dst_offsets = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedDstOffsets());
+    SmallVector<Value> src_sizes = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedSrcSizes());
+    SmallVector<Value> dst_sizes = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedDstSizes());
+    SmallVector<Value> src_strides = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedSrcStrides());
+    SmallVector<Value> dst_strides = getValueOrCreateConstantIndexOp(
+        builder, dmaLoc, dmaMemcpyOp.getMixedDstStrides());
 
     // Create SCF loops to simulate the memory copy
     // We'll assume a 2D memory region and use sizes for both dimensions


### PR DESCRIPTION
The AIR_ENABLE_GPU build path (AIRToROCDLPass, GPUKernelOutlinePass) had rotted because it is not exercised by CI (which builds the AIE config). It no longer compiled against main's own pinned LLVM. Three API drifts:

- DmaMemcpyNdOp switched to mixed static/dynamic offsets/sizes/strides: replace getSrc/DstOffsets/Sizes/Strides() with the getMixed* accessors, materialized to index Values via getValueOrCreateConstantIndexOp.
- gpu.launch_func builder gained an asyncObject operand before clusterSize: pass /*asyncObject=*/nullptr.
- gpu.launch attribution accessor renamed getWorkgroupAttributions() -> getWorkgroupAttributionBBArgs().

Verified by building the GPU config and running the 4k_4k_mul gemm example end to end on gfx950 (Output Matched!).